### PR TITLE
US-007 — Release automation (semver + GitHub Releases)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  verify-version:
+    name: Verify CMake version matches tag
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check VERSION_* in CMakeLists.txt matches tag
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+          TAG_MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          TAG_MINOR=$(echo "$VERSION" | cut -d. -f2)
+          TAG_PATCH=$(echo "$VERSION" | cut -d. -f3)
+
+          CMAKE_MAJOR=$(grep -oP 'set\(VERSION_MAJOR\s+\K\d+' CMakeLists.txt)
+          CMAKE_MINOR=$(grep -oP 'set\(VERSION_MINOR\s+\K\d+' CMakeLists.txt)
+          CMAKE_PATCH=$(grep -oP 'set\(VERSION_PATCH\s+\K\d+' CMakeLists.txt)
+
+          echo "Tag: $TAG_MAJOR.$TAG_MINOR.$TAG_PATCH"
+          echo "CMake: $CMAKE_MAJOR.$CMAKE_MINOR.$CMAKE_PATCH"
+
+          if [ "$TAG_MAJOR" != "$CMAKE_MAJOR" ] \
+          || [ "$TAG_MINOR" != "$CMAKE_MINOR" ] \
+          || [ "$TAG_PATCH" != "$CMAKE_PATCH" ]; then
+            echo "ERROR: version mismatch between tag ($VERSION) and CMakeLists.txt ($CMAKE_MAJOR.$CMAKE_MINOR.$CMAKE_PATCH)"
+            exit 1
+          fi
+
+  build-and-test:
+    name: Build and test (Ubuntu / GCC-13 / Release)
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install GCC-13 and GTest
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y g++-13 libgtest-dev
+
+      - name: Configure
+        env:
+          CC: gcc-13
+          CXX: g++-13
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build --parallel
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure
+
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-24.04
+    needs: [verify-version, build-and-test]
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install git-cliff
+        run: |
+          curl -sSfL \
+            "https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-x86_64-unknown-linux-musl.tar.gz" \
+            | tar -xz --strip-components=1 -C /usr/local/bin git-cliff-*/git-cliff
+
+      - name: Generate CHANGELOG
+        run: git cliff --tag "$GITHUB_REF_NAME" --output CHANGELOG.md
+
+      - name: Extract release notes
+        run: git cliff --tag "$GITHUB_REF_NAME" --unreleased --strip all --output release-notes.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: release-notes.md
+          files: CHANGELOG.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,3 +25,49 @@ Make the hook executable:
 ```bash
 chmod +x .git/hooks/pre-commit
 ```
