### PR TITLE
US-016 — Itérateurs (begin/end et co.)

### DIFF
--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -13,6 +13,7 @@
 #define YSC_MATRIX_HPP
 
 #include <array>
+#include <iterator>
 #include <numeric>
 #include <algorithm>
 #include <stdexcept>
@@ -109,6 +110,20 @@ public:
     using reverse_iterator       = std::reverse_iterator<iterator>;
     /** @brief Const reverse iterator. */
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+public: // iterators
+    constexpr iterator               begin()        noexcept { return _data.begin(); }
+    constexpr const_iterator         begin()  const noexcept { return _data.begin(); }
+    constexpr const_iterator         cbegin() const noexcept { return _data.cbegin(); }
+    constexpr iterator               end()          noexcept { return _data.end(); }
+    constexpr const_iterator         end()    const noexcept { return _data.end(); }
+    constexpr const_iterator         cend()   const noexcept { return _data.cend(); }
+    constexpr reverse_iterator       rbegin()       noexcept { return _data.rbegin(); }
+    constexpr const_reverse_iterator rbegin() const noexcept { return _data.rbegin(); }
+    constexpr const_reverse_iterator crbegin() const noexcept { return _data.crbegin(); }
+    constexpr reverse_iterator       rend()         noexcept { return _data.rend(); }
+    constexpr const_reverse_iterator rend()   const noexcept { return _data.rend(); }
+    constexpr const_reverse_iterator crend()  const noexcept { return _data.crend(); }
 
 public:
     /**

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -198,7 +198,7 @@ public: // copy constructors
      */
     template<class U>
     matrix(matrix<U, Dimensions...> const& other)
-    { std::copy(cbegin(other._data), cend(other._data), begin(_data)); }
+    { std::copy(other._data.cbegin(), other._data.cend(), _data.begin()); }
 
 public: // move constructors
     /**
@@ -220,7 +220,7 @@ public: // move constructors
      */
     template<class U>
     matrix(matrix<U, Dimensions...> && other)
-    { std::move(cbegin(other._data), cend(other._data), begin(_data)); }
+    { std::move(other._data.cbegin(), other._data.cend(), _data.begin()); }
 
 public: // assignment operators (copy)
     /**
@@ -236,7 +236,7 @@ public: // assignment operators (copy)
      */
     template<class U>
     matrix& operator=(matrix<U, Dimensions...> const& other)
-    { std::copy(cbegin(other._data), cend(other._data), begin(_data)); return *this; }
+    { std::copy(other._data.cbegin(), other._data.cend(), _data.begin()); return *this; }
 
 public: // assignment operators (move)
     /**
@@ -252,7 +252,7 @@ public: // assignment operators (move)
      */
     template<class U>
     matrix& operator=(matrix<U, Dimensions...> && other)
-    { std::move(cbegin(other._data), cend(other._data), begin(_data)); return *this; }
+    { std::move(other._data.cbegin(), other._data.cend(), _data.begin()); return *this; }
 
 public: // element access
     /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(${TARGET_NAME}
     src/access.cpp
     src/assignment_returns_self.cpp
     src/construct.cpp
+    src/iterators.cpp
     src/typedefs.cpp
     src/main.cpp
 )

