### PR TITLE
US-008 — Bump C++17 → C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 
 ##
 # general configuration
@@ -14,7 +14,9 @@ mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 ##
 # source configuration
 #
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 add_subdirectory(src)
 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/yscialom/matrix/actions/workflows/ci.yml/badge.svg)](https://github.com/yscialom/matrix/actions/workflows/ci.yml)
 
-A general-purpose multi-dimension container of static dimensions.
+A general-purpose multi-dimension container of static dimensions. Requires **C++20** (`__cplusplus >= 202002L`).
 
 ## Example
 


### PR DESCRIPTION
## Résumé

Upgrade du standard C++ de 17 à 20 dans le système de build. Aucun changement de code fonctionnel à ce stade — il s'agit uniquement de l'upgrade du standard, conformément à la spec US-008. Cette PR débloque les épopées B (concepts, `<=>`), D (typedefs STL), et E (comparaisons, constructeurs contraints).

## Critères d'acceptation

- [x] `cmake_minimum_required` passé à 3.20
- [x] `CMAKE_CXX_STANDARD` passé à 20, avec `CMAKE_CXX_STANDARD_REQUIRED ON` et `CMAKE_CXX_EXTENSIONS OFF`
- [x] `__cplusplus >= 202002L` documenté dans README
- [ ] CI verte sur tous les compilateurs cibles (Ubuntu × GCC 12/13/Clang 15/17, macOS × AppleClang, Windows × MSVC)

## Décisions d'implémentation

- Le `cmake_minimum_required(VERSION 3.20)` recouvre également le périmètre de US-012 (qui prévoyait de le bumper de 3.0 à 3.20 sans toucher au standard). US-012 devra se limiter à son seul critère restant : la correction du typo `Tets → Tests` dans `test/CMakeLists.txt`.