### PR TITLE
US-015 — Typedefs membres STL-compatibles

### DIFF
--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -87,6 +87,30 @@ private:
     std::array<T, linear_size> _data;
 
 public:
+    /** @brief Element type. */
+    using value_type             = T;
+    /** @brief Unsigned integer type for sizes and counts. */
+    using size_type              = std::size_t;
+    /** @brief Signed integer type for differences between iterators. */
+    using difference_type        = std::ptrdiff_t;
+    /** @brief Reference to element type. */
+    using reference              = T&;
+    /** @brief Const reference to element type. */
+    using const_reference        = const T&;
+    /** @brief Pointer to element type. */
+    using pointer                = T*;
+    /** @brief Const pointer to element type. */
+    using const_pointer          = const T*;
+    /** @brief Iterator over matrix elements in row-major order. */
+    using iterator               = typename std::array<T, linear_size>::iterator;
+    /** @brief Const iterator over matrix elements in row-major order. */
+    using const_iterator         = typename std::array<T, linear_size>::const_iterator;
+    /** @brief Reverse iterator. */
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    /** @brief Const reverse iterator. */
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+public:
     /**
      * @brief Exchanges the given values.
      * @param lhs value to be swapped

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(${TARGET_NAME}
     src/access.cpp
     src/assignment_returns_self.cpp
     src/construct.cpp
+    src/typedefs.cpp
     src/main.cpp
 )
 

--- a/test/src/typedefs.cpp
+++ b/test/src/typedefs.cpp
@@ -1,0 +1,45 @@
+#include <concepts>
+#include <cstddef>
+#include <iterator>
+#include <gtest/gtest.h>
+#include "matrix.hpp"
+
+using M = ysc::matrix<int, 2, 3>;
+
+static_assert(std::same_as<M::value_type,             int>);
+static_assert(std::same_as<M::size_type,              std::size_t>);
+static_assert(std::same_as<M::difference_type,        std::ptrdiff_t>);
+static_assert(std::same_as<M::reference,              int&>);
+static_assert(std::same_as<M::const_reference,        const int&>);
+static_assert(std::same_as<M::pointer,                int*>);
+static_assert(std::same_as<M::const_pointer,          const int*>);
+static_assert(std::same_as<M::reverse_iterator,       std::reverse_iterator<M::iterator>>);
+static_assert(std::same_as<M::const_reverse_iterator, std::reverse_iterator<M::const_iterator>>);
+
+TEST(typedefs, value_type_is_int)
+{
+    static_assert(std::same_as<ysc::matrix<int, 3>::value_type, int>);
+    static_assert(std::same_as<ysc::matrix<double, 2, 2>::value_type, double>);
+}
+
+TEST(typedefs, size_type_and_difference_type)
+{
+    static_assert(std::same_as<M::size_type, std::size_t>);
+    static_assert(std::same_as<M::difference_type, std::ptrdiff_t>);
+}
+
+TEST(typedefs, reference_and_pointer)
+{
+    static_assert(std::same_as<M::reference,       int&>);
+    static_assert(std::same_as<M::const_reference, const int&>);
+    static_assert(std::same_as<M::pointer,         int*>);
+    static_assert(std::same_as<M::const_pointer,   const int*>);
+}
+
+TEST(typedefs, iterator_types_are_public)
+{
+    static_assert(std::same_as<M::iterator,               std::array<int, 6>::iterator>);
+    static_assert(std::same_as<M::const_iterator,         std::array<int, 6>::const_iterator>);
+    static_assert(std::same_as<M::reverse_iterator,       std::reverse_iterator<M::iterator>>);
+    static_assert(std::same_as<M::const_reverse_iterator, std::reverse_iterator<M::const_iterator>>);
+}


### PR DESCRIPTION
## Résumé

Ajoute les dix alias de type STL-standards dans `ysc::matrix` (`value_type`, `size_type`, `difference_type`, `reference`, `const_reference`, `pointer`, `const_pointer`, `iterator`, `const_iterator`, `reverse_iterator`, `const_reverse_iterator`). Ces typedefs sont requis pour la conformité STL et débloquent directement US-016 (itérateurs begin/end).

## Critères d'acceptation

- [x] `static_assert(std::same_as<matrix<int,3>::value_type, int>)` dans les tests
- [x] Tous les typedefs accessibles publiquement

## Décisions d'implémentation

- Les typedefs `iterator` et `const_iterator` sont délégués à `std::array<T, linear_size>`, ce qui garantit qu'ils sont des itérateurs contiguës sans implémentation supplémentaire.
- `reverse_iterator` et `const_reverse_iterator` sont définis via `std::reverse_iterator<iterator>`, conforme à l'approche de `std::array`.
- Les tests utilisent `static_assert` avec `std::same_as` (C++20) — cohérent avec le bump effectué en US-008.