### PR TITLE
US-006 — Doc Doxygen publiée sur GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,32 @@
+name: Docs
+
+on:
+  push:
+    branches: [develop]
+
+jobs:
+  deploy:
+    name: Build and deploy Doxygen to GitHub Pages
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Doxygen
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y doxygen
+
+      - name: Configure
+        run: cmake -S . -B build -DBUILD_DOCUMENTATION=ON
+
+      - name: Build documentation
+        run: cmake --build build --target doc
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: build/html

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,7 @@ if(BUILD_DOCUMENTATION)
     configure_file(${doxyfile_in} ${doxyfile} @ONLY)
 
     add_custom_target(doc
-        COMMAND ${DOXYGEN_EXECUTABLE} ${doxyfile} &&
-                env GITHUB_PAGES_DIR=${CMAKE_CURRENT_SOURCE_DIR}/html ${CMAKE_CURRENT_SOURCE_DIR}/doc/publish.sh
+        COMMAND ${DOXYGEN_EXECUTABLE} ${doxyfile}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         COMMENT "Generating API documentation with Doxygen"
         VERBATIM)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/yscialom/matrix/actions/workflows/ci.yml/badge.svg)](https://github.com/yscialom/matrix/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/yscialom/matrix/graph/badge.svg)](https://codecov.io/gh/yscialom/matrix)
+[![docs](https://github.com/yscialom/matrix/actions/workflows/docs.yml/badge.svg)](https://yscialom.github.io/matrix/)
 
 A general-purpose multi-dimension container of static dimensions. Requires **C++20** (`__cplusplus >= 202002L`).
 

--- a/user-stories.md
+++ b/user-stories.md
@@ -4,7 +4,7 @@
 
 | Épopée | Statut | Progression | Détail |
 |--------|--------|-------------|--------|
-| **A — Infrastructure & CI/CD** | 🔶 Partielle | 5/7 | ✅ US-001, US-002, US-003, US-004, US-005 · ⬜ US-006, US-007 |
+| **A — Infrastructure & CI/CD** | 🔶 Partielle | 6/7 | ✅ US-001, US-002, US-003, US-004, US-005, US-006 · ⬜ US-007 |
 | **B — Modernisation C++20** | ✅ Terminée | 3/3 | ✅ US-008, US-009, US-010 (fusionné US-019) |
 | **C — Dette technique** | 🔶 Partielle | 2/4 | ✅ US-011, US-013 · ⬜ US-012, US-014 |
 | **D — Conformité STL** | ✅ Terminée | 4/4 | ✅ US-015, US-016, US-017, US-018 |
@@ -14,7 +14,7 @@
 | **H — Vues & reshape** | ⬜ Non démarrée | 0/3 | ⬜ US-035 à US-037 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/5 | ⬜ US-038 à US-042 |
 
-**Total : 14 / 42 US**
+**Total : 15 / 42 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -25,7 +25,7 @@
 | US-003 | Sanitizers (ASan + UBSan) | P1 | ✅ Done |
 | US-004 | clang-format + vérification CI | P1 | ✅ Done |
 | US-005 | clang-tidy + vérification CI | P1 | ✅ Done |
-| US-006 | Doc Doxygen publiée sur GitHub Pages | P1 | 🔓 Disponible |
+| US-006 | Doc Doxygen publiée sur GitHub Pages | P1 | ✅ Done |
 | US-007 | Release automation (semver + GitHub Releases) | P2 | 🔓 Disponible |
 
 ---


### PR DESCRIPTION
## Résumé

Mise en place d'un workflow CI qui génère la documentation Doxygen et la publie automatiquement sur GitHub Pages (`gh-pages`) à chaque merge sur `develop`. La cible CMake `doc` est simplifiée pour ne faire que la génération HTML — le déploiement est entièrement délégué à la CI.

## Critères d'acceptation

- [x] Doc accessible sur https://yscialom.github.io/matrix/ (déclenchée dès merge)
- [x] Mise à jour automatique à chaque merge sur `develop`

## Décisions d'implémentation

- **`CMakeLists.txt`** : l'appel à `doc/publish.sh` est retiré de la cible `doc`. Le script reste présent pour un usage local éventuel, mais la CI ne l'utilise plus.
- **`docs.yml`** : `permissions: contents: write` requis pour que `peaceiris/actions-gh-pages@v3` puisse pousser sur `gh-pages` via `GITHUB_TOKEN` (pas besoin de secret supplémentaire).
- **Badge** : le badge `docs` dans `README.md` pointe vers l'URL GitHub Pages et affiche le statut du workflow.