### PR TITLE
US-004 — clang-format + vérification CI

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 100
+AccessModifierOffset: -4
+PointerAlignment: Left
+AllowShortFunctionsOnASingleLine: InlineOnly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,3 +222,20 @@ jobs:
           ASAN_OPTIONS: detect_leaks=1
           UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
         run: ctest --test-dir build --output-on-failure
+
+  format-check:
+    name: Format Check (clang-format)
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y clang-format
+
+      - name: Check formatting
+        run: |
+          clang-format --dry-run --Werror \
+            $(find src test -name '*.hpp' -o -name '*.cpp')

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ enable_testing()
 add_subdirectory(test)
 include(cmake/Coverage.cmake)
 include(cmake/Sanitizers.cmake)
+include(cmake/ClangFormat.cmake)
 add_custom_target(check # alias for make && make test
     COMMAND ${CMAKE_CTEST_COMMAND}
     DEPENDS matrix-test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+## Code style
+
+This project uses [clang-format](https://clang.llvm.org/docs/ClangFormat.html) (LLVM-based style,
+4-space indent, 100-column limit). The CI blocks any PR with unformatted code.
+
+Format all source files locally with:
+
+```bash
+cmake --build build --target format
+```
+
+## Pre-commit hook (optional)
+
+To catch formatting issues before committing, add this check to `.git/hooks/pre-commit`:
+
+```sh
+#!/bin/sh
+clang-format --dry-run --Werror $(find src test -name '*.hpp' -o -name '*.cpp')
+```
+
+Make the hook executable:
+
+```bash
+chmod +x .git/hooks/pre-commit
+```

--- a/cmake/ClangFormat.cmake
+++ b/cmake/ClangFormat.cmake
@@ -1,0 +1,17 @@
+find_program(CLANG_FORMAT_EXECUTABLE NAMES clang-format)
+
+if(CLANG_FORMAT_EXECUTABLE)
+    file(GLOB_RECURSE ALL_SOURCES
+        ${CMAKE_SOURCE_DIR}/src/*.hpp
+        ${CMAKE_SOURCE_DIR}/test/include/*.hpp
+        ${CMAKE_SOURCE_DIR}/test/src/*.cpp
+    )
+    add_custom_target(format
+        COMMAND ${CLANG_FORMAT_EXECUTABLE} -i ${ALL_SOURCES}
+        COMMENT "Formatting source files with clang-format"
+        VERBATIM
+    )
+    message(STATUS "clang-format found: ${CLANG_FORMAT_EXECUTABLE} -- target 'format' available")
+else()
+    message(STATUS "clang-format not found -- target 'format' unavailable")
+endif()

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -12,40 +12,40 @@
 #ifndef YSC_MATRIX_HPP
 #define YSC_MATRIX_HPP
 
+#include <algorithm>
 #include <array>
 #include <compare>
 #include <concepts>
 #include <iterator>
 #include <numeric>
-#include <algorithm>
 #include <stdexcept>
 #include <type_traits>
 
-namespace ysc
-{
-namespace _details
-{
-    template<class InputIt, class OutputIt>
-    OutputIt partial_product(InputIt first, InputIt last, OutputIt output)
-    { *output++ = 1; return partial_sum(first, last, output, std::multiplies<>{}); }
-
-    // cache-friendly:
-    // neighbor objects within the right-most coordinate are neighbors in memory
-    template<class TDim, class TCoord>
-    auto coordinates_to_index(TDim const& dimensions, TCoord const& coords)
-    {
-        std::array<std::size_t, std::tuple_size_v<TDim>> dimension_product;
-        using std::begin, std::cbegin, std::cend, std::crbegin, std::crend, std::prev;
-        partial_product(crbegin(dimensions), prev(crend(dimensions)), begin(dimension_product));
-        return std::inner_product(cbegin(dimension_product), cend(dimension_product), crbegin(coords), 0);
-    }
+namespace ysc {
+namespace _details {
+template <class InputIt, class OutputIt>
+OutputIt partial_product(InputIt first, InputIt last, OutputIt output) {
+    *output++ = 1;
+    return partial_sum(first, last, output, std::multiplies<>{});
 }
+
+// cache-friendly:
+// neighbor objects within the right-most coordinate are neighbors in memory
+template <class TDim, class TCoord>
+auto coordinates_to_index(TDim const& dimensions, TCoord const& coords) {
+    std::array<std::size_t, std::tuple_size_v<TDim>> dimension_product;
+    using std::begin, std::cbegin, std::cend, std::crbegin, std::crend, std::prev;
+    partial_product(crbegin(dimensions), prev(crend(dimensions)), begin(dimension_product));
+    return std::inner_product(cbegin(dimension_product), cend(dimension_product), crbegin(coords),
+                              0);
+}
+} // namespace _details
 
 /**
  * @brief Satisfied when `U` is convertible to `T`.
  * Used to constrain converting constructors and assignment operators.
  */
-template<class T, class U>
+template <class T, class U>
 concept matrix_convertible_from = std::convertible_to<U, T>;
 
 /**
@@ -53,14 +53,15 @@ concept matrix_convertible_from = std::convertible_to<U, T>;
  * Used to constrain `operator()` and `at()` so that floating-point or other
  * non-integral coordinate types yield a readable diagnostic.
  */
-template<class... Coords>
+template <class... Coords>
 concept integral_coordinates = (std::integral<std::remove_cvref_t<Coords>> && ...);
 
 /**
  * @brief Tag a @c matrix object to be zero-initialized.
  * @see matrix::matrix(matrix_zero_t)
  */
-constexpr struct matrix_zero_t {} zero;
+constexpr struct matrix_zero_t {
+} zero;
 
 /**
  * @brief Multi-dimensional container encapsulating a fixed size matrix.
@@ -90,16 +91,14 @@ constexpr struct matrix_zero_t {} zero;
  * the matrix. One should take note, however, that during swap, the iterator will continue
  * to point to the same matrix element, and will thus change its value.
  */
-template<class T, std::size_t... Dimensions>
-class matrix
-{
-template<class, std::size_t...> friend class matrix;
+template <class T, std::size_t... Dimensions> class matrix {
+    template <class, std::size_t...> friend class matrix;
 
 public:
     /** @brief Order of the matrix (2D matrix have order 2, 3D order 3, etc.). */
-    static constexpr std::size_t order      = sizeof...(Dimensions);
+    static constexpr std::size_t order = sizeof...(Dimensions);
     /** @brief Dimensions of the matrix. An order-`N` matrix has `N` dimensions. */
-    static constexpr std::array  dimensions = { Dimensions... };
+    static constexpr std::array dimensions = {Dimensions...};
 
 private:
     static constexpr std::size_t linear_size = (Dimensions * ...);
@@ -107,41 +106,41 @@ private:
 
 public:
     /** @brief Element type. */
-    using value_type             = T;
+    using value_type = T;
     /** @brief Unsigned integer type for sizes and counts. */
-    using size_type              = std::size_t;
+    using size_type = std::size_t;
     /** @brief Signed integer type for differences between iterators. */
-    using difference_type        = std::ptrdiff_t;
+    using difference_type = std::ptrdiff_t;
     /** @brief Reference to element type. */
-    using reference              = T&;
+    using reference = T&;
     /** @brief Const reference to element type. */
-    using const_reference        = const T&;
+    using const_reference = const T&;
     /** @brief Pointer to element type. */
-    using pointer                = T*;
+    using pointer = T*;
     /** @brief Const pointer to element type. */
-    using const_pointer          = const T*;
+    using const_pointer = const T*;
     /** @brief Iterator over matrix elements in row-major order. */
-    using iterator               = typename std::array<T, linear_size>::iterator;
+    using iterator = typename std::array<T, linear_size>::iterator;
     /** @brief Const iterator over matrix elements in row-major order. */
-    using const_iterator         = typename std::array<T, linear_size>::const_iterator;
+    using const_iterator = typename std::array<T, linear_size>::const_iterator;
     /** @brief Reverse iterator. */
-    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using reverse_iterator = std::reverse_iterator<iterator>;
     /** @brief Const reverse iterator. */
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
 public: // iterators
-    constexpr iterator               begin()        noexcept { return _data.begin(); }
-    constexpr const_iterator         begin()  const noexcept { return _data.begin(); }
-    constexpr const_iterator         cbegin() const noexcept { return _data.cbegin(); }
-    constexpr iterator               end()          noexcept { return _data.end(); }
-    constexpr const_iterator         end()    const noexcept { return _data.end(); }
-    constexpr const_iterator         cend()   const noexcept { return _data.cend(); }
-    constexpr reverse_iterator       rbegin()       noexcept { return _data.rbegin(); }
+    constexpr iterator begin() noexcept { return _data.begin(); }
+    constexpr const_iterator begin() const noexcept { return _data.begin(); }
+    constexpr const_iterator cbegin() const noexcept { return _data.cbegin(); }
+    constexpr iterator end() noexcept { return _data.end(); }
+    constexpr const_iterator end() const noexcept { return _data.end(); }
+    constexpr const_iterator cend() const noexcept { return _data.cend(); }
+    constexpr reverse_iterator rbegin() noexcept { return _data.rbegin(); }
     constexpr const_reverse_iterator rbegin() const noexcept { return _data.rbegin(); }
     constexpr const_reverse_iterator crbegin() const noexcept { return _data.crbegin(); }
-    constexpr reverse_iterator       rend()         noexcept { return _data.rend(); }
-    constexpr const_reverse_iterator rend()   const noexcept { return _data.rend(); }
-    constexpr const_reverse_iterator crend()  const noexcept { return _data.crend(); }
+    constexpr reverse_iterator rend() noexcept { return _data.rend(); }
+    constexpr const_reverse_iterator rend() const noexcept { return _data.rend(); }
+    constexpr const_reverse_iterator crend() const noexcept { return _data.crend(); }
 
 public: // capacity
     /**
@@ -149,7 +148,7 @@ public: // capacity
      *
      * @note This function is @c static because the size is a compile-time constant.
      */
-    static constexpr size_type size()     noexcept { return linear_size; }
+    static constexpr size_type size() noexcept { return linear_size; }
 
     /**
      * @brief Returns the maximum number of elements the matrix can hold.
@@ -165,14 +164,14 @@ public: // capacity
      *
      * @note This function is @c static because the value is a compile-time constant.
      */
-    static constexpr bool      empty()    noexcept { return linear_size == 0; }
+    static constexpr bool empty() noexcept { return linear_size == 0; }
 
     /**
      * @brief Returns a pointer to the underlying element storage.
      *
      * Elements are stored in row-major order (rightmost dimension is contiguous).
      */
-    constexpr pointer       data()       noexcept { return _data.data(); }
+    constexpr pointer data() noexcept { return _data.data(); }
 
     /**
      * @brief Returns a pointer to the underlying element storage.
@@ -190,13 +189,12 @@ public:
      * Swaps the elements of @a lhs and @a rhs as if:
      * @code
      using std::swap;
-     for (auto lhs_it = lhs.begin(), auto rhs_it = rhs.begin() ; lhs_it != lhs.end() ; ++lhs_it, ++rhs_it) {
-         swap(*lhs_it, *rhs_it);
+     for (auto lhs_it = lhs.begin(), auto rhs_it = rhs.begin() ; lhs_it != lhs.end() ; ++lhs_it,
+     ++rhs_it) { swap(*lhs_it, *rhs_it);
      }
      @endcode
      */
-    friend void swap(matrix& lhs, matrix& rhs)
-    {
+    friend void swap(matrix& lhs, matrix& rhs) {
         using std::swap;
         swap(lhs._data, rhs._data);
     }
@@ -215,13 +213,11 @@ public: // default constructor
      * @note If `T` is a trivial type, the matrix is zero-initialized; otherwise the default
      * constructors of its elements are called.
      */
-    matrix(matrix_zero_t)
-        : _data({})
-    {}
+    matrix(matrix_zero_t) : _data({}) {}
 
     /*
-     * @todo Code & test "As an aggregate impersonator, it can be initialized with aggregate-initialization
-     * given at most @c N initializers that are convertible to @c T"
+     * @todo Code & test "As an aggregate impersonator, it can be initialized with
+     * aggregate-initialization given at most @c N initializers that are convertible to @c T"
      */
 
 public: // aggregate constructors
@@ -233,10 +229,7 @@ public: // aggregate constructors
      * `matrix<long, 2, 2> m{true, '\x02', 3, 4L},` initializes an order-2 matrix from the values
      * ` true`, `'\x02'`, `3` and `4L` converted to `int`.
      */
-    template<class ... Args>
-    matrix(Args&& ... args)
-        : _data{std::forward<Args>(args)...}
-    {}
+    template <class... Args> matrix(Args&&... args) : _data{std::forward<Args>(args)...} {}
 
 public: // copy constructors
     /**
@@ -250,12 +243,13 @@ public: // copy constructors
      * @tparam U     Element type of the source matrix
      * @param  other Source matrix
      *
-     * Elements of the matrix are copy-initialized from the elements of the source matrix. 
+     * Elements of the matrix are copy-initialized from the elements of the source matrix.
      */
-    template<class U>
+    template <class U>
         requires matrix_convertible_from<T, U>
-    matrix(matrix<U, Dimensions...> const& other)
-    { std::copy(other._data.cbegin(), other._data.cend(), _data.begin()); }
+    matrix(matrix<U, Dimensions...> const& other) {
+        std::copy(other._data.cbegin(), other._data.cend(), _data.begin());
+    }
 
 public: // move constructors
     /**
@@ -265,7 +259,7 @@ public: // move constructors
      * Elements of the matrix are move-initialized from the elements of the source matrix.
      * `other` is left in a valid but unspecified state.
      */
-    matrix(matrix && other) = default;
+    matrix(matrix&& other) = default;
 
     /**
      * @brief Initializes the matrix with the content of another.
@@ -275,10 +269,11 @@ public: // move constructors
      * Elements of the matrix are move-initialized from the elements of the source matrix.
      * `other` is left in a valid but unspecified state.
      */
-    template<class U>
+    template <class U>
         requires matrix_convertible_from<T, U>
-    matrix(matrix<U, Dimensions...> && other)
-    { std::move(other._data.cbegin(), other._data.cend(), _data.begin()); }
+    matrix(matrix<U, Dimensions...>&& other) {
+        std::move(other._data.cbegin(), other._data.cend(), _data.begin());
+    }
 
 public: // assignment operators (copy)
     /**
@@ -286,33 +281,37 @@ public: // assignment operators (copy)
      * @param other Source matrix
      */
     matrix& operator=(matrix const& other) = default;
-    
+
     /**
      * @brief Assigns values to a matrix.
      * @tparam U     Element type of the source matrix
      * @param  other Source matrix
      */
-    template<class U>
+    template <class U>
         requires matrix_convertible_from<T, U>
-    matrix& operator=(matrix<U, Dimensions...> const& other)
-    { std::copy(other._data.cbegin(), other._data.cend(), _data.begin()); return *this; }
+    matrix& operator=(matrix<U, Dimensions...> const& other) {
+        std::copy(other._data.cbegin(), other._data.cend(), _data.begin());
+        return *this;
+    }
 
 public: // assignment operators (move)
     /**
      * @brief Replace the element with those of another matrix.
      * @param other Source matrix
      */
-    matrix& operator=(matrix && other) = default;
+    matrix& operator=(matrix&& other) = default;
 
     /**
      * @brief Replaces the element with those of another matrix.
      * @tparam U     Element type of the source matrix
      * @param  other Source matrix
      */
-    template<class U>
+    template <class U>
         requires matrix_convertible_from<T, U>
-    matrix& operator=(matrix<U, Dimensions...> && other)
-    { std::move(other._data.cbegin(), other._data.cend(), _data.begin()); return *this; }
+    matrix& operator=(matrix<U, Dimensions...>&& other) {
+        std::move(other._data.cbegin(), other._data.cend(), _data.begin());
+        return *this;
+    }
 
 public: // comparison operators
     /** @brief Equality comparison — lexicographic on the flat row-major storage. */
@@ -325,15 +324,13 @@ public: // modifiers
      * @brief Assigns the given value to all elements of the matrix.
      * @param value Value to assign
      */
-    void fill(const T& value) noexcept(std::is_nothrow_copy_assignable_v<T>)
-    { _data.fill(value); }
+    void fill(const T& value) noexcept(std::is_nothrow_copy_assignable_v<T>) { _data.fill(value); }
 
     /**
      * @brief Exchanges the contents of this matrix with another.
      * @param other Matrix to swap with
      */
-    void swap(matrix& other) noexcept(std::is_nothrow_swappable_v<T>)
-    { _data.swap(other._data); }
+    void swap(matrix& other) noexcept(std::is_nothrow_swappable_v<T>) { _data.swap(other._data); }
 
 public: // element access
     /**
@@ -341,7 +338,7 @@ public: // element access
      *
      * Calling @c front() on an empty matrix is undefined behavior.
      */
-    constexpr reference       front()       noexcept { return _data.front(); }
+    constexpr reference front() noexcept { return _data.front(); }
 
     /**
      * @brief Returns a const reference to the first element in the matrix (row-major order).
@@ -355,14 +352,14 @@ public: // element access
      *
      * Calling @c back() on an empty matrix is undefined behavior.
      */
-    constexpr reference       back()        noexcept { return _data.back(); }
+    constexpr reference back() noexcept { return _data.back(); }
 
     /**
      * @brief Returns a const reference to the last element in the matrix (row-major order).
      *
      * Calling @c back() on an empty matrix is undefined behavior.
      */
-    constexpr const_reference back()  const noexcept { return _data.back(); }
+    constexpr const_reference back() const noexcept { return _data.back(); }
 
 public: // element access
     /**
@@ -372,10 +369,11 @@ public: // element access
      * No bounds checking is performed; if @c coordinates are outside od
      * the matrix dimensions, the behavior is undefined.
      */
-    template<class... Coords>
+    template <class... Coords>
         requires integral_coordinates<Coords...>
-    T const& operator()(Coords... coordinates) const
-    { return _data[_details::coordinates_to_index(dimensions, std::array{coordinates...})]; }
+    T const& operator()(Coords... coordinates) const {
+        return _data[_details::coordinates_to_index(dimensions, std::array{coordinates...})];
+    }
 
     /**
      * @brief Returns a reference to the element at coordinates.
@@ -384,10 +382,11 @@ public: // element access
      * No bounds checking is performed; if @c coordinates are outside od
      * the matrix dimensions, the behavior is undefined.
      */
-    template<class... Coords>
+    template <class... Coords>
         requires integral_coordinates<Coords...>
-    T& operator()(Coords... coordinates)
-    { return _data[_details::coordinates_to_index(dimensions, std::array{coordinates...})]; }
+    T& operator()(Coords... coordinates) {
+        return _data[_details::coordinates_to_index(dimensions, std::array{coordinates...})];
+    }
 
     /**
      * @brief Returns a reference to the element at coordinates.
@@ -396,12 +395,11 @@ public: // element access
      * If @a coordinates is not within the range of the container, an exception of type
      * @c std::out_of_range is thrown.
      */
-    template<class... Coords>
+    template <class... Coords>
         requires integral_coordinates<Coords...>
-    const T& at(Coords... coordinates) const
-    {
-        const bool any_of_coords_is_negative = ( (coordinates < 0) || ... );
-        const bool any_of_coords_is_out_of_bound = ( (coordinates >= Dimensions) || ... );
+    const T& at(Coords... coordinates) const {
+        const bool any_of_coords_is_negative = ((coordinates < 0) || ...);
+        const bool any_of_coords_is_out_of_bound = ((coordinates >= Dimensions) || ...);
         if (any_of_coords_is_negative == true || any_of_coords_is_out_of_bound == true) {
             throw std::out_of_range{"matrix::at"};
         }
@@ -415,12 +413,11 @@ public: // element access
      * If @a coordinates is not within the range of the container, an exception of type
      * @c std::out_of_range is thrown.
      */
-    template<class... Coords>
+    template <class... Coords>
         requires integral_coordinates<Coords...>
-    T& at(Coords... coordinates)
-    {
-        const bool any_of_coords_is_negative = ( (coordinates < 0) || ... );
-        const bool any_of_coords_is_out_of_bound = ( (coordinates >= Dimensions) || ... );
+    T& at(Coords... coordinates) {
+        const bool any_of_coords_is_negative = ((coordinates < 0) || ...);
+        const bool any_of_coords_is_out_of_bound = ((coordinates >= Dimensions) || ...);
         if (any_of_coords_is_negative == true || any_of_coords_is_out_of_bound == true) {
             throw std::out_of_range{"matrix::at"};
         }

--- a/test/include/utils.hpp
+++ b/test/include/utils.hpp
@@ -1,61 +1,52 @@
 #ifndef YSC_MATRIX_TEST_INCLUDE_UTILS_HPP
 #define YSC_MATRIX_TEST_INCLUDE_UTILS_HPP
 
-#include <type_traits>
 #include <cstddef>
 #include <memory>
+#include <type_traits>
 
-namespace ysc::test
-{
+namespace ysc::test {
 
-template<class Ret = void, class ... Args>
-class SideEffect
-{
+template <class Ret = void, class... Args> class SideEffect {
     bool invoked = false;
 
 public:
-    template<class R = Ret, std::enable_if_t<!std::is_same_v<void, R>, int> = 0>
-    R trigger(R&& ret, Args&&...)
-    {
+    template <class R = Ret, std::enable_if_t<!std::is_same_v<void, R>, int> = 0>
+    R trigger(R&& ret, Args&&...) {
         invoked = true;
         return std::forward<R>(ret);
     }
 
-    template<class R = Ret, std::enable_if_t<std::is_same_v<void, R>, int> = 0>
-    void trigger(Args&&...)
-    {
+    template <class R = Ret, std::enable_if_t<std::is_same_v<void, R>, int> = 0>
+    void trigger(Args&&...) {
         invoked = true;
     }
 
-    bool triggered() const
-    { return true == invoked; }
+    bool triggered() const { return true == invoked; }
 };
 
-static auto non_zero_memory(std::size_t size)
-{
+static auto non_zero_memory(std::size_t size) {
     constexpr std::byte non_zero = static_cast<std::byte>(0xC5);
 
     auto memory = std::make_unique<std::byte[]>(size);
-    std::fill(memory.get(), memory.get()+size, non_zero);
+    std::fill(memory.get(), memory.get() + size, non_zero);
     return memory;
 }
 
-template <class T, class... Args>
-static auto on_non_zero_memory(Args&& ...args)
-{
+template <class T, class... Args> static auto on_non_zero_memory(Args&&... args) {
     auto memory = non_zero_memory(sizeof(T));
     T* const naked_object = ([&]() {
         if constexpr (0 == sizeof...(Args)) {
             return new (memory.get()) T;
         } else {
-            return new (memory.get()) T {std::forward<Args>(args)...};
+            return new (memory.get()) T{std::forward<Args>(args)...};
         }
     })();
     memory.release();
 
     return std::shared_ptr<T>(naked_object, [](T* ptr) {
         ptr->~T();
-        ::operator delete[] (reinterpret_cast<void*>(ptr));
+        ::operator delete[](reinterpret_cast<void*>(ptr));
     });
 }
 

--- a/test/include/utils.hpp
+++ b/test/include/utils.hpp
@@ -1,6 +1,7 @@
 #ifndef YSC_MATRIX_TEST_INCLUDE_UTILS_HPP
 #define YSC_MATRIX_TEST_INCLUDE_UTILS_HPP
 
+#include <algorithm>
 #include <cstddef>
 #include <memory>
 #include <type_traits>

--- a/test/src/access.cpp
+++ b/test/src/access.cpp
@@ -1,92 +1,87 @@
-#include <matrix.hpp>
 #include "utils.hpp"
+#include <matrix.hpp>
 
 #include <gtest/gtest.h>
-
 
 //
 // --- ELEMENT ACCESS ---
 //
 
 // Access element of a constant matrix, no bound checking (access within bounds)
-TEST(access, const_no_check_nominal)
-{
+TEST(access, const_no_check_nominal) {
     ysc::matrix<int, 2, 2> const m{0, 1, 2, 3};
-    ASSERT_EQ(m(0,0), 0);
-    ASSERT_EQ(m(0,1), 1);
-    ASSERT_EQ(m(1,0), 2);
-    ASSERT_EQ(m(1,1), 3);
+    ASSERT_EQ(m(0, 0), 0);
+    ASSERT_EQ(m(0, 1), 1);
+    ASSERT_EQ(m(1, 0), 2);
+    ASSERT_EQ(m(1, 1), 3);
 }
 
 // Access element of a constant matrix, no bound checking (access out of bounds)
-TEST(access, const_no_check_outofbound)
-{
+TEST(access, const_no_check_outofbound) {
 #if defined(_ITERATOR_DEBUG_LEVEL) && _ITERATOR_DEBUG_LEVEL > 0
     GTEST_SKIP() << "MSVC debug iterator checks intercept UB access before operator() returns";
 #endif
 #if defined(YSC_SANITIZERS_ENABLED) || defined(_GLIBCXX_ASSERTIONS)
-    GTEST_SKIP() << "Runtime hardening (sanitizers or libstdc++ assertions) intercepts the intentional out-of-bounds UB in operator()";
+    GTEST_SKIP() << "Runtime hardening (sanitizers or libstdc++ assertions) intercepts the "
+                    "intentional out-of-bounds UB in operator()";
 #endif
     ysc::matrix<int, 2, 2> const m{0, 1, 2, 3};
     try {
-        (void) m(-1, -1);
+        (void)m(-1, -1);
     } catch (...) {
         ASSERT_TRUE(false);
     }
 }
 
 // Access element of a mutable matrix, no bound checking (access within bounds)
-TEST(access, mutable_no_check_nominal)
-{
+TEST(access, mutable_no_check_nominal) {
     ysc::matrix<int, 2, 2> m{0, 1, 2, 3};
 
-    m(0,0) = 10;
-    m(0,1) = 11;
-    m(1,0) = 12;
-    m(1,1) = 13;
+    m(0, 0) = 10;
+    m(0, 1) = 11;
+    m(1, 0) = 12;
+    m(1, 1) = 13;
 
-    ASSERT_EQ(m(0,0), 10);
-    ASSERT_EQ(m(0,1), 11);
-    ASSERT_EQ(m(1,0), 12);
-    ASSERT_EQ(m(1,1), 13);
+    ASSERT_EQ(m(0, 0), 10);
+    ASSERT_EQ(m(0, 1), 11);
+    ASSERT_EQ(m(1, 0), 12);
+    ASSERT_EQ(m(1, 1), 13);
 }
 
 // Access element of a mutable matrix, no bound checking (access out of bounds)
-TEST(access, mutable_no_check_outofbound)
-{
+TEST(access, mutable_no_check_outofbound) {
 #if defined(_ITERATOR_DEBUG_LEVEL) && _ITERATOR_DEBUG_LEVEL > 0
     GTEST_SKIP() << "MSVC debug iterator checks intercept UB access before operator() returns";
 #endif
 #if defined(YSC_SANITIZERS_ENABLED) || defined(_GLIBCXX_ASSERTIONS)
-    GTEST_SKIP() << "Runtime hardening (sanitizers or libstdc++ assertions) intercepts the intentional out-of-bounds UB in operator()";
+    GTEST_SKIP() << "Runtime hardening (sanitizers or libstdc++ assertions) intercepts the "
+                    "intentional out-of-bounds UB in operator()";
 #endif
     ysc::matrix<int, 2, 2> m{0, 1, 2, 3};
     try {
-        (void) m(-1, -1);
+        (void)m(-1, -1);
     } catch (...) {
         ASSERT_TRUE(false);
     }
 }
 
 // Access element of a constant matrix, with bound checking (access within bounds)
-TEST(access, const_with_check_nominal)
-{
+TEST(access, const_with_check_nominal) {
     ysc::matrix<int, 2, 2> const m{0, 1, 2, 3};
-    ASSERT_EQ(m.at(0,0), 0);
-    ASSERT_EQ(m.at(0,1), 1);
-    ASSERT_EQ(m.at(1,0), 2);
-    ASSERT_EQ(m.at(1,1), 3);
+    ASSERT_EQ(m.at(0, 0), 0);
+    ASSERT_EQ(m.at(0, 1), 1);
+    ASSERT_EQ(m.at(1, 0), 2);
+    ASSERT_EQ(m.at(1, 1), 3);
 }
 
 // Access element of a constant matrix, with bound checking (access out of bounds)
-TEST(access, const_with_check_outofbound)
-{
+TEST(access, const_with_check_outofbound) {
     ysc::matrix<int, 2, 2> const m{0, 1, 2, 3};
 
     {
         bool out_of_range_exception_catch = false;
         try {
-            (void) m.at(-1, 0);
+            (void)m.at(-1, 0);
         } catch (std::out_of_range&) {
             out_of_range_exception_catch = true;
         }
@@ -95,7 +90,7 @@ TEST(access, const_with_check_outofbound)
     {
         bool out_of_range_exception_catch = false;
         try {
-            (void) m.at(2, 0);
+            (void)m.at(2, 0);
         } catch (std::out_of_range&) {
             out_of_range_exception_catch = true;
         }
@@ -104,30 +99,28 @@ TEST(access, const_with_check_outofbound)
 }
 
 // Access element of a mutable matrix, with bound checking (access within bounds)
-TEST(access, mutable_with_check_nominal)
-{
+TEST(access, mutable_with_check_nominal) {
     ysc::matrix<int, 2, 2> m{0, 1, 2, 3};
 
-    m.at(0,0) = 10;
-    m.at(0,1) = 11;
-    m.at(1,0) = 12;
-    m.at(1,1) = 13;
+    m.at(0, 0) = 10;
+    m.at(0, 1) = 11;
+    m.at(1, 0) = 12;
+    m.at(1, 1) = 13;
 
-    ASSERT_EQ(m.at(0,0), 10);
-    ASSERT_EQ(m.at(0,1), 11);
-    ASSERT_EQ(m.at(1,0), 12);
-    ASSERT_EQ(m.at(1,1), 13);
+    ASSERT_EQ(m.at(0, 0), 10);
+    ASSERT_EQ(m.at(0, 1), 11);
+    ASSERT_EQ(m.at(1, 0), 12);
+    ASSERT_EQ(m.at(1, 1), 13);
 }
 
 // Access element of a mutable matrix, with bound checking (access out of bounds)
-TEST(access, mutable_with_check_outofbound)
-{
+TEST(access, mutable_with_check_outofbound) {
     ysc::matrix<int, 2, 2> m{0, 1, 2, 3};
 
     {
         bool out_of_range_exception_catch = false;
         try {
-            (void) m.at(-1, 0);
+            (void)m.at(-1, 0);
         } catch (std::out_of_range&) {
             out_of_range_exception_catch = true;
         }
@@ -136,11 +129,10 @@ TEST(access, mutable_with_check_outofbound)
     {
         bool out_of_range_exception_catch = false;
         try {
-            (void) m.at(0, 2);
+            (void)m.at(0, 2);
         } catch (std::out_of_range&) {
             out_of_range_exception_catch = true;
         }
         ASSERT_TRUE(out_of_range_exception_catch);
     }
 }
-

--- a/test/src/accessors.cpp
+++ b/test/src/accessors.cpp
@@ -2,83 +2,70 @@
 
 #include <gtest/gtest.h>
 
-
 //
 // --- front() ---
 //
 
-TEST(accessors_front, returns_first_element)
-{
+TEST(accessors_front, returns_first_element) {
     ysc::matrix<int, 3> m{10, 20, 30};
     ASSERT_EQ(m.front(), 10);
 }
 
-TEST(accessors_front, const_returns_first_element)
-{
+TEST(accessors_front, const_returns_first_element) {
     const ysc::matrix<int, 3> m{10, 20, 30};
     ASSERT_EQ(m.front(), 10);
 }
 
-TEST(accessors_front, reference_allows_mutation)
-{
+TEST(accessors_front, reference_allows_mutation) {
     ysc::matrix<int, 3> m{10, 20, 30};
     m.front() = 99;
     ASSERT_EQ(m(0), 99);
 }
 
-TEST(accessors_front, noexcept_guaranteed)
-{
+TEST(accessors_front, noexcept_guaranteed) {
     ysc::matrix<int, 3> m{1, 2, 3};
     static_assert(noexcept(m.front()));
     const ysc::matrix<int, 3> cm{1, 2, 3};
     static_assert(noexcept(cm.front()));
 }
 
-
 //
 // --- back() ---
 //
 
-TEST(accessors_back, returns_last_element)
-{
+TEST(accessors_back, returns_last_element) {
     ysc::matrix<int, 3> m{10, 20, 30};
     ASSERT_EQ(m.back(), 30);
 }
 
-TEST(accessors_back, const_returns_last_element)
-{
+TEST(accessors_back, const_returns_last_element) {
     const ysc::matrix<int, 3> m{10, 20, 30};
     ASSERT_EQ(m.back(), 30);
 }
 
-TEST(accessors_back, reference_allows_mutation)
-{
+TEST(accessors_back, reference_allows_mutation) {
     ysc::matrix<int, 3> m{10, 20, 30};
     m.back() = 99;
     ASSERT_EQ(m(2), 99);
 }
 
-TEST(accessors_back, noexcept_guaranteed)
-{
+TEST(accessors_back, noexcept_guaranteed) {
     ysc::matrix<int, 3> m{1, 2, 3};
     static_assert(noexcept(m.back()));
     const ysc::matrix<int, 3> cm{1, 2, 3};
     static_assert(noexcept(cm.back()));
 }
 
-TEST(accessors_back, 2d_last_element_is_row_major_last)
-{
+TEST(accessors_back, 2d_last_element_is_row_major_last) {
     ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
     ASSERT_EQ(m.back(), 6);
 }
-
 
 //
 // --- swap() membre ---
 //
 
-TEST(accessors_swap_member, exchanges_contents)
-{
+TEST(accessors_swap_member, exchanges_contents) {
     ysc::matrix<int, 3> a{1, 2, 3};
     ysc::matrix<int, 3> b{4, 5, 6};
     a.swap(b);
@@ -90,8 +77,7 @@ TEST(accessors_swap_member, exchanges_contents)
     ASSERT_EQ(b(2), 3);
 }
 
-TEST(accessors_swap_member, self_swap_is_stable)
-{
+TEST(accessors_swap_member, self_swap_is_stable) {
     ysc::matrix<int, 3> m{1, 2, 3};
     m.swap(m);
     ASSERT_EQ(m(0), 1);
@@ -99,20 +85,17 @@ TEST(accessors_swap_member, self_swap_is_stable)
     ASSERT_EQ(m(2), 3);
 }
 
-TEST(accessors_swap_member, noexcept_for_nothrow_swappable)
-{
+TEST(accessors_swap_member, noexcept_for_nothrow_swappable) {
     static_assert(std::is_nothrow_swappable_v<int>);
     ysc::matrix<int, 3> a, b;
     static_assert(noexcept(a.swap(b)));
 }
 
-
 //
 // --- swap() friend (ADL) ---
 //
 
-TEST(accessors_swap_free, exchanges_contents)
-{
+TEST(accessors_swap_free, exchanges_contents) {
     ysc::matrix<int, 2, 2> a{1, 2, 3, 4};
     ysc::matrix<int, 2, 2> b{5, 6, 7, 8};
     using std::swap;

--- a/test/src/assignment_returns_self.cpp
+++ b/test/src/assignment_returns_self.cpp
@@ -2,10 +2,8 @@
 
 #include <gtest/gtest.h>
 
-
 // Verify copy-assign from different type returns *this
-TEST(assign_returns_self, copy_different_type)
-{
+TEST(assign_returns_self, copy_different_type) {
     ysc::matrix<int, 3> m1 = {1, 2, 3};
     ysc::matrix<long, 3> m2;
     auto& ref = (m2 = m1);
@@ -13,8 +11,7 @@ TEST(assign_returns_self, copy_different_type)
 }
 
 // Verify move-assign from different type returns *this
-TEST(assign_returns_self, move_different_type)
-{
+TEST(assign_returns_self, move_different_type) {
     ysc::matrix<int, 3> m1 = {1, 2, 3};
     ysc::matrix<long, 3> m2;
     auto& ref = (m2 = std::move(m1));
@@ -22,8 +19,7 @@ TEST(assign_returns_self, move_different_type)
 }
 
 // Verify copy-assign is chainable
-TEST(assign_returns_self, chain_copy)
-{
+TEST(assign_returns_self, chain_copy) {
     ysc::matrix<int, 3> src = {1, 2, 3};
     ysc::matrix<long, 3> a, b;
     b = a = src;

--- a/test/src/comparison.cpp
+++ b/test/src/comparison.cpp
@@ -4,41 +4,35 @@
 
 #include <compare>
 
-
 //
 // --- EQUALITY ---
 //
 
-TEST(comparison, equal_same_values)
-{
+TEST(comparison, equal_same_values) {
     ysc::matrix<int, 2, 3> m1{1, 2, 3, 4, 5, 6};
     ysc::matrix<int, 2, 3> m2{1, 2, 3, 4, 5, 6};
     ASSERT_TRUE(m1 == m2);
     ASSERT_FALSE(m1 != m2);
 }
 
-TEST(comparison, equal_different_values)
-{
+TEST(comparison, equal_different_values) {
     ysc::matrix<int, 2, 3> m1{1, 2, 3, 4, 5, 6};
     ysc::matrix<int, 2, 3> m2{1, 2, 3, 4, 5, 7};
     ASSERT_FALSE(m1 == m2);
     ASSERT_TRUE(m1 != m2);
 }
 
-TEST(comparison, equal_self)
-{
+TEST(comparison, equal_self) {
     ysc::matrix<int, 3> m{10, 20, 30};
     ASSERT_TRUE(m == m);
     ASSERT_FALSE(m != m);
 }
 
-
 //
 // --- THREE-WAY (lexicographic) ---
 //
 
-TEST(comparison, less_than)
-{
+TEST(comparison, less_than) {
     ysc::matrix<int, 3> m1{1, 2, 3};
     ysc::matrix<int, 3> m2{1, 2, 4};
     ASSERT_TRUE(m1 < m2);
@@ -47,8 +41,7 @@ TEST(comparison, less_than)
     ASSERT_FALSE(m1 >= m2);
 }
 
-TEST(comparison, greater_than)
-{
+TEST(comparison, greater_than) {
     ysc::matrix<int, 3> m1{1, 3, 0};
     ysc::matrix<int, 3> m2{1, 2, 9};
     ASSERT_TRUE(m1 > m2);
@@ -57,27 +50,23 @@ TEST(comparison, greater_than)
     ASSERT_FALSE(m1 <= m2);
 }
 
-TEST(comparison, lexicographic_first_element_wins)
-{
+TEST(comparison, lexicographic_first_element_wins) {
     ysc::matrix<int, 3> lo{0, 99, 99};
     ysc::matrix<int, 3> hi{1, 0, 0};
     ASSERT_TRUE(lo < hi);
 }
 
-TEST(comparison, ordering_equal)
-{
+TEST(comparison, ordering_equal) {
     ysc::matrix<int, 2> m{5, 5};
     ASSERT_TRUE(m >= m);
     ASSERT_TRUE(m <= m);
 }
 
-
 //
 // --- STATIC ASSERTIONS ---
 //
 
-TEST(comparison, three_way_comparable_concept)
-{
+TEST(comparison, three_way_comparable_concept) {
     static_assert(std::three_way_comparable<ysc::matrix<int, 3>>);
     static_assert(std::three_way_comparable<ysc::matrix<double, 2, 2>>);
 }

--- a/test/src/concepts.cpp
+++ b/test/src/concepts.cpp
@@ -1,10 +1,10 @@
-#include <gtest/gtest.h>
 #include "matrix.hpp"
+#include <gtest/gtest.h>
 #include <string>
 
 // Helper concept to test at() callability (GCC 15 does not support bare requires
 // expressions in static_assert when all overload candidates are constrained out)
-template<class M, class... Args>
+template <class M, class... Args>
 concept at_callable = requires(M& m, Args... args) { m.at(args...); };
 
 // integral_coordinates
@@ -23,27 +23,25 @@ static_assert(!ysc::matrix_convertible_from<int, std::string>);
 static_assert(!ysc::matrix_convertible_from<std::string, int>);
 
 // operator() accepts integral coordinates, rejects floating-point
-static_assert( std::is_invocable_v<ysc::matrix<int, 2, 3>&, int, int>);
+static_assert(std::is_invocable_v<ysc::matrix<int, 2, 3>&, int, int>);
 static_assert(!std::is_invocable_v<ysc::matrix<int, 2, 3>&, double, double>);
 static_assert(!std::is_invocable_v<ysc::matrix<int, 2, 3>&, float, float>);
 
 // at() accepts integral coordinates, rejects floating-point
-static_assert( at_callable<ysc::matrix<int, 2, 3>, int, int>);
+static_assert(at_callable<ysc::matrix<int, 2, 3>, int, int>);
 static_assert(!at_callable<ysc::matrix<int, 2, 3>, double, double>);
 static_assert(!at_callable<ysc::matrix<int, 2, 3>, float, float>);
 
 // Converting constructor is constrained (positive case)
 static_assert(std::is_constructible_v<ysc::matrix<double, 3>, ysc::matrix<int, 3> const&>);
 
-TEST(concepts, operator_call_integral_coords)
-{
+TEST(concepts, operator_call_integral_coords) {
     ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
     EXPECT_EQ(m(0, 0), 1);
     EXPECT_EQ(m(1, 2), 6);
 }
 
-TEST(concepts, converting_ctor_constrained)
-{
+TEST(concepts, converting_ctor_constrained) {
     // const source: the more-specialized converting ctor wins over the variadic ctor
     const ysc::matrix<int, 3> mi{1, 2, 3};
     ysc::matrix<double, 3> md(mi);
@@ -52,8 +50,7 @@ TEST(concepts, converting_ctor_constrained)
     EXPECT_DOUBLE_EQ(md(2), 3.0);
 }
 
-TEST(concepts, converting_assign_constrained)
-{
+TEST(concepts, converting_assign_constrained) {
     const ysc::matrix<int, 3> mi{4, 5, 6};
     ysc::matrix<double, 3> md;
     md = mi;

--- a/test/src/construct.cpp
+++ b/test/src/construct.cpp
@@ -1,19 +1,17 @@
-#include <matrix.hpp>
 #include "utils.hpp"
+#include <matrix.hpp>
 
 #include <gtest/gtest.h>
 
-#include <string>
 #include <memory>
-
+#include <string>
 
 //
 // --- DEFAULT CONSTRUCTORS ---
 //
 
 // Expect matrix elements to be default-initialized (uninitialized) for trivial types
-TEST(construct_default, default_trivial_type)
-{
+TEST(construct_default, default_trivial_type) {
     /*
      * Since reading uninitialized memory is UB, we can not rely solely on
      * reading the value of a matrix<unsigned> element after default-init.
@@ -23,31 +21,29 @@ TEST(construct_default, default_trivial_type)
 }
 
 // Expect matrix elements to be default-initialized for user-defined types
-TEST(construct_default, default_user_defined_type)
-{
-    struct user_defined : ysc::test::SideEffect<>
-    { user_defined() { trigger(); } };
+TEST(construct_default, default_user_defined_type) {
+    struct user_defined : ysc::test::SideEffect<> {
+        user_defined() { trigger(); }
+    };
     ysc::matrix<user_defined, 1> const m;
     ASSERT_TRUE(m(0).triggered());
 }
 
 // Expect matrix elements to be default-initialized for array types
-TEST(construct_default, default_array_type)
-{
-    struct user_defined : ysc::test::SideEffect<>
-    { user_defined() { trigger(); } };
+TEST(construct_default, default_array_type) {
+    struct user_defined : ysc::test::SideEffect<> {
+        user_defined() { trigger(); }
+    };
     ysc::matrix<user_defined[1], 1> const m;
     ASSERT_TRUE(m(0)[0].triggered());
 }
-
 
 //
 // --- AGGREGATE CONSTRUCTORS ---
 //
 
 // Expect matrix elements to be zero-initialized for trivial types on demand
-TEST(construct_init, zero_trivial_type)
-{
+TEST(construct_init, zero_trivial_type) {
     /*
      * Since reading uninitialized memory is UB, we can not rely solely on
      * reading the value of a matrix<unsigned> element after default-init.
@@ -57,50 +53,44 @@ TEST(construct_init, zero_trivial_type)
 }
 
 // Expect matrix elements to be aggregate-initializable (trival types)
-TEST(construct_init, aggregate_trivial_types)
-{
-    ysc::matrix<int, 3> const m = { 1987, 04, 24 };
+TEST(construct_init, aggregate_trivial_types) {
+    ysc::matrix<int, 3> const m = {1987, 04, 24};
     ASSERT_EQ(m(0), 1987);
     ASSERT_EQ(m(1), 04);
     ASSERT_EQ(m(2), 24);
 }
 
 // Expect matrix elements to be aggregate-initializable (trival types, multi-dim)
-TEST(construct_init, aggregate_trivial_types_multidim)
-{
-    ysc::matrix<int, 2, 2, 2> const m = { 1, 2, 3, 4, 5, 6, 7, 8 };
-    ASSERT_EQ(m(0,0,0), 1);
-    ASSERT_EQ(m(0,0,1), 2);
-    ASSERT_EQ(m(1,1,1), 8);
+TEST(construct_init, aggregate_trivial_types_multidim) {
+    ysc::matrix<int, 2, 2, 2> const m = {1, 2, 3, 4, 5, 6, 7, 8};
+    ASSERT_EQ(m(0, 0, 0), 1);
+    ASSERT_EQ(m(0, 0, 1), 2);
+    ASSERT_EQ(m(1, 1, 1), 8);
 }
 
 // Expect matrix elements to be aggregate-initializable (user-defined types)
-TEST(construct_init, aggregate_user_defined_types)
-{
-    ysc::matrix<std::string, 3> const m = { "1987", "04", "24" };
+TEST(construct_init, aggregate_user_defined_types) {
+    ysc::matrix<std::string, 3> const m = {"1987", "04", "24"};
     ASSERT_EQ(m(0), "1987");
     ASSERT_EQ(m(1), "04");
     ASSERT_EQ(m(2), "24");
 }
 
 // Expect matrix elements to be aggregate-initializable from mixed source types
-TEST(construct_init, aggregate_mixed_types)
-{
-    ysc::matrix<long long, 3> const m = { 1987, '\x04', 24L };
+TEST(construct_init, aggregate_mixed_types) {
+    ysc::matrix<long long, 3> const m = {1987, '\x04', 24L};
     ASSERT_EQ(m(0), 1987);
     ASSERT_EQ(m(1), 04);
     ASSERT_EQ(m(2), 24);
 }
-
 
 //
 // --- COPY CONSTRUCTORS ---
 //
 
 // Expect matrixes to be copyable for trivial types
-TEST(construct_copy, trivial_type)
-{
-    ysc::matrix<int, 3> const m = { 1987, 04, 24 };
+TEST(construct_copy, trivial_type) {
+    ysc::matrix<int, 3> const m = {1987, 04, 24};
     auto const m_copy = m;
     ASSERT_EQ(m_copy(0), 1987);
     ASSERT_EQ(m_copy(1), 04);
@@ -108,9 +98,8 @@ TEST(construct_copy, trivial_type)
 }
 
 // Expect matrixes to be copyable for trivial types from a different source type
-TEST(construct_copy, different_trivial_type)
-{
-    ysc::matrix<int, 3> const m = { 1987, 04, 24 };
+TEST(construct_copy, different_trivial_type) {
+    ysc::matrix<int, 3> const m = {1987, 04, 24};
     ysc::matrix<long, 3> const m_copy = m;
     ASSERT_EQ(m_copy(0), 1987);
     ASSERT_EQ(m_copy(1), 04);
@@ -118,24 +107,21 @@ TEST(construct_copy, different_trivial_type)
 }
 
 // Expect matrixes to be copyable for user-defined types
-TEST(construct_copy, user_defined_type)
-{
-    ysc::matrix<std::string, 3> const m = { "1987", "04", "24" };
+TEST(construct_copy, user_defined_type) {
+    ysc::matrix<std::string, 3> const m = {"1987", "04", "24"};
     auto const m_copy = m;
     ASSERT_EQ(m_copy(0), "1987");
     ASSERT_EQ(m_copy(1), "04");
     ASSERT_EQ(m_copy(2), "24");
 }
 
-
 //
 // --- MOVE CONSTRUCTORS ---
 //
 
 // Expect matrixes to be movable for trivial types
-TEST(construct_move, trivial_type)
-{
-    ysc::matrix<int, 3> m = { 1987, 04, 24 };
+TEST(construct_move, trivial_type) {
+    ysc::matrix<int, 3> m = {1987, 04, 24};
     auto const m_copy = std::move(m);
     ASSERT_EQ(m_copy(0), 1987);
     ASSERT_EQ(m_copy(1), 04);
@@ -143,9 +129,8 @@ TEST(construct_move, trivial_type)
 }
 
 // Expect matrixes to be movable for trivial types from a different source type
-TEST(construct_move, different_trivial_type)
-{
-    ysc::matrix<int, 3> m = { 1987, 04, 24 };
+TEST(construct_move, different_trivial_type) {
+    ysc::matrix<int, 3> m = {1987, 04, 24};
     ysc::matrix<long, 3> const m_copy = std::move(m);
     ASSERT_EQ(m_copy(0), 1987);
     ASSERT_EQ(m_copy(1), 04);
@@ -153,23 +138,20 @@ TEST(construct_move, different_trivial_type)
 }
 
 // Expect matrixes to be movable for user-defined types
-TEST(construct_move, user_defined_type)
-{
-    ysc::matrix<std::shared_ptr<int>, 1> m = { std::make_shared<int>(0) };
+TEST(construct_move, user_defined_type) {
+    ysc::matrix<std::shared_ptr<int>, 1> m = {std::make_shared<int>(0)};
     auto const m_copy = std::move(m);
     ASSERT_EQ(*m_copy(0), 0);
     ASSERT_FALSE(static_cast<bool>(m(0)));
 }
-
 
 //
 // --- ASSIGNMENT OPERATORS ---
 //
 
 // Expect matrixes to be assignable for trivial types
-TEST(assign_copy, trivial_type)
-{
-    ysc::matrix<int, 3> const m = { 1987, 04, 24 };
+TEST(assign_copy, trivial_type) {
+    ysc::matrix<int, 3> const m = {1987, 04, 24};
     ysc::matrix<int, 3> m_assign;
     m_assign = m;
     ASSERT_EQ(m_assign(0), 1987);
@@ -178,9 +160,8 @@ TEST(assign_copy, trivial_type)
 }
 
 // Expect matrixes to be assignable for trivial types from a different source type
-TEST(assign_copy, different_trivial_type)
-{
-    ysc::matrix<int, 3> const m = { 1987, 04, 24 };
+TEST(assign_copy, different_trivial_type) {
+    ysc::matrix<int, 3> const m = {1987, 04, 24};
     ysc::matrix<long, 3> m_assign;
     m_assign = m;
     ASSERT_EQ(m_assign(0), 1987);
@@ -189,9 +170,8 @@ TEST(assign_copy, different_trivial_type)
 }
 
 // Expect matrixes to be assignable for user-defined types
-TEST(assign_copy, user_defined_type)
-{
-    ysc::matrix<std::string, 3> const m = { "1987", "04", "24" };
+TEST(assign_copy, user_defined_type) {
+    ysc::matrix<std::string, 3> const m = {"1987", "04", "24"};
     ysc::matrix<std::string, 3> m_assign;
     m_assign = m;
     ASSERT_EQ(m_assign(0), "1987");
@@ -200,9 +180,8 @@ TEST(assign_copy, user_defined_type)
 }
 
 // Expect matrixes to be assignable (move) for trivial types
-TEST(assign_move, trivial_type)
-{
-    ysc::matrix<int, 3> m = { 1987, 04, 24 };
+TEST(assign_move, trivial_type) {
+    ysc::matrix<int, 3> m = {1987, 04, 24};
     ysc::matrix<int, 3> m_assign;
     m_assign = std::move(m);
     ASSERT_EQ(m_assign(0), 1987);
@@ -211,9 +190,8 @@ TEST(assign_move, trivial_type)
 }
 
 // Expect matrixes to be assignable (move) for trivial types from a different source type
-TEST(assign_move, different_trivial_type)
-{
-    ysc::matrix<int, 3> m = { 1987, 04, 24 };
+TEST(assign_move, different_trivial_type) {
+    ysc::matrix<int, 3> m = {1987, 04, 24};
     ysc::matrix<long, 3> m_assign;
     m_assign = std::move(m);
     ASSERT_EQ(m_assign(0), 1987);
@@ -222,9 +200,8 @@ TEST(assign_move, different_trivial_type)
 }
 
 // Expect matrixes to be assignable (move) for user-defined types
-TEST(assign_move, user_defined_type)
-{
-    ysc::matrix<std::string, 3> m = { "1987", "04", "24" };
+TEST(assign_move, user_defined_type) {
+    ysc::matrix<std::string, 3> m = {"1987", "04", "24"};
     ysc::matrix<std::string, 3> m_assign;
     m_assign = std::move(m);
     ASSERT_EQ(m_assign(0), "1987");
@@ -232,24 +209,22 @@ TEST(assign_move, user_defined_type)
     ASSERT_EQ(m_assign(2), "24");
 }
 
-
 //
 // --- DESTRUCTOR ---
 //
 
 // Expect matrix elements to be destructed
-TEST(destruct, user_defined_type)
-{
+TEST(destruct, user_defined_type) {
     bool trigger = false;
     struct S {
         S(bool& flag) : _flag(flag) {}
-        ~S() { _flag = true; }         // upon destruction: sets trigger to true
+        ~S() { _flag = true; } // upon destruction: sets trigger to true
         bool& _flag;
     };
 
     {
         // trigger is false
-        ysc::matrix<S, 1> const m = { trigger };
-    }   // trigger should be toggled as m is destructed
+        ysc::matrix<S, 1> const m = {trigger};
+    } // trigger should be toggled as m is destructed
     ASSERT_TRUE(trigger);
 }

--- a/test/src/fill.cpp
+++ b/test/src/fill.cpp
@@ -4,13 +4,11 @@
 
 #include <type_traits>
 
-
 //
 // --- TRIVIAL TYPE ---
 //
 
-TEST(fill, trivial_type_all_elements_set)
-{
+TEST(fill, trivial_type_all_elements_set) {
     ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
     m.fill(42);
     for (auto v : m) {
@@ -18,8 +16,7 @@ TEST(fill, trivial_type_all_elements_set)
     }
 }
 
-TEST(fill, trivial_type_overwrite_zeros)
-{
+TEST(fill, trivial_type_overwrite_zeros) {
     ysc::matrix<int, 4> m{0, 0, 0, 0};
     m.fill(-1);
     for (auto v : m) {
@@ -27,15 +24,13 @@ TEST(fill, trivial_type_overwrite_zeros)
     }
 }
 
-TEST(fill, trivial_type_fill_zero)
-{
+TEST(fill, trivial_type_fill_zero) {
     ysc::matrix<double, 3, 3> m{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0};
     m.fill(0.0);
     for (auto v : m) {
         ASSERT_DOUBLE_EQ(v, 0.0);
     }
 }
-
 
 //
 // --- USER-DEFINED TYPE ---
@@ -46,8 +41,7 @@ struct Point {
     bool operator==(const Point&) const = default;
 };
 
-TEST(fill, user_defined_type)
-{
+TEST(fill, user_defined_type) {
     ysc::matrix<Point, 3> m{Point{1, 2}, Point{3, 4}, Point{5, 6}};
     m.fill(Point{0, 0});
     for (auto v : m) {
@@ -55,13 +49,11 @@ TEST(fill, user_defined_type)
     }
 }
 
-
 //
 // --- MATRIX OF MATRIX ---
 //
 
-TEST(fill, matrix_of_matrix)
-{
+TEST(fill, matrix_of_matrix) {
     using Inner = ysc::matrix<int, 2>;
     ysc::matrix<Inner, 3> m;
     const Inner pattern{7, 7};
@@ -71,13 +63,11 @@ TEST(fill, matrix_of_matrix)
     }
 }
 
-
 //
 // --- NOEXCEPT ---
 //
 
-TEST(fill, noexcept_for_nothrow_copy_assignable)
-{
+TEST(fill, noexcept_for_nothrow_copy_assignable) {
     static_assert(std::is_nothrow_copy_assignable_v<int>);
     ysc::matrix<int, 3> m;
     static_assert(noexcept(m.fill(0)));

--- a/test/src/iterators.cpp
+++ b/test/src/iterators.cpp
@@ -1,17 +1,16 @@
+#include "matrix.hpp"
 #include <algorithm>
 #include <concepts>
+#include <gtest/gtest.h>
 #include <iterator>
 #include <ranges>
-#include <gtest/gtest.h>
-#include "matrix.hpp"
 
 using M = ysc::matrix<int, 2, 3>;
 
 static_assert(std::contiguous_iterator<M::iterator>);
 static_assert(std::contiguous_iterator<M::const_iterator>);
 
-TEST(iterators, begin_end_mutable_range_for)
-{
+TEST(iterators, begin_end_mutable_range_for) {
     M m{1, 2, 3, 4, 5, 6};
     int sum = 0;
     for (auto& v : m)
@@ -19,8 +18,7 @@ TEST(iterators, begin_end_mutable_range_for)
     EXPECT_EQ(sum, 21);
 }
 
-TEST(iterators, begin_end_const_range_for)
-{
+TEST(iterators, begin_end_const_range_for) {
     const M m{1, 2, 3, 4, 5, 6};
     int sum = 0;
     for (const auto& v : m)
@@ -28,8 +26,7 @@ TEST(iterators, begin_end_const_range_for)
     EXPECT_EQ(sum, 21);
 }
 
-TEST(iterators, cbegin_cend)
-{
+TEST(iterators, cbegin_cend) {
     M m{10, 20, 30, 40, 50, 60};
     int sum = 0;
     for (auto it = m.cbegin(); it != m.cend(); ++it)
@@ -37,53 +34,61 @@ TEST(iterators, cbegin_cend)
     EXPECT_EQ(sum, 210);
 }
 
-TEST(iterators, rbegin_rend_mutable)
-{
+TEST(iterators, rbegin_rend_mutable) {
     M m{1, 2, 3, 4, 5, 6};
     auto it = m.rbegin();
-    EXPECT_EQ(*it, 6); ++it;
-    EXPECT_EQ(*it, 5); ++it;
-    EXPECT_EQ(*it, 4); ++it;
-    EXPECT_EQ(*it, 3); ++it;
-    EXPECT_EQ(*it, 2); ++it;
-    EXPECT_EQ(*it, 1); ++it;
+    EXPECT_EQ(*it, 6);
+    ++it;
+    EXPECT_EQ(*it, 5);
+    ++it;
+    EXPECT_EQ(*it, 4);
+    ++it;
+    EXPECT_EQ(*it, 3);
+    ++it;
+    EXPECT_EQ(*it, 2);
+    ++it;
+    EXPECT_EQ(*it, 1);
+    ++it;
     EXPECT_EQ(it, m.rend());
 }
 
-TEST(iterators, rbegin_rend_const)
-{
+TEST(iterators, rbegin_rend_const) {
     const M m{1, 2, 3, 4, 5, 6};
     auto it = m.rbegin();
-    EXPECT_EQ(*it, 6); ++it;
+    EXPECT_EQ(*it, 6);
+    ++it;
     EXPECT_EQ(*it, 5);
     EXPECT_EQ(std::distance(m.rbegin(), m.rend()), 6);
 }
 
-TEST(iterators, crbegin_crend)
-{
+TEST(iterators, crbegin_crend) {
     M m{1, 2, 3, 4, 5, 6};
     auto it = m.crbegin();
     EXPECT_EQ(*it, 6);
     EXPECT_EQ(std::distance(m.crbegin(), m.crend()), 6);
 }
 
-TEST(iterators, begin_end_write_through_iterator)
-{
+TEST(iterators, begin_end_write_through_iterator) {
     M m{1, 2, 3, 4, 5, 6};
     for (auto& v : m)
         v *= 2;
     auto it = m.begin();
-    EXPECT_EQ(*it, 2); ++it;
-    EXPECT_EQ(*it, 4); ++it;
-    EXPECT_EQ(*it, 6); ++it;
-    EXPECT_EQ(*it, 8); ++it;
-    EXPECT_EQ(*it, 10); ++it;
-    EXPECT_EQ(*it, 12); ++it;
+    EXPECT_EQ(*it, 2);
+    ++it;
+    EXPECT_EQ(*it, 4);
+    ++it;
+    EXPECT_EQ(*it, 6);
+    ++it;
+    EXPECT_EQ(*it, 8);
+    ++it;
+    EXPECT_EQ(*it, 10);
+    ++it;
+    EXPECT_EQ(*it, 12);
+    ++it;
     EXPECT_EQ(it, m.end());
 }
 
-TEST(iterators, ranges_sort)
-{
+TEST(iterators, ranges_sort) {
     M m{6, 3, 1, 4, 5, 2};
     std::ranges::sort(m);
     EXPECT_TRUE(std::ranges::is_sorted(m));

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
-int main(int argc, char** argv)
-{
+int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }

--- a/test/src/size_data.cpp
+++ b/test/src/size_data.cpp
@@ -1,58 +1,50 @@
-#include <gtest/gtest.h>
 #include "matrix.hpp"
+#include <gtest/gtest.h>
 
 using M23 = ysc::matrix<int, 2, 3>;
-using M1  = ysc::matrix<int, 7>;
+using M1 = ysc::matrix<int, 7>;
 
 // compile-time guarantees
-static_assert(M23::size()     == 6);
+static_assert(M23::size() == 6);
 static_assert(M23::max_size() == 6);
-static_assert(M23::empty()    == false);
-static_assert(M1::size()      == 7);
+static_assert(M23::empty() == false);
+static_assert(M1::size() == 7);
 
-TEST(size, equals_product_of_dimensions)
-{
+TEST(size, equals_product_of_dimensions) {
     EXPECT_EQ(M23::size(), 6u);
 }
 
-TEST(size, single_dimension)
-{
+TEST(size, single_dimension) {
     EXPECT_EQ(M1::size(), 7u);
 }
 
-TEST(max_size, equals_size)
-{
+TEST(max_size, equals_size) {
     EXPECT_EQ(M23::max_size(), M23::size());
 }
 
-TEST(empty, non_empty_matrix_is_false)
-{
+TEST(empty, non_empty_matrix_is_false) {
     EXPECT_FALSE(M23::empty());
 }
 
-TEST(data, mutable_points_to_first_element)
-{
+TEST(data, mutable_points_to_first_element) {
     M23 m{1, 2, 3, 4, 5, 6};
     EXPECT_EQ(m.data(), &m(0, 0));
     EXPECT_EQ(*m.data(), 1);
 }
 
-TEST(data, const_points_to_first_element)
-{
+TEST(data, const_points_to_first_element) {
     const M23 m{10, 20, 30, 40, 50, 60};
     EXPECT_EQ(m.data(), &m(0, 0));
     EXPECT_EQ(*m.data(), 10);
 }
 
-TEST(data, mutable_write_through)
-{
+TEST(data, mutable_write_through) {
     M23 m{1, 2, 3, 4, 5, 6};
     *m.data() = 99;
     EXPECT_EQ(m(0, 0), 99);
 }
 
-TEST(data, contiguous_storage)
-{
+TEST(data, contiguous_storage) {
     M23 m{1, 2, 3, 4, 5, 6};
     for (ysc::matrix<int, 2, 3>::size_type i = 0; i < M23::size(); ++i)
         EXPECT_EQ(*(m.data() + i), static_cast<int>(i + 1));

--- a/test/src/typedefs.cpp
+++ b/test/src/typedefs.cpp
@@ -1,45 +1,42 @@
+#include "matrix.hpp"
 #include <concepts>
 #include <cstddef>
-#include <iterator>
 #include <gtest/gtest.h>
-#include "matrix.hpp"
+#include <iterator>
 
 using M = ysc::matrix<int, 2, 3>;
 
-static_assert(std::same_as<M::value_type,             int>);
-static_assert(std::same_as<M::size_type,              std::size_t>);
-static_assert(std::same_as<M::difference_type,        std::ptrdiff_t>);
-static_assert(std::same_as<M::reference,              int&>);
-static_assert(std::same_as<M::const_reference,        const int&>);
-static_assert(std::same_as<M::pointer,                int*>);
-static_assert(std::same_as<M::const_pointer,          const int*>);
-static_assert(std::same_as<M::reverse_iterator,       std::reverse_iterator<M::iterator>>);
+static_assert(std::same_as<M::value_type, int>);
+static_assert(std::same_as<M::size_type, std::size_t>);
+static_assert(std::same_as<M::difference_type, std::ptrdiff_t>);
+static_assert(std::same_as<M::reference, int&>);
+static_assert(std::same_as<M::const_reference, const int&>);
+static_assert(std::same_as<M::pointer, int*>);
+static_assert(std::same_as<M::const_pointer, const int*>);
+static_assert(std::same_as<M::reverse_iterator, std::reverse_iterator<M::iterator>>);
 static_assert(std::same_as<M::const_reverse_iterator, std::reverse_iterator<M::const_iterator>>);
 
-TEST(typedefs, value_type_is_int)
-{
+TEST(typedefs, value_type_is_int) {
     static_assert(std::same_as<ysc::matrix<int, 3>::value_type, int>);
     static_assert(std::same_as<ysc::matrix<double, 2, 2>::value_type, double>);
 }
 
-TEST(typedefs, size_type_and_difference_type)
-{
+TEST(typedefs, size_type_and_difference_type) {
     static_assert(std::same_as<M::size_type, std::size_t>);
     static_assert(std::same_as<M::difference_type, std::ptrdiff_t>);
 }
 
-TEST(typedefs, reference_and_pointer)
-{
-    static_assert(std::same_as<M::reference,       int&>);
+TEST(typedefs, reference_and_pointer) {
+    static_assert(std::same_as<M::reference, int&>);
     static_assert(std::same_as<M::const_reference, const int&>);
-    static_assert(std::same_as<M::pointer,         int*>);
-    static_assert(std::same_as<M::const_pointer,   const int*>);
+    static_assert(std::same_as<M::pointer, int*>);
+    static_assert(std::same_as<M::const_pointer, const int*>);
 }
 
-TEST(typedefs, iterator_types_are_public)
-{
-    static_assert(std::same_as<M::iterator,               std::array<int, 6>::iterator>);
-    static_assert(std::same_as<M::const_iterator,         std::array<int, 6>::const_iterator>);
-    static_assert(std::same_as<M::reverse_iterator,       std::reverse_iterator<M::iterator>>);
-    static_assert(std::same_as<M::const_reverse_iterator, std::reverse_iterator<M::const_iterator>>);
+TEST(typedefs, iterator_types_are_public) {
+    static_assert(std::same_as<M::iterator, std::array<int, 6>::iterator>);
+    static_assert(std::same_as<M::const_iterator, std::array<int, 6>::const_iterator>);
+    static_assert(std::same_as<M::reverse_iterator, std::reverse_iterator<M::iterator>>);
+    static_assert(
+        std::same_as<M::const_reverse_iterator, std::reverse_iterator<M::const_iterator>>);
 }

--- a/user-stories.md
+++ b/user-stories.md
@@ -4,7 +4,7 @@
 
 | Épopée | Statut | Progression | Détail |
 |--------|--------|-------------|--------|
-| **A — Infrastructure & CI/CD** | 🔶 Partielle | 3/7 | ✅ US-001, US-002, US-003 · ⬜ US-004 à US-007 |
+| **A — Infrastructure & CI/CD** | 🔶 Partielle | 4/7 | ✅ US-001, US-002, US-003, US-004 · ⬜ US-005 à US-007 |
 | **B — Modernisation C++20** | ✅ Terminée | 3/3 | ✅ US-008, US-009, US-010 (fusionné US-019) |
 | **C — Dette technique** | 🔶 Partielle | 2/4 | ✅ US-011, US-013 · ⬜ US-012, US-014 |
 | **D — Conformité STL** | ✅ Terminée | 4/4 | ✅ US-015, US-016, US-017, US-018 |
@@ -14,7 +14,7 @@
 | **H — Vues & reshape** | ⬜ Non démarrée | 0/3 | ⬜ US-035 à US-037 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/5 | ⬜ US-038 à US-042 |
 
-**Total : 12 / 42 US**
+**Total : 13 / 42 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -23,7 +23,7 @@
 | US-001 | Pipeline CI multi-plateforme | P0 | ✅ Done |
 | US-002 | Couverture de code (gcov + lcov + Codecov) | P0 | ✅ Done |
 | US-003 | Sanitizers (ASan + UBSan) | P1 | ✅ Done |
-| US-004 | clang-format + vérification CI | P1 | 🔓 Disponible |
+| US-004 | clang-format + vérification CI | P1 | ✅ Done |
 | US-005 | clang-tidy + vérification CI | P1 | 🔓 Disponible |
 | US-006 | Doc Doxygen publiée sur GitHub Pages | P1 | 🔓 Disponible |
 | US-007 | Release automation (semver + GitHub Releases) | P2 | 🔓 Disponible |


### PR DESCRIPTION
## Résumé

Instaure un style de code unique (LLVM-based, 4-space indent, 100-col) via clang-format. Tous les fichiers sources existants sont reformatés. Un job CI `format-check` bloque désormais toute PR dont le code n'est pas conforme.

## Critères d'acceptation

- [x] Fichier `.clang-format` présent à la racine (BasedOnStyle: LLVM, IndentWidth: 4, ColumnLimit: 100)
- [x] Tous les fichiers sources reformatés (`clang-format --dry-run --Werror` passe sans erreur)
- [x] Tests verts après reformatage
- [x] Cible CMake `format` disponible (`cmake --build build --target format`)
- [x] Job CI `format-check` bloque toute PR non formatée

## Décisions d'implémentation

- `cmake/ClangFormat.cmake` ne suit pas le pattern `ENABLE_XXX` : la cible `format` est une cible utilitaire toujours disponible (si `clang-format` est trouvé), pas un flag de build.
- La CI utilise `clang-format` sans suffixe de version (Ubuntu 24.04 → clang-format-20 par défaut) ; la cohérence de style est garantie par le `.clang-format` versionné dans le dépôt.
- `CONTRIBUTING.md` créé avec la documentation du pre-commit hook optionnel.