### PR TITLE
US-018 — front(), back(), swap() membre

### DIFF
--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -307,6 +307,42 @@ public: // modifiers
     void fill(const T& value) noexcept(std::is_nothrow_copy_assignable_v<T>)
     { _data.fill(value); }
 
+    /**
+     * @brief Exchanges the contents of this matrix with another.
+     * @param other Matrix to swap with
+     */
+    void swap(matrix& other) noexcept(std::is_nothrow_swappable_v<T>)
+    { _data.swap(other._data); }
+
+public: // element access
+    /**
+     * @brief Returns a reference to the first element in the matrix (row-major order).
+     *
+     * Calling @c front() on an empty matrix is undefined behavior.
+     */
+    constexpr reference       front()       noexcept { return _data.front(); }
+
+    /**
+     * @brief Returns a const reference to the first element in the matrix (row-major order).
+     *
+     * Calling @c front() on an empty matrix is undefined behavior.
+     */
+    constexpr const_reference front() const noexcept { return _data.front(); }
+
+    /**
+     * @brief Returns a reference to the last element in the matrix (row-major order).
+     *
+     * Calling @c back() on an empty matrix is undefined behavior.
+     */
+    constexpr reference       back()        noexcept { return _data.back(); }
+
+    /**
+     * @brief Returns a const reference to the last element in the matrix (row-major order).
+     *
+     * Calling @c back() on an empty matrix is undefined behavior.
+     */
+    constexpr const_reference back()  const noexcept { return _data.back(); }
+
 public: // element access
     /**
      * @brief Returns a reference to the element at coordinates.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ include_directories(include)
 set(TARGET_NAME matrix-test)
 add_executable(${TARGET_NAME}
     src/access.cpp
+    src/accessors.cpp
     src/assignment_returns_self.cpp
     src/comparison.cpp
     src/construct.cpp

--- a/test/src/accessors.cpp
+++ b/test/src/accessors.cpp
@@ -1,0 +1,122 @@
+#include <matrix.hpp>
+
+#include <gtest/gtest.h>
+
+
+//
+// --- front() ---
+//
+
+TEST(accessors_front, returns_first_element)
+{
+    ysc::matrix<int, 3> m{10, 20, 30};
+    ASSERT_EQ(m.front(), 10);
+}
+
+TEST(accessors_front, const_returns_first_element)
+{
+    const ysc::matrix<int, 3> m{10, 20, 30};
+    ASSERT_EQ(m.front(), 10);
+}
+
+TEST(accessors_front, reference_allows_mutation)
+{
+    ysc::matrix<int, 3> m{10, 20, 30};
+    m.front() = 99;
+    ASSERT_EQ(m(0), 99);
+}
+
+TEST(accessors_front, noexcept_guaranteed)
+{
+    ysc::matrix<int, 3> m;
+    static_assert(noexcept(m.front()));
+    const ysc::matrix<int, 3> cm;
+    static_assert(noexcept(cm.front()));
+}
+
+
+//
+// --- back() ---
+//
+
+TEST(accessors_back, returns_last_element)
+{
+    ysc::matrix<int, 3> m{10, 20, 30};
+    ASSERT_EQ(m.back(), 30);
+}
+
+TEST(accessors_back, const_returns_last_element)
+{
+    const ysc::matrix<int, 3> m{10, 20, 30};
+    ASSERT_EQ(m.back(), 30);
+}
+
+TEST(accessors_back, reference_allows_mutation)
+{
+    ysc::matrix<int, 3> m{10, 20, 30};
+    m.back() = 99;
+    ASSERT_EQ(m(2), 99);
+}
+
+TEST(accessors_back, noexcept_guaranteed)
+{
+    ysc::matrix<int, 3> m;
+    static_assert(noexcept(m.back()));
+    const ysc::matrix<int, 3> cm;
+    static_assert(noexcept(cm.back()));
+}
+
+TEST(accessors_back, 2d_last_element_is_row_major_last)
+{
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    ASSERT_EQ(m.back(), 6);
+}
+
+
+//
+// --- swap() membre ---
+//
+
+TEST(accessors_swap_member, exchanges_contents)
+{
+    ysc::matrix<int, 3> a{1, 2, 3};
+    ysc::matrix<int, 3> b{4, 5, 6};
+    a.swap(b);
+    ASSERT_EQ(a(0), 4);
+    ASSERT_EQ(a(1), 5);
+    ASSERT_EQ(a(2), 6);
+    ASSERT_EQ(b(0), 1);
+    ASSERT_EQ(b(1), 2);
+    ASSERT_EQ(b(2), 3);
+}
+
+TEST(accessors_swap_member, self_swap_is_stable)
+{
+    ysc::matrix<int, 3> m{1, 2, 3};
+    m.swap(m);
+    ASSERT_EQ(m(0), 1);
+    ASSERT_EQ(m(1), 2);
+    ASSERT_EQ(m(2), 3);
+}
+
+TEST(accessors_swap_member, noexcept_for_nothrow_swappable)
+{
+    static_assert(std::is_nothrow_swappable_v<int>);
+    ysc::matrix<int, 3> a, b;
+    static_assert(noexcept(a.swap(b)));
+}
+
+
+//
+// --- swap() friend (ADL) ---
+//
+
+TEST(accessors_swap_free, exchanges_contents)
+{
+    ysc::matrix<int, 2, 2> a{1, 2, 3, 4};
+    ysc::matrix<int, 2, 2> b{5, 6, 7, 8};
+    using std::swap;
+    swap(a, b);
+    ASSERT_EQ(a(0, 0), 5);
+    ASSERT_EQ(b(0, 0), 1);
+}

--- a/test/src/accessors.cpp
+++ b/test/src/accessors.cpp
@@ -28,9 +28,9 @@ TEST(accessors_front, reference_allows_mutation)
 
 TEST(accessors_front, noexcept_guaranteed)
 {
-    ysc::matrix<int, 3> m;
+    ysc::matrix<int, 3> m{1, 2, 3};
     static_assert(noexcept(m.front()));
-    const ysc::matrix<int, 3> cm;
+    const ysc::matrix<int, 3> cm{1, 2, 3};
     static_assert(noexcept(cm.front()));
 }
 
@@ -60,9 +60,9 @@ TEST(accessors_back, reference_allows_mutation)
 
 TEST(accessors_back, noexcept_guaranteed)
 {
-    ysc::matrix<int, 3> m;
+    ysc::matrix<int, 3> m{1, 2, 3};
     static_assert(noexcept(m.back()));
-    const ysc::matrix<int, 3> cm;
+    const ysc::matrix<int, 3> cm{1, 2, 3};
     static_assert(noexcept(cm.back()));
 }
 


### PR DESCRIPTION
## Résumé

Ajout des accesseurs `front()` et `back()` (mutable et const) ainsi que du membre `swap()`, complétant la conformité STL de `ysc::matrix`. La méthode `fill()` était déjà présente via US-011. Le `swap()` friend (ADL) existait déjà ; le membre `swap()` est ajouté en complément pour l'interface STL standard.

## Critères d'acceptation

- [x] `front()` et `back()` (mutable + const) — délèguent à `std::array`
- [x] `swap()` membre — `noexcept(std::is_nothrow_swappable_v<T>)`, délègue à `_data.swap()`
- [x] `fill()` présent (via US-011, non modifié)
- [x] Tests dans `test/src/accessors.cpp` : front/back/swap membre/swap free — couverture complète

## Décisions d'implémentation

- `front()` et `back()` sont `constexpr noexcept` car `std::array` les garantit ainsi.
- Le comportement sur matrice vide (`linear_size == 0`) est UB — conforme à `std::array` ; US-038 traitera ce cas.
- Le `swap()` membre coexiste avec le `swap()` friend déjà présent ; les deux sont testés.