### PR TITLE
US-011 — fill() : intégration propre depuis feature-fill

### DIFF
--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -299,6 +299,14 @@ public: // comparison operators
     /** @brief Three-way comparison — lexicographic on the flat row-major storage. */
     friend auto operator<=>(const matrix& lhs, const matrix& rhs) = default;
 
+public: // modifiers
+    /**
+     * @brief Assigns the given value to all elements of the matrix.
+     * @param value Value to assign
+     */
+    void fill(const T& value) noexcept(std::is_nothrow_copy_assignable_v<T>)
+    { _data.fill(value); }
+
 public: // element access
     /**
      * @brief Returns a reference to the element at coordinates.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(${TARGET_NAME}
     src/assignment_returns_self.cpp
     src/comparison.cpp
     src/construct.cpp
+    src/fill.cpp
     src/iterators.cpp
     src/size_data.cpp
     src/typedefs.cpp

--- a/test/src/fill.cpp
+++ b/test/src/fill.cpp
@@ -1,0 +1,84 @@
+#include <matrix.hpp>
+
+#include <gtest/gtest.h>
+
+#include <type_traits>
+
+
+//
+// --- TRIVIAL TYPE ---
+//
+
+TEST(fill, trivial_type_all_elements_set)
+{
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    m.fill(42);
+    for (auto v : m) {
+        ASSERT_EQ(v, 42);
+    }
+}
+
+TEST(fill, trivial_type_overwrite_zeros)
+{
+    ysc::matrix<int, 4> m{0, 0, 0, 0};
+    m.fill(-1);
+    for (auto v : m) {
+        ASSERT_EQ(v, -1);
+    }
+}
+
+TEST(fill, trivial_type_fill_zero)
+{
+    ysc::matrix<double, 3, 3> m{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    m.fill(0.0);
+    for (auto v : m) {
+        ASSERT_DOUBLE_EQ(v, 0.0);
+    }
+}
+
+
+//
+// --- USER-DEFINED TYPE ---
+//
+
+struct Point {
+    int x, y;
+    bool operator==(const Point&) const = default;
+};
+
+TEST(fill, user_defined_type)
+{
+    ysc::matrix<Point, 3> m{Point{1, 2}, Point{3, 4}, Point{5, 6}};
+    m.fill(Point{0, 0});
+    for (auto v : m) {
+        ASSERT_EQ(v, (Point{0, 0}));
+    }
+}
+
+
+//
+// --- MATRIX OF MATRIX ---
+//
+
+TEST(fill, matrix_of_matrix)
+{
+    using Inner = ysc::matrix<int, 2>;
+    ysc::matrix<Inner, 3> m;
+    const Inner pattern{7, 7};
+    m.fill(pattern);
+    for (const auto& v : m) {
+        ASSERT_EQ(v, pattern);
+    }
+}
+
+
+//
+// --- NOEXCEPT ---
+//
+
+TEST(fill, noexcept_for_nothrow_copy_assignable)
+{
+    static_assert(std::is_nothrow_copy_assignable_v<int>);
+    ysc::matrix<int, 3> m;
+    static_assert(noexcept(m.fill(0)));
+}

--- a/test/src/fill.cpp
+++ b/test/src/fill.cpp
@@ -29,7 +29,7 @@ TEST(fill, trivial_type_overwrite_zeros)
 
 TEST(fill, trivial_type_fill_zero)
 {
-    ysc::matrix<double, 3, 3> m{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    ysc::matrix<double, 3, 3> m{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0};
     m.fill(0.0);
     for (auto v : m) {
         ASSERT_DOUBLE_EQ(v, 0.0);


### PR DESCRIPTION
## Résumé

Intégration de `fill()` depuis la branche historique `origin/feature-fill` (commit `22accdb`), sans importer la suppression accidentelle de `at()` ni les autres modifications hors-périmètre. La méthode délègue à `std::array::fill` avec spécification noexcept correcte.

## Critères d'acceptation

- [x] `at()` toujours présent et fonctionnel (inchangé)
- [x] `fill()` testé — `test/src/fill.cpp` couvre : type trivial, type utilisateur, `matrix<matrix<...>>`, garantie noexcept
- [x] Branche remote `feature-fill` à supprimer après merge : `git push origin --delete feature-fill`

## Décisions d'implémentation

- Signature retenue : `void fill(const T& value) noexcept(std::is_nothrow_copy_assignable_v<T>)` (conforme à la spécification US-011, plus précise que l'original `feature-fill`).
- Placé dans une section `public: // modifiers` pour anticiper `swap()` membre (US-018) sans perturber la lecture du header.