### PR TITLE
US-003 — Sanitizers (ASan + UBSan)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,3 +192,33 @@ jobs:
           files: coverage.info
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  sanitizers:
+    name: Sanitizers (Ubuntu / Clang-17 / Debug)
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Clang-17 and GTest
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y clang-17 libgtest-dev
+
+      - name: Configure with sanitizers
+        env:
+          CC: clang-17
+          CXX: clang++-17
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DENABLE_SANITIZERS=ON
+
+      - name: Build
+        run: cmake --build build --parallel
+
+      - name: Run tests
+        env:
+          ASAN_OPTIONS: detect_leaks=1
+          UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+        run: ctest --test-dir build --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ add_subdirectory(src)
 enable_testing()
 add_subdirectory(test)
 include(cmake/Coverage.cmake)
+include(cmake/Sanitizers.cmake)
 add_custom_target(check # alias for make && make test
     COMMAND ${CMAKE_CTEST_COMMAND}
     DEPENDS matrix-test

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -1,0 +1,20 @@
+option(ENABLE_SANITIZERS "Enable ASan + UBSan instrumentation (Clang/GCC only)" OFF)
+
+if(ENABLE_SANITIZERS)
+    if(NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        message(FATAL_ERROR
+            "ENABLE_SANITIZERS=ON requires GCC or Clang. "
+            "Current compiler: ${CMAKE_CXX_COMPILER_ID}")
+    endif()
+
+    message(STATUS "Sanitizer instrumentation enabled (ASan + UBSan)")
+
+    target_compile_options(matrix-test PRIVATE
+        -fsanitize=address,undefined
+        -fno-omit-frame-pointer
+        -g
+    )
+    target_link_options(matrix-test PRIVATE
+        -fsanitize=address,undefined
+    )
+endif()

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -17,4 +17,5 @@ if(ENABLE_SANITIZERS)
     target_link_options(matrix-test PRIVATE
         -fsanitize=address,undefined
     )
+    target_compile_definitions(matrix-test PRIVATE YSC_SANITIZERS_ENABLED)
 endif()

--- a/test/src/access.cpp
+++ b/test/src/access.cpp
@@ -24,7 +24,7 @@ TEST(access, const_no_check_outofbound)
 #if defined(_ITERATOR_DEBUG_LEVEL) && _ITERATOR_DEBUG_LEVEL > 0
     GTEST_SKIP() << "MSVC debug iterator checks intercept UB access before operator() returns";
 #endif
-#if defined(__SANITIZE_ADDRESS__) || (defined(__has_feature) && __has_feature(address_sanitizer))
+#if defined(__SANITIZE_ADDRESS__)
     GTEST_SKIP() << "ASan intercepts the intentional out-of-bounds UB in operator()";
 #endif
 #if defined(_GLIBCXX_ASSERTIONS)
@@ -60,7 +60,7 @@ TEST(access, mutable_no_check_outofbound)
 #if defined(_ITERATOR_DEBUG_LEVEL) && _ITERATOR_DEBUG_LEVEL > 0
     GTEST_SKIP() << "MSVC debug iterator checks intercept UB access before operator() returns";
 #endif
-#if defined(__SANITIZE_ADDRESS__) || (defined(__has_feature) && __has_feature(address_sanitizer))
+#if defined(__SANITIZE_ADDRESS__)
     GTEST_SKIP() << "ASan intercepts the intentional out-of-bounds UB in operator()";
 #endif
 #if defined(_GLIBCXX_ASSERTIONS)

--- a/test/src/access.cpp
+++ b/test/src/access.cpp
@@ -24,11 +24,8 @@ TEST(access, const_no_check_outofbound)
 #if defined(_ITERATOR_DEBUG_LEVEL) && _ITERATOR_DEBUG_LEVEL > 0
     GTEST_SKIP() << "MSVC debug iterator checks intercept UB access before operator() returns";
 #endif
-#if defined(__SANITIZE_ADDRESS__)
-    GTEST_SKIP() << "ASan intercepts the intentional out-of-bounds UB in operator()";
-#endif
-#if defined(_GLIBCXX_ASSERTIONS)
-    GTEST_SKIP() << "libstdc++ hardened assertions intercept the intentional out-of-bounds UB in operator()";
+#if defined(YSC_SANITIZERS_ENABLED) || defined(_GLIBCXX_ASSERTIONS)
+    GTEST_SKIP() << "Runtime hardening (sanitizers or libstdc++ assertions) intercepts the intentional out-of-bounds UB in operator()";
 #endif
     ysc::matrix<int, 2, 2> const m{0, 1, 2, 3};
     try {
@@ -60,11 +57,8 @@ TEST(access, mutable_no_check_outofbound)
 #if defined(_ITERATOR_DEBUG_LEVEL) && _ITERATOR_DEBUG_LEVEL > 0
     GTEST_SKIP() << "MSVC debug iterator checks intercept UB access before operator() returns";
 #endif
-#if defined(__SANITIZE_ADDRESS__)
-    GTEST_SKIP() << "ASan intercepts the intentional out-of-bounds UB in operator()";
-#endif
-#if defined(_GLIBCXX_ASSERTIONS)
-    GTEST_SKIP() << "libstdc++ hardened assertions intercept the intentional out-of-bounds UB in operator()";
+#if defined(YSC_SANITIZERS_ENABLED) || defined(_GLIBCXX_ASSERTIONS)
+    GTEST_SKIP() << "Runtime hardening (sanitizers or libstdc++ assertions) intercepts the intentional out-of-bounds UB in operator()";
 #endif
     ysc::matrix<int, 2, 2> m{0, 1, 2, 3};
     try {

--- a/test/src/access.cpp
+++ b/test/src/access.cpp
@@ -24,6 +24,12 @@ TEST(access, const_no_check_outofbound)
 #if defined(_ITERATOR_DEBUG_LEVEL) && _ITERATOR_DEBUG_LEVEL > 0
     GTEST_SKIP() << "MSVC debug iterator checks intercept UB access before operator() returns";
 #endif
+#if defined(__SANITIZE_ADDRESS__) || (defined(__has_feature) && __has_feature(address_sanitizer))
+    GTEST_SKIP() << "ASan intercepts the intentional out-of-bounds UB in operator()";
+#endif
+#if defined(_GLIBCXX_ASSERTIONS)
+    GTEST_SKIP() << "libstdc++ hardened assertions intercept the intentional out-of-bounds UB in operator()";
+#endif
     ysc::matrix<int, 2, 2> const m{0, 1, 2, 3};
     try {
         (void) m(-1, -1);
@@ -53,6 +59,12 @@ TEST(access, mutable_no_check_outofbound)
 {
 #if defined(_ITERATOR_DEBUG_LEVEL) && _ITERATOR_DEBUG_LEVEL > 0
     GTEST_SKIP() << "MSVC debug iterator checks intercept UB access before operator() returns";
+#endif
+#if defined(__SANITIZE_ADDRESS__) || (defined(__has_feature) && __has_feature(address_sanitizer))
+    GTEST_SKIP() << "ASan intercepts the intentional out-of-bounds UB in operator()";
+#endif
+#if defined(_GLIBCXX_ASSERTIONS)
+    GTEST_SKIP() << "libstdc++ hardened assertions intercept the intentional out-of-bounds UB in operator()";
 #endif
     ysc::matrix<int, 2, 2> m{0, 1, 2, 3};
     try {

--- a/user-stories.md
+++ b/user-stories.md
@@ -4,7 +4,7 @@
 
 | Épopée | Statut | Progression | Détail |
 |--------|--------|-------------|--------|
-| **A — Infrastructure & CI/CD** | 🔶 Partielle | 2/7 | ✅ US-001, US-002 · ⬜ US-003 à US-007 |
+| **A — Infrastructure & CI/CD** | 🔶 Partielle | 3/7 | ✅ US-001, US-002, US-003 · ⬜ US-004 à US-007 |
 | **B — Modernisation C++20** | ✅ Terminée | 3/3 | ✅ US-008, US-009, US-010 (fusionné US-019) |
 | **C — Dette technique** | 🔶 Partielle | 2/4 | ✅ US-011, US-013 · ⬜ US-012, US-014 |
 | **D — Conformité STL** | ✅ Terminée | 4/4 | ✅ US-015, US-016, US-017, US-018 |
@@ -22,7 +22,7 @@
 |----|-------|----------|--------|
 | US-001 | Pipeline CI multi-plateforme | P0 | ✅ Done |
 | US-002 | Couverture de code (gcov + lcov + Codecov) | P0 | ✅ Done |
-| US-003 | Sanitizers (ASan + UBSan) | P1 | 🔓 Disponible |
+| US-003 | Sanitizers (ASan + UBSan) | P1 | ✅ Done |
 | US-004 | clang-format + vérification CI | P1 | 🔓 Disponible |
 | US-005 | clang-tidy + vérification CI | P1 | 🔓 Disponible |
 | US-006 | Doc Doxygen publiée sur GitHub Pages | P1 | 🔓 Disponible |


### PR DESCRIPTION
## Résumé

Ajoute l'instrumentation ASan + UBSan en option CMake et un job CI dédié sur Ubuntu 24.04 / Clang-17 / Debug. Corrige au passage les deux tests `no_check_outofbound` qui invoquaient délibérément un UB capturé par les gardes runtime (ASan, libstdc++ hardened GCC 15).

## Critères d'acceptation

- [x] Job `sanitizers` vert sur develop (Ubuntu / Clang-17 / Debug)
- [x] Tout test échouant en sanitizer = build rouge

## Décisions notables

- `cmake/Sanitizers.cmake` modélisé sur `cmake/Coverage.cmake` (opt-in via `-DENABLE_SANITIZERS=ON`).
- Les tests `access.{const,mutable}_no_check_outofbound` testent un UB intentionnel (`operator()` sans vérification). Ils sont maintenant skippés quand ASan ou `_GLIBCXX_ASSERTIONS` (GCC 15 hardened libstdc++) est actif — exactement comme le guard MSVC `_ITERATOR_DEBUG_LEVEL` existait déjà.
- Pas de TSan (bibliothèque non thread-safe par conception), pas de MSan (trop complexe à provisionner).