### PR TITLE
US-019 — operator== et operator<=>

### DIFF
--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -13,6 +13,7 @@
 #define YSC_MATRIX_HPP
 
 #include <array>
+#include <compare>
 #include <iterator>
 #include <numeric>
 #include <algorithm>
@@ -291,6 +292,12 @@ public: // assignment operators (move)
     template<class U>
     matrix& operator=(matrix<U, Dimensions...> && other)
     { std::move(other._data.cbegin(), other._data.cend(), _data.begin()); return *this; }
+
+public: // comparison operators
+    /** @brief Equality comparison — lexicographic on the flat row-major storage. */
+    friend bool operator==(const matrix& lhs, const matrix& rhs) = default;
+    /** @brief Three-way comparison — lexicographic on the flat row-major storage. */
+    friend auto operator<=>(const matrix& lhs, const matrix& rhs) = default;
 
 public: // element access
     /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,7 @@ set(TARGET_NAME matrix-test)
 add_executable(${TARGET_NAME}
     src/access.cpp
     src/assignment_returns_self.cpp
+    src/comparison.cpp
     src/construct.cpp
     src/iterators.cpp
     src/size_data.cpp

--- a/test/src/comparison.cpp
+++ b/test/src/comparison.cpp
@@ -1,0 +1,83 @@
+#include <matrix.hpp>
+
+#include <gtest/gtest.h>
+
+#include <compare>
+
+
+//
+// --- EQUALITY ---
+//
+
+TEST(comparison, equal_same_values)
+{
+    ysc::matrix<int, 2, 3> m1{1, 2, 3, 4, 5, 6};
+    ysc::matrix<int, 2, 3> m2{1, 2, 3, 4, 5, 6};
+    ASSERT_TRUE(m1 == m2);
+    ASSERT_FALSE(m1 != m2);
+}
+
+TEST(comparison, equal_different_values)
+{
+    ysc::matrix<int, 2, 3> m1{1, 2, 3, 4, 5, 6};
+    ysc::matrix<int, 2, 3> m2{1, 2, 3, 4, 5, 7};
+    ASSERT_FALSE(m1 == m2);
+    ASSERT_TRUE(m1 != m2);
+}
+
+TEST(comparison, equal_self)
+{
+    ysc::matrix<int, 3> m{10, 20, 30};
+    ASSERT_TRUE(m == m);
+    ASSERT_FALSE(m != m);
+}
+
+
+//
+// --- THREE-WAY (lexicographic) ---
+//
+
+TEST(comparison, less_than)
+{
+    ysc::matrix<int, 3> m1{1, 2, 3};
+    ysc::matrix<int, 3> m2{1, 2, 4};
+    ASSERT_TRUE(m1 < m2);
+    ASSERT_TRUE(m1 <= m2);
+    ASSERT_FALSE(m1 > m2);
+    ASSERT_FALSE(m1 >= m2);
+}
+
+TEST(comparison, greater_than)
+{
+    ysc::matrix<int, 3> m1{1, 3, 0};
+    ysc::matrix<int, 3> m2{1, 2, 9};
+    ASSERT_TRUE(m1 > m2);
+    ASSERT_TRUE(m1 >= m2);
+    ASSERT_FALSE(m1 < m2);
+    ASSERT_FALSE(m1 <= m2);
+}
+
+TEST(comparison, lexicographic_first_element_wins)
+{
+    ysc::matrix<int, 3> lo{0, 99, 99};
+    ysc::matrix<int, 3> hi{1, 0, 0};
+    ASSERT_TRUE(lo < hi);
+}
+
+TEST(comparison, ordering_equal)
+{
+    ysc::matrix<int, 2> m{5, 5};
+    ASSERT_TRUE(m >= m);
+    ASSERT_TRUE(m <= m);
+}
+
+
+//
+// --- STATIC ASSERTIONS ---
+//
+
+TEST(comparison, three_way_comparable_concept)
+{
+    static_assert(std::three_way_comparable<ysc::matrix<int, 3>>);
+    static_assert(std::three_way_comparable<ysc::matrix<double, 2, 2>>);
+}


### PR DESCRIPTION
## Résumé

Ajout de `operator==` et `operator<=>` (defaulted, C++20) à `ysc::matrix`. La comparaison est lexicographique sur le stockage linéaire row-major, délégué à `std::array<T, N>`. Les matrices de dimensions différentes étant des types distincts, leur comparaison produit une erreur de compilation.

## Critères d'acceptation

- [x] `m1 == m2`, `m1 != m2`, `m1 < m2`, `m1 <= m2`, `m1 > m2`, `m1 >= m2` fonctionnent
- [x] `static_assert(std::three_way_comparable<matrix<int,3>>)` passe
- [x] Comparer des matrices de dimensions différentes → erreur de compilation
- [x] Test `comparison.cpp`

## Décisions d'implémentation

- `= default` délègue la comparaison à `std::array`, ce qui donne nativement la sémantique lexicographique souhaitée, sans code supplémentaire.
- `<compare>` ajouté aux includes.
- `friend` hidden friends : évite les problèmes ADL et restreint la lookup au type exact.