### PR TITLE
fix: guard tests behind BUILD_TESTING — fix docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
           sudo apt-get install -y doxygen
 
       - name: Configure
-        run: cmake -S . -B build -DBUILD_DOCUMENTATION=ON
+        run: cmake -S . -B build -DBUILD_DOCUMENTATION=ON -DBUILD_TESTING=OFF
 
       - name: Build documentation
         run: cmake --build build --target doc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,15 +24,18 @@ add_subdirectory(src)
 ##
 # test configuration
 #
-enable_testing()
-add_subdirectory(test)
-include(cmake/Coverage.cmake)
-include(cmake/Sanitizers.cmake)
 include(cmake/ClangFormat.cmake)
-add_custom_target(check # alias for make && make test
-    COMMAND ${CMAKE_CTEST_COMMAND}
-    DEPENDS matrix-test
-)
+option(BUILD_TESTING "Build the test suite" ON)
+if(BUILD_TESTING)
+    enable_testing()
+    add_subdirectory(test)
+    include(cmake/Coverage.cmake)
+    include(cmake/Sanitizers.cmake)
+    add_custom_target(check # alias for make && make test
+        COMMAND ${CMAKE_CTEST_COMMAND}
+        DEPENDS matrix-test
+    )
+endif()
 
 
 ##


### PR DESCRIPTION
## Résumé

Le job CI Docs échouait car `add_subdirectory(test)` était appelé inconditionnellement, déclenchant `find_package(GTest REQUIRED)` dans un environnement où GTest n'est pas installé.

**Changements :**
- `CMakeLists.txt` : le bloc test (enable_testing, add_subdirectory(test), Coverage, Sanitizers, cible `check`) est désormais conditionné par `option(BUILD_TESTING "..." ON)`
- `docs.yml` : ajout de `-DBUILD_TESTING=OFF` dans l'étape Configure

## Critères de validation

- [x] `cmake -S . -B build -DBUILD_DOCUMENTATION=ON -DBUILD_TESTING=OFF` configure sans erreur (pas de GTest nécessaire)
- [x] `cmake -S . -B build -DBUILD_TESTING=ON && cmake --build build --target check` : 100% tests passent (chemin normal inchangé)
- [x] `BUILD_TESTING` vaut `ON` par défaut — aucune régression pour les développeurs