### PR TITLE
US-002 — Couverture de code (gcov + lcov + Codecov)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,8 @@ jobs:
           lcov --capture \
                --directory build \
                --output-file coverage.info \
-               --gcov-tool gcov-13
+               --gcov-tool gcov-13 \
+               --ignore-errors mismatch
 
       - name: Filter coverage data
         run: |
@@ -182,7 +183,8 @@ jobs:
                '*/_deps/*' \
                '/usr/*' \
                --output-file coverage.info \
-               --gcov-tool gcov-13
+               --gcov-tool gcov-13 \
+               --ignore-errors mismatch
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,3 +140,53 @@ jobs:
 
       - name: Test
         run: ctest --test-dir build --output-on-failure --build-config ${{ matrix.build_type }}
+
+  coverage:
+    name: Coverage (Ubuntu / GCC-13 / Debug)
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install GCC-13, GTest and lcov
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y g++-13 libgtest-dev lcov
+
+      - name: Configure with coverage
+        env:
+          CC: gcc-13
+          CXX: g++-13
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DENABLE_COVERAGE=ON
+
+      - name: Build
+        run: cmake --build build --parallel
+
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure
+
+      - name: Collect coverage data
+        run: |
+          lcov --capture \
+               --directory build \
+               --output-file coverage.info \
+               --gcov-tool gcov-13
+
+      - name: Filter coverage data
+        run: |
+          lcov --remove coverage.info \
+               '*/test/*' \
+               '*/_deps/*' \
+               '/usr/*' \
+               --output-file coverage.info \
+               --gcov-tool gcov-13
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.info
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
                '/usr/*' \
                --output-file coverage.info \
                --gcov-tool gcov-13 \
-               --ignore-errors mismatch
+               --ignore-errors mismatch,unused
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ add_subdirectory(src)
 #
 enable_testing()
 add_subdirectory(test)
+include(cmake/Coverage.cmake)
 add_custom_target(check # alias for make && make test
     COMMAND ${CMAKE_CTEST_COMMAND}
     DEPENDS matrix-test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # `ysc::matrix`
 
 [![CI](https://github.com/yscialom/matrix/actions/workflows/ci.yml/badge.svg)](https://github.com/yscialom/matrix/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/yscialom/matrix/graph/badge.svg)](https://codecov.io/gh/yscialom/matrix)
 
 A general-purpose multi-dimension container of static dimensions. Requires **C++20** (`__cplusplus >= 202002L`).
 

--- a/cmake/Coverage.cmake
+++ b/cmake/Coverage.cmake
@@ -1,0 +1,22 @@
+option(ENABLE_COVERAGE "Enable code coverage instrumentation (GCC/Clang only)" OFF)
+
+if(ENABLE_COVERAGE)
+    if(NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        message(FATAL_ERROR
+            "ENABLE_COVERAGE=ON requires GCC or Clang. "
+            "Current compiler: ${CMAKE_CXX_COMPILER_ID}")
+    endif()
+
+    message(STATUS "Coverage instrumentation enabled")
+
+    target_compile_options(matrix-test PRIVATE
+        -O0
+        -g
+        --coverage
+        -fprofile-arcs
+        -ftest-coverage
+    )
+    target_link_options(matrix-test PRIVATE
+        --coverage
+    )
+endif()

--- a/user-stories.md
+++ b/user-stories.md
@@ -4,7 +4,7 @@
 
 | Épopée | Statut | Progression | Détail |
 |--------|--------|-------------|--------|
-| **A — Infrastructure & CI/CD** | 🔶 Partielle | 1/7 | ✅ US-001 · ⬜ US-002 à US-007 |
+| **A — Infrastructure & CI/CD** | 🔶 Partielle | 2/7 | ✅ US-001, US-002 · ⬜ US-003 à US-007 |
 | **B — Modernisation C++20** | ✅ Terminée | 3/3 | ✅ US-008, US-009, US-010 (fusionné US-019) |
 | **C — Dette technique** | 🔶 Partielle | 2/4 | ✅ US-011, US-013 · ⬜ US-012, US-014 |
 | **D — Conformité STL** | ✅ Terminée | 4/4 | ✅ US-015, US-016, US-017, US-018 |
@@ -14,14 +14,14 @@
 | **H — Vues & reshape** | ⬜ Non démarrée | 0/3 | ⬜ US-035 à US-037 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/5 | ⬜ US-038 à US-042 |
 
-**Total : 11 / 42 US**
+**Total : 12 / 42 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
 | US | Titre | Priorité | Statut |
 |----|-------|----------|--------|
 | US-001 | Pipeline CI multi-plateforme | P0 | ✅ Done |
-| US-002 | Couverture de code (gcov + lcov + Codecov) | P0 | 🔓 Disponible |
+| US-002 | Couverture de code (gcov + lcov + Codecov) | P0 | ✅ Done |
 | US-003 | Sanitizers (ASan + UBSan) | P1 | 🔓 Disponible |
 | US-004 | clang-format + vérification CI | P1 | 🔓 Disponible |
 | US-005 | clang-tidy + vérification CI | P1 | 🔓 Disponible |


### PR DESCRIPTION
## Résumé

Ajoute la mesure de couverture de code au projet : instrumentation gcov via un module CMake opt-in (`-DENABLE_COVERAGE=ON`), génération du rapport lcov, upload automatique sur Codecov.io dans un job CI dédié, et badge dans le README.

## Critères d'acceptation

- [x] Rapport visible sur codecov.io
- [x] Badge dans README
- [x] Couverture initiale rapportée (≥ existante, pas de seuil bloquant)

## Décisions d'implémentation

- `cmake/Coverage.cmake` cible `matrix-test` (le binaire de test) et non la cible `matrix` qui est INTERFACE — les fichiers `.gcda`/`.gcno` sont générés par la compilation du binaire de test uniquement.
- `--gcov-tool gcov-13` explicité dans les commandes lcov pour éviter les erreurs de parsing de format gcov 4.x avec lcov 1.x sur Ubuntu 24.04.
- Le job `coverage` est indépendant du job `build` (pas de `needs:`), sans ccache (incompatible avec les fichiers `.gcda`).
- `fail_ci_if_error: true` sur l'étape Codecov : préférable à un faux-vert silencieux en cas d'échec d'upload.

**Prérequis :** le secret `CODECOV_TOKEN` doit être configuré dans Settings → Secrets → Actions du dépôt.