### PR TITLE
US-013 — Fix UB: return *this manquant dans les operator= templatés

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _cmake
 *.orig
 *~
 html
+CLAUDE.md

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -197,7 +197,7 @@ public: // assignment operators (copy)
      */
     template<class U>
     matrix& operator=(matrix<U, Dimensions...> const& other)
-    { std::copy(cbegin(other._data), cend(other._data), begin(_data)); }
+    { std::copy(cbegin(other._data), cend(other._data), begin(_data)); return *this; }
 
 public: // assignment operators (move)
     /**
@@ -213,7 +213,7 @@ public: // assignment operators (move)
      */
     template<class U>
     matrix& operator=(matrix<U, Dimensions...> && other)
-    { std::move(cbegin(other._data), cend(other._data), begin(_data)); }
+    { std::move(cbegin(other._data), cend(other._data), begin(_data)); return *this; }
 
 public: // element access
     /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,7 @@ include_directories(include)
 set(TARGET_NAME matrix-test)
 add_executable(${TARGET_NAME}
     src/access.cpp
+    src/assignment_returns_self.cpp
     src/construct.cpp
     src/main.cpp
 )

--- a/test/src/assignment_returns_self.cpp
+++ b/test/src/assignment_returns_self.cpp
@@ -1,0 +1,32 @@
+#include <matrix.hpp>
+
+#include <gtest/gtest.h>
+
+
+// Verify copy-assign from different type returns *this
+TEST(assign_returns_self, copy_different_type)
+{
+    ysc::matrix<int, 3> m1 = {1, 2, 3};
+    ysc::matrix<long, 3> m2;
+    auto& ref = (m2 = m1);
+    ASSERT_EQ(&ref, &m2);
+}
+
+// Verify move-assign from different type returns *this
+TEST(assign_returns_self, move_different_type)
+{
+    ysc::matrix<int, 3> m1 = {1, 2, 3};
+    ysc::matrix<long, 3> m2;
+    auto& ref = (m2 = std::move(m1));
+    ASSERT_EQ(&ref, &m2);
+}
+
+// Verify copy-assign is chainable
+TEST(assign_returns_self, chain_copy)
+{
+    ysc::matrix<int, 3> src = {1, 2, 3};
+    ysc::matrix<long, 3> a, b;
+    b = a = src;
+    ASSERT_EQ(a(0), 1);
+    ASSERT_EQ(b(0), 1);
+}


### PR DESCRIPTION
## Résumé

Les deux surcharges templatées de `operator=` (`matrix<U>` copy et move) ne retournaient pas `*this`, ce qui constitue un comportement indéfini (UB) selon la norme C++ : une fonction à valeur de retour non-void sans `return` est UB lors de l'instanciation.

## Critères d'acceptation

- [x] Bug corrigé : `return *this;` ajouté dans les deux `operator=` templatés (`matrix.hpp` lignes 200 et 216)
- [x] Test ajouté : `test/src/assignment_returns_self.cpp` vérifie que l'assignation retourne `*this` (identité de pointeur) et que le chaînage fonctionne, pour copy-assign et move-assign cross-type