### PR TITLE
docs: amélioration du README et de la page d'accueil Doxygen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ if(BUILD_DOCUMENTATION)
 
     set(doxyfile_in    ${CMAKE_CURRENT_SOURCE_DIR}/doc/Doxyfile.in)
     set(doxyfile       ${CMAKE_CURRENT_BINARY_DIR}/doc/Doxyfile)
-    set(doxy_main_page ${CMAKE_CURRENT_SOURCE_DIR}/README.md)
+    set(doxy_main_page ${CMAKE_CURRENT_SOURCE_DIR}/doc/mainpage.md)
 
     configure_file(${doxyfile_in} ${doxyfile} @ONLY)
 

--- a/README.md
+++ b/README.md
@@ -4,35 +4,92 @@
 [![codecov](https://codecov.io/gh/yscialom/matrix/graph/badge.svg)](https://codecov.io/gh/yscialom/matrix)
 [![docs](https://github.com/yscialom/matrix/actions/workflows/docs.yml/badge.svg)](https://yscialom.github.io/matrix/)
 
-A general-purpose multi-dimension container of static dimensions. Requires **C++20** (`__cplusplus >= 202002L`).
+A **header-only C++20** template library providing a general-purpose multi-dimensional
+container with static dimensions. Inspired by `std::array`, it extends it to N dimensions
+while keeping the same zero-overhead, `constexpr`-friendly design.
 
-## Example
+Full API reference: [yscialom.github.io/matrix](https://yscialom.github.io/matrix/)
 
+---
 
-    #include <matrix.hpp>
-    #include <iostream>
-    #include <string>
+## Installation
 
-    int main()
-    {
-        ysc::matrix<int, 3, 3> const data = {
-            1, 2, 3,
-            4, 5, 6,
-            7, 8, 9
-        };
+### CMake FetchContent (recommended)
 
-        std::cout << data(0, 0) + data(1, 1) + data(2, 2) << '\n';
+```cmake
+include(FetchContent)
+FetchContent_Declare(
+    ysc-matrix
+    GIT_REPOSITORY https://github.com/yscialom/matrix.git
+    GIT_TAG        v1.0.0
+)
+FetchContent_MakeAvailable(ysc-matrix)
 
-        ysc::matrix<std::string, 3, 3> data_as_string;
-        for (int i=0 ; i < data_as_string.dimensions[0] ; ++i) {
-            for (int j=0 ; j < data_as_string.dimensions[1] ; ++j) {
-                data_as_string(i, j) = std::to_string(data(i, j));
-            }
-        }
+target_link_libraries(my_target PRIVATE ysc::matrix)
+```
 
-        std::cout << "|_log(data(1, 1))_| is " << data_as_string(1, 1).size() << ".\n";
-    }
-    
-## Feature
+### Manual
 
-todo...
+Copy `src/include/matrix.hpp` into your project and add its directory to your include path.
+
+---
+
+## Quick Start
+
+```cpp
+#include <matrix.hpp>
+#include <iostream>
+
+int main()
+{
+    // A 3×3 matrix of integers, aggregate-initialized
+    ysc::matrix<int, 3, 3> m = {
+        1, 2, 3,
+        4, 5, 6,
+        7, 8, 9
+    };
+
+    // Unchecked element access (performance path)
+    std::cout << m(1, 1) << '\n';  // 5
+
+    // Bounds-checked access (throws std::out_of_range if out of bounds)
+    std::cout << m.at(2, 2) << '\n';  // 9
+
+    // Compile-time metadata
+    static_assert(m.order == 2);
+    static_assert(m.dimensions[0] == 3);
+    static_assert(m.size() == 9);
+
+    // Range-based for loop (row-major order)
+    for (int& x : m)
+        x *= 2;
+
+    // Works with any type, any number of dimensions
+    ysc::matrix<double, 2, 3, 4> tensor;  // 3D, 24 elements
+}
+```
+
+---
+
+## Features
+
+- **N-dimensional** — any number of dimensions, all sizes fixed at compile time
+- **STL-compatible** — `begin`/`end`, `size()`, `data()`, `front()`, `back()`, `fill()`, `swap()`
+- **Two access policies** — unchecked `operator()` (fast path) and bounds-checked `at()`
+- **Aggregate initialization** — `matrix<int, 2, 3> m = {1, 2, 3, 4, 5, 6};`
+- **Type conversion** — constructors and assignment from `matrix<U, Dims...>` when `U` converts to `T`
+- **Comparison** — `==` and `<=>` (lexicographic, row-major order)
+- **Compile-time metadata** — `order`, `dimensions`, `size()`, `empty()` all `static constexpr`
+- **Zero-init tag** — `matrix<T, Dims...> m{ysc::zero};` for explicit zero-initialization
+- **Zero overhead** — storage is `std::array<T, N>`, no heap, no virtual dispatch, no indirection
+
+---
+
+## Building and Testing
+
+```bash
+cmake -S . -B build
+cmake --build build --target check
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development guide.

--- a/doc/mainpage.md
+++ b/doc/mainpage.md
@@ -1,0 +1,87 @@
+@mainpage ysc::matrix — Multi-dimensional Array Library
+
+`ysc::matrix<T, Dims...>` is a **header-only C++20** template library providing a
+general-purpose multi-dimensional container with static dimensions.
+
+It has the performance of a raw C array with the ergonomics of a standard container:
+no heap allocation, no overhead, full `constexpr` support, and a complete STL-compatible
+interface.
+
+---
+
+## Quick Start
+
+```cpp
+#include <matrix.hpp>
+
+// A 3×4 matrix of doubles
+ysc::matrix<double, 3, 4> m;
+
+// Aggregate initialization
+ysc::matrix<int, 2, 3> grid = {1, 2, 3,
+                                4, 5, 6};
+
+// Element access — unchecked (fast path)
+grid(0, 1) = 42;
+
+// Element access — bounds-checked (throws std::out_of_range)
+int v = grid.at(1, 2);
+
+// Range-based for loop (row-major order)
+for (int& x : grid)
+    x *= 2;
+```
+
+---
+
+## Installation
+
+### CMake FetchContent (recommended)
+
+```cmake
+include(FetchContent)
+FetchContent_Declare(
+    ysc-matrix
+    GIT_REPOSITORY https://github.com/yscialom/matrix.git
+    GIT_TAG        v1.0.0
+)
+FetchContent_MakeAvailable(ysc-matrix)
+
+target_link_libraries(my_target PRIVATE ysc::matrix)
+```
+
+### Manual
+
+Copy `src/include/matrix.hpp` into your project and add its directory to your include path.
+
+```cpp
+#include "matrix.hpp"
+```
+
+---
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| N-dimensional | Any number of dimensions; all sizes fixed at compile time |
+| STL-compatible | `begin`/`end`, `size()`, `data()`, `front()`, `back()`, `fill()`, `swap()` |
+| Unchecked access | `operator()` — no bounds check, UB out-of-bounds (performance path) |
+| Bounds-checked access | `at()` — throws `std::out_of_range` |
+| Aggregate init | `matrix<int,2,3> m = {1,2,3,4,5,6};` |
+| Type conversion | Converting constructors and assignment from `matrix<U, Dims...>` |
+| Comparison | `==` and `<=>` (lexicographic on row-major storage) |
+| Compile-time metadata | `order`, `dimensions`, `size()`, `empty()` — all `static constexpr` |
+| Zero-init tag | `matrix<T, Dims...> m{ysc::zero};` — explicit zero-initialization |
+| Zero overhead | Storage is `std::array<T, N>`, no heap, no virtual, no indirection |
+
+---
+
+## API Reference
+
+The main entry point is the @ref ysc::matrix class.
+
+Related types and concepts:
+- @ref ysc::matrix_zero_t — tag type for explicit zero-initialization (`ysc::zero`)
+- @ref ysc::integral_coordinates — concept constraining `operator()` and `at()` coordinates
+- @ref ysc::matrix_convertible_from — concept constraining converting constructors and assignments


### PR DESCRIPTION
## Résumé

Cette US améliore la documentation sur deux fronts :

**README.md** — Le README était quasi-vide (exemple basique + « Features: todo… »). Il contient maintenant :
- Une section **Installation** avec un snippet CMake FetchContent et la méthode manuelle.
- Un **Quick Start** commenté montrant construction, accès, métadonnées compile-time et boucle range-for.
- Une liste **Features** complète (accès unchecked/checked, STL-compat, conversions, comparaisons, zero-init tag, zero overhead).
- Un lien direct vers la doc hébergée sur GitHub Pages.

**doc/mainpage.md** — Nouvelle page d'accueil Doxygen dédiée, remplaçant README comme `USE_MDFILE_AS_MAINPAGE`. Elle inclut :
- Vue d'ensemble orientée utilisateur.
- Quick Start et installation (adaptés au layout Doxygen).
- Tableau Features avec descriptions.
- Liens `@ref` directs vers `ysc::matrix`, `ysc::matrix_zero_t`, `ysc::integral_coordinates` et `ysc::matrix_convertible_from`.

**CMakeLists.txt** — `doxy_main_page` pointe désormais vers `doc/mainpage.md`.

## Critères d'acceptation

- [x] README contient une section Installation avec CMake FetchContent
- [x] README contient un Quick Start commenté
- [x] README contient une liste Features complète
- [x] README pointe vers la doc hébergée
- [x] La page d'accueil Doxygen guide directement vers la classe `ysc::matrix` via `@ref`
- [x] Les tests passent (`cmake --build build --target check` : 1/1)