--- a/test/src/iterators.cpp
+++ b/test/src/iterators.cpp
@@ -1,0 +1,92 @@
+#include <algorithm>
+#include <concepts>
+#include <iterator>
+#include <ranges>
+#include <gtest/gtest.h>
+#include "matrix.hpp"
+
+using M = ysc::matrix<int, 2, 3>;
+
+static_assert(std::contiguous_iterator<M::iterator>);
+static_assert(std::contiguous_iterator<M::const_iterator>);
+
+TEST(iterators, begin_end_mutable_range_for)
+{
+    M m{1, 2, 3, 4, 5, 6};
+    int sum = 0;
+    for (auto& v : m)
+        sum += v;
+    EXPECT_EQ(sum, 21);
+}
+
+TEST(iterators, begin_end_const_range_for)
+{
+    const M m{1, 2, 3, 4, 5, 6};
+    int sum = 0;
+    for (const auto& v : m)
+        sum += v;
+    EXPECT_EQ(sum, 21);
+}
+
+TEST(iterators, cbegin_cend)
+{
+    M m{10, 20, 30, 40, 50, 60};
+    int sum = 0;
+    for (auto it = m.cbegin(); it != m.cend(); ++it)
+        sum += *it;
+    EXPECT_EQ(sum, 210);
+}
+
+TEST(iterators, rbegin_rend_mutable)
+{
+    M m{1, 2, 3, 4, 5, 6};
+    auto it = m.rbegin();
+    EXPECT_EQ(*it, 6); ++it;
+    EXPECT_EQ(*it, 5); ++it;
+    EXPECT_EQ(*it, 4); ++it;
+    EXPECT_EQ(*it, 3); ++it;
+    EXPECT_EQ(*it, 2); ++it;
+    EXPECT_EQ(*it, 1); ++it;
+    EXPECT_EQ(it, m.rend());
+}
+
+TEST(iterators, rbegin_rend_const)
+{
+    const M m{1, 2, 3, 4, 5, 6};
+    auto it = m.rbegin();
+    EXPECT_EQ(*it, 6); ++it;
+    EXPECT_EQ(*it, 5);
+    EXPECT_EQ(std::distance(m.rbegin(), m.rend()), 6);
+}
+
+TEST(iterators, crbegin_crend)
+{
+    M m{1, 2, 3, 4, 5, 6};
+    auto it = m.crbegin();
+    EXPECT_EQ(*it, 6);
+    EXPECT_EQ(std::distance(m.crbegin(), m.crend()), 6);
+}
+
+TEST(iterators, begin_end_write_through_iterator)
+{
+    M m{1, 2, 3, 4, 5, 6};
+    for (auto& v : m)
+        v *= 2;
+    auto it = m.begin();
+    EXPECT_EQ(*it, 2); ++it;
+    EXPECT_EQ(*it, 4); ++it;
+    EXPECT_EQ(*it, 6); ++it;
+    EXPECT_EQ(*it, 8); ++it;
+    EXPECT_EQ(*it, 10); ++it;
+    EXPECT_EQ(*it, 12); ++it;
+    EXPECT_EQ(it, m.end());
+}
+
+TEST(iterators, ranges_sort)
+{
+    M m{6, 3, 1, 4, 5, 2};
+    std::ranges::sort(m);
+    EXPECT_TRUE(std::ranges::is_sorted(m));
+    EXPECT_EQ(*m.begin(), 1);
+    EXPECT_EQ(*std::prev(m.end()), 6);
+}


### PR DESCRIPTION
## Résumé

Implémente les 12 méthodes d'itération linéaire (row-major) sur `ysc::matrix` conformément à la spécification US-016 : `begin`, `end`, `cbegin`, `cend`, `rbegin`, `rend`, `crbegin`, `crend` et leurs surcharges const. L'itération délègue directement au `std::array` interne, sans overhead.

## Critères d'acceptation

- [x] `static_assert(std::contiguous_iterator<M::iterator>)` — vérifié dans `iterators.cpp`
- [x] `static_assert(std::contiguous_iterator<M::const_iterator>)` — vérifié dans `iterators.cpp`
- [x] Range-for fonctionne sur matrix mutable et const
- [x] `std::ranges::sort(m)` compile et fonctionne
- [x] Test `iterators.cpp` couvre toutes les variantes (begin/end, cbegin/cend, rbegin/rend, crbegin/crend, écriture via itérateur)

## Décisions d'implémentation

- `#include <iterator>` ajouté explicitement (était tiré transitivement avant, bonne pratique de le rendre explicite).
- Toutes les méthodes sont `constexpr noexcept`, conformes à la spécification.