### PR TITLE
US-017 — size(), empty(), data(), max_size()

### DIFF
--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -125,6 +125,44 @@ public: // iterators
     constexpr const_reverse_iterator rend()   const noexcept { return _data.rend(); }
     constexpr const_reverse_iterator crend()  const noexcept { return _data.crend(); }
 
+public: // capacity
+    /**
+     * @brief Returns the number of elements in the matrix (product of all dimensions).
+     *
+     * @note This function is @c static because the size is a compile-time constant.
+     */
+    static constexpr size_type size()     noexcept { return linear_size; }
+
+    /**
+     * @brief Returns the maximum number of elements the matrix can hold.
+     *
+     * Always equal to @c size() for this fixed-size container.
+     *
+     * @note This function is @c static because the value is a compile-time constant.
+     */
+    static constexpr size_type max_size() noexcept { return linear_size; }
+
+    /**
+     * @brief Returns whether the matrix has no elements.
+     *
+     * @note This function is @c static because the value is a compile-time constant.
+     */
+    static constexpr bool      empty()    noexcept { return linear_size == 0; }
+
+    /**
+     * @brief Returns a pointer to the underlying element storage.
+     *
+     * Elements are stored in row-major order (rightmost dimension is contiguous).
+     */
+    constexpr pointer       data()       noexcept { return _data.data(); }
+
+    /**
+     * @brief Returns a pointer to the underlying element storage.
+     *
+     * Elements are stored in row-major order (rightmost dimension is contiguous).
+     */
+    constexpr const_pointer data() const noexcept { return _data.data(); }
+
 public:
     /**
      * @brief Exchanges the given values.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(${TARGET_NAME}
     src/assignment_returns_self.cpp
     src/construct.cpp
     src/iterators.cpp
+    src/size_data.cpp
     src/typedefs.cpp
     src/main.cpp
 )

--- a/test/src/size_data.cpp
+++ b/test/src/size_data.cpp
@@ -1,0 +1,59 @@
+#include <gtest/gtest.h>
+#include "matrix.hpp"
+
+using M23 = ysc::matrix<int, 2, 3>;
+using M1  = ysc::matrix<int, 7>;
+
+// compile-time guarantees
+static_assert(M23::size()     == 6);
+static_assert(M23::max_size() == 6);
+static_assert(M23::empty()    == false);
+static_assert(M1::size()      == 7);
+
+TEST(size, equals_product_of_dimensions)
+{
+    EXPECT_EQ(M23::size(), 6u);
+}
+
+TEST(size, single_dimension)
+{
+    EXPECT_EQ(M1::size(), 7u);
+}
+
+TEST(max_size, equals_size)
+{
+    EXPECT_EQ(M23::max_size(), M23::size());
+}
+
+TEST(empty, non_empty_matrix_is_false)
+{
+    EXPECT_FALSE(M23::empty());
+}
+
+TEST(data, mutable_points_to_first_element)
+{
+    M23 m{1, 2, 3, 4, 5, 6};
+    EXPECT_EQ(m.data(), &m(0, 0));
+    EXPECT_EQ(*m.data(), 1);
+}
+
+TEST(data, const_points_to_first_element)
+{
+    const M23 m{10, 20, 30, 40, 50, 60};
+    EXPECT_EQ(m.data(), &m(0, 0));
+    EXPECT_EQ(*m.data(), 10);
+}
+
+TEST(data, mutable_write_through)
+{
+    M23 m{1, 2, 3, 4, 5, 6};
+    *m.data() = 99;
+    EXPECT_EQ(m(0, 0), 99);
+}
+
+TEST(data, contiguous_storage)
+{
+    M23 m{1, 2, 3, 4, 5, 6};
+    for (ysc::matrix<int, 2, 3>::size_type i = 0; i < M23::size(); ++i)
+        EXPECT_EQ(*(m.data() + i), static_cast<int>(i + 1));
+}


### PR DESCRIPTION
## Résumé

Ajoute les méthodes de capacité STL-compatibles à `ysc::matrix` : `size()`, `max_size()` et `empty()` sont déclarées `static constexpr` (valeurs connues à la compilation), `data()` est fournie en deux variantes (mutable et const) et retourne un pointeur direct sur le stockage interne.

## Critères d'acceptation

- [x] `static_assert(matrix<int,2,3>::size() == 6)` passe
- [x] `data()` retourne l'adresse de `_data[0]`

## Tests

Nouveau fichier `test/src/size_data.cpp` :
- `static_assert` compile-time sur `size()`, `max_size()`, `empty()`
- Tests d'adresse et de contiguïté pour `data()` mutable et const
- Test d'écriture via `data()`

## Notes d'implémentation

- `size()`, `max_size()`, `empty()` sont `static` car elles ne dépendent que des paramètres template, jamais de l'instance. Ce choix est documenté dans les docstrings Doxygen.