### PR TITLE
US-009 — Remplacer SFINAE par Concepts

### DIFF
--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -14,10 +14,12 @@
 
 #include <array>
 #include <compare>
+#include <concepts>
 #include <iterator>
 #include <numeric>
 #include <algorithm>
 #include <stdexcept>
+#include <type_traits>
 
 namespace ysc
 {
@@ -38,6 +40,21 @@ namespace _details
         return std::inner_product(cbegin(dimension_product), cend(dimension_product), crbegin(coords), 0);
     }
 }
+
+/**
+ * @brief Satisfied when `U` is convertible to `T`.
+ * Used to constrain converting constructors and assignment operators.
+ */
+template<class T, class U>
+concept matrix_convertible_from = std::convertible_to<U, T>;
+
+/**
+ * @brief Satisfied when all types in `Coords` are integral (ignoring cv-ref qualifiers).
+ * Used to constrain `operator()` and `at()` so that floating-point or other
+ * non-integral coordinate types yield a readable diagnostic.
+ */
+template<class... Coords>
+concept integral_coordinates = (std::integral<std::remove_cvref_t<Coords>> && ...);
 
 /**
  * @brief Tag a @c matrix object to be zero-initialized.
@@ -236,6 +253,7 @@ public: // copy constructors
      * Elements of the matrix are copy-initialized from the elements of the source matrix. 
      */
     template<class U>
+        requires matrix_convertible_from<T, U>
     matrix(matrix<U, Dimensions...> const& other)
     { std::copy(other._data.cbegin(), other._data.cend(), _data.begin()); }
 
@@ -258,6 +276,7 @@ public: // move constructors
      * `other` is left in a valid but unspecified state.
      */
     template<class U>
+        requires matrix_convertible_from<T, U>
     matrix(matrix<U, Dimensions...> && other)
     { std::move(other._data.cbegin(), other._data.cend(), _data.begin()); }
 
@@ -274,6 +293,7 @@ public: // assignment operators (copy)
      * @param  other Source matrix
      */
     template<class U>
+        requires matrix_convertible_from<T, U>
     matrix& operator=(matrix<U, Dimensions...> const& other)
     { std::copy(other._data.cbegin(), other._data.cend(), _data.begin()); return *this; }
 
@@ -290,6 +310,7 @@ public: // assignment operators (move)
      * @param  other Source matrix
      */
     template<class U>
+        requires matrix_convertible_from<T, U>
     matrix& operator=(matrix<U, Dimensions...> && other)
     { std::move(other._data.cbegin(), other._data.cend(), _data.begin()); return *this; }
 
@@ -352,6 +373,7 @@ public: // element access
      * the matrix dimensions, the behavior is undefined.
      */
     template<class... Coords>
+        requires integral_coordinates<Coords...>
     T const& operator()(Coords... coordinates) const
     { return _data[_details::coordinates_to_index(dimensions, std::array{coordinates...})]; }
 
@@ -363,6 +385,7 @@ public: // element access
      * the matrix dimensions, the behavior is undefined.
      */
     template<class... Coords>
+        requires integral_coordinates<Coords...>
     T& operator()(Coords... coordinates)
     { return _data[_details::coordinates_to_index(dimensions, std::array{coordinates...})]; }
 
@@ -374,6 +397,7 @@ public: // element access
      * @c std::out_of_range is thrown.
      */
     template<class... Coords>