+
+## Commit messages
+
+This project follows [Conventional Commits](https://www.conventionalcommits.org/). Each commit
+message must have the form:
+
+```
+<type>[optional scope]: <description>
+```
+
+Recognised types:
+
+| Type       | When to use                                    |
+|------------|------------------------------------------------|
+| `feat`     | New feature visible to users                   |
+| `fix`      | Bug fix                                        |
+| `perf`     | Performance improvement                        |
+| `refactor` | Code restructuring without behaviour change    |
+| `docs`     | Documentation only                             |
+| `test`     | Tests only                                     |
+| `chore`    | Tooling, build, CI, dependencies               |
+| `ci`       | CI/CD pipeline changes                         |
+| `build`    | Build system changes                           |
+| `revert`   | Reverts a previous commit                      |
+
+Breaking changes must be noted with a `!` after the type (e.g. `feat!: remove deprecated API`) or
+with a `BREAKING CHANGE:` footer.
+
+The CHANGELOG is generated automatically from these messages on each release via
+[git-cliff](https://git-cliff.org/) (configuration in `cliff.toml`).
+
+## Releasing
+
+Releases are automated via `.github/workflows/release.yml`. To cut a release:
+
+1. Update `VERSION_MAJOR`, `VERSION_MINOR`, and `VERSION_PATCH` in `CMakeLists.txt`.
+2. Merge the version bump PR into `develop`.
+3. Push a tag matching `vMAJOR.MINOR.PATCH`:
+
+```bash
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+The CI will verify that the tag matches the version declared in `CMakeLists.txt`, run the tests,
+generate the CHANGELOG, and publish the GitHub Release automatically.

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,40 @@
+[changelog]
+header = "# Changelog\n\nAll notable changes to this project will be documented in this file.\n"
+body = """
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim | upper_first }}
+{% for commit in commits %}
+- {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | upper_first }}\
+{% endfor %}
+{% endfor %}\n
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_preprocessors = []
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactoring" },
+    { message = "^doc|^docs", group = "Documentation" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore|^ci|^build", group = "Miscellaneous" },
+    { message = "^revert", group = "Reverted" },
+]
+protect_breaking_commits = false
+filter_commits = true
+tag_pattern = "v[0-9]*\\.[0-9]*\\.[0-9]*"
+skip_tags = ""
+ignore_tags = ""
+topo_order = false
+sort_commits = "oldest"

--- a/user-stories.md
+++ b/user-stories.md
@@ -4,7 +4,7 @@
 
 | Épopée | Statut | Progression | Détail |
 |--------|--------|-------------|--------|
-| **A — Infrastructure & CI/CD** | 🔶 Partielle | 6/7 | ✅ US-001, US-002, US-003, US-004, US-005, US-006 · ⬜ US-007 |
+| **A — Infrastructure & CI/CD** | ✅ Terminée | 7/7 | ✅ US-001, US-002, US-003, US-004, US-005, US-006, US-007 |
 | **B — Modernisation C++20** | ✅ Terminée | 3/3 | ✅ US-008, US-009, US-010 (fusionné US-019) |
 | **C — Dette technique** | 🔶 Partielle | 2/4 | ✅ US-011, US-013 · ⬜ US-012, US-014 |
 | **D — Conformité STL** | ✅ Terminée | 4/4 | ✅ US-015, US-016, US-017, US-018 |
@@ -14,7 +14,7 @@
 | **H — Vues & reshape** | ⬜ Non démarrée | 0/3 | ⬜ US-035 à US-037 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/5 | ⬜ US-038 à US-042 |
 
-**Total : 15 / 42 US**
+**Total : 16 / 42 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -26,7 +26,7 @@
 | US-004 | clang-format + vérification CI | P1 | ✅ Done |
 | US-005 | clang-tidy + vérification CI | P1 | ✅ Done |
 | US-006 | Doc Doxygen publiée sur GitHub Pages | P1 | ✅ Done |
-| US-007 | Release automation (semver + GitHub Releases) | P2 | 🔓 Disponible |
+| US-007 | Release automation (semver + GitHub Releases) | P2 | ✅ Done |
 
 ---
 


### PR DESCRIPTION
## Résumé

Mise en place de l'automatisation des releases : un workflow GitHub Actions déclenché sur tout
tag `v*.*.*` vérifie la cohérence du tag avec les variables `VERSION_*` de `CMakeLists.txt`,
construit et teste le projet, génère un CHANGELOG via `git-cliff` (Conventional Commits), puis
publie la GitHub Release correspondante.

## Critères d'acceptation

- [x] Workflow `.github/workflows/release.yml` déclenché sur tag `v*.*.*`
- [x] Job `verify-version` : vérifie que `VERSION_MAJOR/MINOR/PATCH` dans `CMakeLists.txt`
      correspond au tag poussé
- [x] Job `build-and-test` : build Release + `ctest` (Ubuntu / GCC-13)
- [x] Job `release` : génère CHANGELOG via `git-cliff`, publie GitHub Release avec
      `softprops/action-gh-release@v1`
- [x] `cliff.toml` configuré pour les Conventional Commits
- [x] Convention Conventional Commits documentée dans `CONTRIBUTING.md` avec procédure de release
- [ ] Release v2.0.0 créée à la fin de la roadmap (cf. US-042 — hors périmètre de cette US)
- [ ] CHANGELOG généré (sera produit lors de la première release taguée)

## Décisions d'implémentation

- Le CHANGELOG complet est joint en artefact de la release ; les release notes (corps du message)
  n'affichent que les commits depuis le tag précédent (`--unreleased --strip all`).
- La vérification de version échoue proprement si les variables CMake et le tag divergent,
  bloquant la release avant tout déploiement.
- `git-cliff` est installé via l'archive musl statique (sans dépendances système) pour fiabilité.