### PR TITLE
US-021 — Refactor du constructeur variadic

### DIFF
--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -75,7 +75,7 @@ constexpr struct matrix_zero_t {
  * a struct holding a C-style array `T[Dimensions][...]` as its only non-static
  * data member. Unlike a C-style array, it doesn't decay to `T*` automatically.
  * As an aggregate impersonator, it can be initialized with aggregate-initialization
- * given at most @c N initializers that are convertible to @c T:
+ * given exactly @c linear_size initializers that are convertible to @c T:
  * `ysc::matrix<int, 3, 2> m = {1,2,3,4,5,6};`.
  *
  * The struct combines the performance and accessibility of a C-style array with
@@ -221,24 +221,23 @@ public:
      */
     matrix(matrix_zero_t /*zero*/) : _data({}) {}
 
-    /*
-     * @todo Code & test "As an aggregate impersonator, it can be initialized with
-     * aggregate-initialization given at most @c N initializers that are convertible to @c T"
-     */
-
     // aggregate constructors
     /**
      * @brief Initializes the matrix following the rules of aggregate initialization.
-     * @tparam Args... Source types
-     * @param args...  Source values
+     * @tparam Args... Source types (must all be convertible to @c T)
+     * @param args...  Source values (must be exactly @c linear_size values)
      *
-     * `matrix<long, 2, 2> m{true, '\x02', 3, 4L},` initializes an order-2 matrix from the values
-     * ` true`, `'\x02'`, `3` and `4L` converted to `int`.
+     * `matrix<long, 2, 2> m{true, '\x02', 3, 4L}` initializes an order-2 matrix from the values
+     * `true`, `'\x02'`, `3` and `4L` converted to `long`.
+     * Partial initialization (fewer than `linear_size` values) is not supported; use
+     * `matrix(matrix_zero_t)` to zero-initialize.
      */
-    // False positive on forwarding templates: if Args contains a C array, decay occurs at the
-    // call site, not here.
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-    template <class... Args> matrix(Args&&... args) : _data{std::forward<Args>(args)...} {}
+    template <class... Args>
+        requires(sizeof...(Args) == linear_size) && (std::convertible_to<Args, T> && ...) &&
+                (sizeof...(Args) > 0)
+    constexpr explicit(sizeof...(Args) == 1) matrix(Args&&... args)
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+        : _data{static_cast<T>(std::forward<Args>(args))...} {}
 
     // copy constructors
     /**

--- a/test/src/construct.cpp
+++ b/test/src/construct.cpp
@@ -140,7 +140,7 @@ TEST(construct_move, different_trivial_type) {
 
 // Expect matrixes to be movable for user-defined types
 TEST(construct_move, user_defined_type) {
-    ysc::matrix<std::shared_ptr<int>, 1> m = {std::make_shared<int>(0)};
+    ysc::matrix<std::shared_ptr<int>, 1> m{std::make_shared<int>(0)};
     auto const m_copy = std::move(m);
     ASSERT_EQ(*m_copy(0), 0);
     ASSERT_FALSE(
@@ -212,6 +212,31 @@ TEST(assign_move, user_defined_type) {
 }
 
 //
+// --- CONSTRAINED VARIADIC CONSTRUCTOR ---
+//
+
+// Exact count: exactly linear_size initializers required
+static_assert(std::is_constructible_v<ysc::matrix<int, 3>, int, int, int>);
+static_assert(!std::is_constructible_v<ysc::matrix<int, 3>, int, int>);
+static_assert(!std::is_constructible_v<ysc::matrix<int, 3>, int, int, int, int>);
+
+// Type constraint: all initializers must be convertible to T
+static_assert(!std::is_constructible_v<ysc::matrix<int, 2>, int, std::string>);
+
+// Single-element matrix: explicit to prevent accidental implicit conversions
+static_assert(!std::is_convertible_v<int, ysc::matrix<int, 1>>);
+static_assert(std::is_constructible_v<ysc::matrix<int, 1>, int>);
+
+// Copy constructor takes precedence over variadic when copying a matrix
+TEST(construct_init, copy_not_variadic) {
+    ysc::matrix<int, 3> const m1 = {1, 2, 3};
+    ysc::matrix<int, 3> const m2 = m1; // must call copy ctor, not variadic
+    ASSERT_EQ(m2(0), 1);
+    ASSERT_EQ(m2(1), 2);
+    ASSERT_EQ(m2(2), 3);
+}
+
+//
 // --- DESTRUCTOR ---
 //
 
@@ -231,7 +256,7 @@ TEST(destruct, user_defined_type) {
 
     {
         // trigger is false
-        ysc::matrix<S, 1> const m = {trigger};
+        ysc::matrix<S, 1> const m{trigger};
     } // trigger should be toggled as m is destructed
     ASSERT_TRUE(trigger);
 }

--- a/user-stories.md
+++ b/user-stories.md
@@ -6,15 +6,15 @@
 |--------|--------|-------------|--------|
 | **A — Infrastructure & CI/CD** | ✅ Terminée | 7/7 | ✅ US-001, US-002, US-003, US-004, US-005, US-006, US-007 |
 | **B — Modernisation C++20** | ✅ Terminée | 3/3 | ✅ US-008, US-009, US-010 (fusionné US-019) |
-| **C — Dette technique** | 🔶 Partielle | 2/4 | ✅ US-011, US-013 · ⬜ US-012, US-014 |
+| **C — Dette technique** | 🔶 Partielle | 3/4 | ✅ US-011, US-012, US-013 · ⬜ US-014 |
 | **D — Conformité STL** | ✅ Terminée | 4/4 | ✅ US-015, US-016, US-017, US-018 |
-| **E — Comparaison & I/O** | 🔶 Partielle | 1/7 | ✅ US-019 · ⬜ US-020 à US-025 |
+| **E — Comparaison & I/O** | 🔶 Partielle | 2/7 | ✅ US-019, US-021 · ⬜ US-020, US-022 à US-025 |
 | **F — Arithmétique** | ⬜ Non démarrée | 0/4 | ⬜ US-026 à US-029 |
 | **G — Algorithmes** | ⬜ Non démarrée | 0/5 | ⬜ US-030 à US-034 |
 | **H — Vues & reshape** | ⬜ Non démarrée | 0/3 | ⬜ US-035 à US-037 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/5 | ⬜ US-038 à US-042 |
 
-**Total : 16 / 42 US**
+**Total : 18 / 42 US**
 
 ## EPIC A — Infrastructure & CI/CD
 


### PR DESCRIPTION
## Résumé

Le constructeur variadic `template<class... Args> matrix(Args&&...)` était trop greedy : sans contrainte, il pouvait capturer des appels de copie ou d'autres constructeurs en présence de résolution d'overload ambiguë. Cette PR l'encadre avec des contraintes C++20 (`requires`) pour garantir qu'il n'est sélectionné que lorsque exactement `linear_size` valeurs convertibles vers `T` sont fournies.

## Changements

**`src/include/matrix.hpp`**
- Ajout de `requires (sizeof...(Args) == linear_size) && (std::convertible_to<Args, T> && ...) && (sizeof...(Args) > 0)` sur le constructeur variadic
- Ajout de `constexpr` et `explicit(sizeof...(Args) == 1)` (empêche la conversion implicite pour les matrices à un seul élément)
- Utilisation de `static_cast<T>` dans l'initialisation pour rendre la conversion explicite
- Suppression du `@todo` désormais résolu ; mise à jour du commentaire Doxygen

**`test/src/construct.cpp`**
- `static_assert` sur les contraintes (exact count, type constraint, explicit single-element)
- Nouveau test `construct_init.copy_not_variadic` vérifiant que la copie d'une matrice passe bien par le copy ctor
- Adaptation de deux tests existants `matrix<T,1>` à la sémantique `explicit` (passage de `= {val}` à `{val}`)

**`user-stories.md`**
- US-012 marquée ✅ Done (critères déjà satisfaits depuis US-008 : CMake 3.20, typo absente)
- US-021 marquée ✅ Done

## Critères d'acceptation

- [x] `matrix<int,3> m{1,2,3}` compile
- [x] `matrix<int,3> m{1,2}` ne compile pas (`static_assert(!std::is_constructible_v<ysc::matrix<int,3>, int, int>)`)
- [x] `matrix<int,3> m1; matrix<int,3> m2 = m1;` appelle bien le copy ctor (test `copy_not_variadic`)