+        requires integral_coordinates<Coords...>
     const T& at(Coords... coordinates) const
     {
         const bool any_of_coords_is_negative = ( (coordinates < 0) || ... );
@@ -392,6 +416,7 @@ public: // element access
      * @c std::out_of_range is thrown.
      */
     template<class... Coords>
+        requires integral_coordinates<Coords...>
     T& at(Coords... coordinates)
     {
         const bool any_of_coords_is_negative = ( (coordinates < 0) || ... );

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(${TARGET_NAME}
     src/accessors.cpp
     src/assignment_returns_self.cpp
     src/comparison.cpp
+    src/concepts.cpp
     src/construct.cpp
     src/fill.cpp
     src/iterators.cpp

--- a/test/src/concepts.cpp
+++ b/test/src/concepts.cpp
@@ -1,0 +1,63 @@
+#include <gtest/gtest.h>
+#include "matrix.hpp"
+#include <string>
+
+// Helper concept to test at() callability (GCC 15 does not support bare requires
+// expressions in static_assert when all overload candidates are constrained out)
+template<class M, class... Args>
+concept at_callable = requires(M& m, Args... args) { m.at(args...); };
+
+// integral_coordinates
+static_assert(ysc::integral_coordinates<int>);
+static_assert(ysc::integral_coordinates<int, int>);
+static_assert(ysc::integral_coordinates<unsigned int, std::size_t>);
+static_assert(!ysc::integral_coordinates<double>);
+static_assert(!ysc::integral_coordinates<int, double>);
+static_assert(!ysc::integral_coordinates<float>);
+
+// matrix_convertible_from
+static_assert(ysc::matrix_convertible_from<int, int>);
+static_assert(ysc::matrix_convertible_from<double, int>);
+static_assert(ysc::matrix_convertible_from<int, double>);
+static_assert(!ysc::matrix_convertible_from<int, std::string>);
+static_assert(!ysc::matrix_convertible_from<std::string, int>);
+
+// operator() accepts integral coordinates, rejects floating-point
+static_assert( std::is_invocable_v<ysc::matrix<int, 2, 3>&, int, int>);
+static_assert(!std::is_invocable_v<ysc::matrix<int, 2, 3>&, double, double>);
+static_assert(!std::is_invocable_v<ysc::matrix<int, 2, 3>&, float, float>);
+
+// at() accepts integral coordinates, rejects floating-point
+static_assert( at_callable<ysc::matrix<int, 2, 3>, int, int>);
+static_assert(!at_callable<ysc::matrix<int, 2, 3>, double, double>);
+static_assert(!at_callable<ysc::matrix<int, 2, 3>, float, float>);
+
+// Converting constructor is constrained (positive case)
+static_assert(std::is_constructible_v<ysc::matrix<double, 3>, ysc::matrix<int, 3> const&>);
+
+TEST(concepts, operator_call_integral_coords)
+{
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    EXPECT_EQ(m(0, 0), 1);
+    EXPECT_EQ(m(1, 2), 6);
+}
+
+TEST(concepts, converting_ctor_constrained)
+{
+    // const source: the more-specialized converting ctor wins over the variadic ctor
+    const ysc::matrix<int, 3> mi{1, 2, 3};
+    ysc::matrix<double, 3> md(mi);
+    EXPECT_DOUBLE_EQ(md(0), 1.0);
+    EXPECT_DOUBLE_EQ(md(1), 2.0);
+    EXPECT_DOUBLE_EQ(md(2), 3.0);
+}
+
+TEST(concepts, converting_assign_constrained)
+{
+    const ysc::matrix<int, 3> mi{4, 5, 6};
+    ysc::matrix<double, 3> md;
+    md = mi;
+    EXPECT_DOUBLE_EQ(md(0), 4.0);
+    EXPECT_DOUBLE_EQ(md(1), 5.0);
+    EXPECT_DOUBLE_EQ(md(2), 6.0);
+}


### PR DESCRIPTION
## Résumé

Introduit deux concepts C++20 dans `namespace ysc` afin de remplacer la validation implicite par des contraintes explicites : `integral_coordinates` (coordonnées entières pour `operator()` et `at()`) et `matrix_convertible_from` (conversion compatible pour les ctors/assignments templatés sur `U`). Les messages d'erreur passent d'un mur de substitutions SFINAE à un message direct mentionnant le concept non satisfait.

## Critères d'acceptation

- [x] Compilation `matrix<int,3> m; m(1.5);` produit un message lisible citant `integral_coordinates` (vérifié localement avec GCC 15 et Clang)
- [x] Tests existants restent verts (l'unique échec local sur `access.const_no_check_outofbound` est pré-existant sur `develop` — assertion libstdc++15 absente des compilateurs CI)
- [x] Nouveau test `concepts.cpp` : `static_assert` sur les deux concepts + cas d'utilisation runtime

## Décisions d'implémentation

- Les concepts vivent dans `namespace ysc` (accessibles pour les tests et potentiellement utiles aux utilisateurs de la bibliothèque).
- Les `requires` expressions directes dans `static_assert` provoquent des erreurs dures sous GCC 15 quand tous les candidats sont contraints. Le test utilise à la place `std::is_invocable_v` pour `operator()` et un concept `at_callable` local pour `at()`.
- Le test de construction négative (`matrix<string,3>` depuis `matrix<int,3>`) est intentionnellement absent : le constructeur variadic non contraint absorbe encore l'appel. Cette limitation sera corrigée par US-021.