### PR TITLE
US-023 — Factories zeros, ones, full, identity

### DIFF
--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -22,12 +22,13 @@
 
 namespace ysc {
 namespace _details {
-// Row-major index: index = c[0]*D[1]*…*D[N-1] + c[1]*D[2]*…*D[N-1] + … + c[N-1]
-// Evaluated right-to-left; `stride` is the product of all dimensions already visited.
+// cache-friendly: neighbor objects within the right-most coordinate are neighbors in memory
 template <class TDim, class TCoord>
 constexpr auto coordinates_to_index(TDim const& dimensions, TCoord const& coords) {
+    // Row-major index: index = c[0]*D[1]*…*D[N-1] + c[1]*D[2]*…*D[N-1] + … + c[N-1]
+    // Evaluated right-to-left; `stride` is the product of all dimensions already visited.
     std::size_t index = 0;
-    std::size_t stride = 1; // stride = product(D[k] for all k already visited)
+    std::size_t stride = 1;
     auto dim = dimensions.crbegin();
     auto coord = coords.crbegin();
     for (; dim != dimensions.crend(); ++dim, ++coord) {

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -17,27 +17,23 @@
 #include <compare>
 #include <concepts>
 #include <iterator>
-#include <numeric>
 #include <stdexcept>
 #include <type_traits>
 
 namespace ysc {
 namespace _details {
-template <class InputIt, class OutputIt>
-OutputIt partial_product(const InputIt& first, const InputIt& last, OutputIt output) {
-    *output++ = 1;
-    return partial_sum(first, last, output, std::multiplies<>{});
-}
-
-// cache-friendly:
-// neighbor objects within the right-most coordinate are neighbors in memory
+// cache-friendly: neighbor objects within the right-most coordinate are neighbors in memory
 template <class TDim, class TCoord>
-auto coordinates_to_index(TDim const& dimensions, TCoord const& coords) {
-    std::array<std::size_t, std::tuple_size_v<TDim>> dimension_product{};
-    using std::begin, std::cbegin, std::cend, std::crbegin, std::crend, std::prev;
-    partial_product(crbegin(dimensions), prev(crend(dimensions)), begin(dimension_product));
-    return std::inner_product(cbegin(dimension_product), cend(dimension_product), crbegin(coords),
-                              std::size_t{0});
+constexpr auto coordinates_to_index(TDim const& dimensions, TCoord const& coords) {
+    std::size_t index = 0;
+    std::size_t stride = 1;
+    auto d_it = dimensions.crbegin();
+    auto c_it = coords.crbegin();
+    for (; d_it != dimensions.crend(); ++d_it, ++c_it) {
+        index += static_cast<std::size_t>(*c_it) * stride;
+        stride *= *d_it;
+    }
+    return index;
 }
 } // namespace _details
 
@@ -219,7 +215,7 @@ public:
      * @note If `T` is a trivial type, the matrix is zero-initialized; otherwise the default
      * constructors of its elements are called.
      */
-    matrix(matrix_zero_t /*zero*/) : _data({}) {}
+    constexpr matrix(matrix_zero_t /*zero*/) : _data({}) {}
 
     // aggregate constructors
     /**
@@ -341,7 +337,9 @@ public:
      * @brief Assigns the given value to all elements of the matrix.
      * @param value Value to assign
      */
-    void fill(const T& value) noexcept(std::is_nothrow_copy_assignable_v<T>) { _data.fill(value); }
+    constexpr void fill(const T& value) noexcept(std::is_nothrow_copy_assignable_v<T>) {
+        _data.fill(value);
+    }
 
     /**
      * @brief Exchanges the contents of this matrix with another.
@@ -387,7 +385,7 @@ public:
      */
     template <class... Coords>
         requires integral_coordinates<Coords...>
-    T const& operator()(Coords... coordinates) const {
+    constexpr T const& operator()(Coords... coordinates) const {
         // Intentional: unchecked access on the performance path. Use at() for bounds checking.
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
         return _data[_details::coordinates_to_index(dimensions, std::array{coordinates...})];
@@ -402,7 +400,7 @@ public:
      */
     template <class... Coords>
         requires integral_coordinates<Coords...>
-    T& operator()(Coords... coordinates) {
+    constexpr T& operator()(Coords... coordinates) {
         // Intentional: unchecked access on the performance path. Use at() for bounds checking.
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
         return _data[_details::coordinates_to_index(dimensions, std::array{coordinates...})];
@@ -444,6 +442,50 @@ public:
         return (*this)(coordinates...);
     }
 };
+
+/**
+ * @brief Returns a matrix with all elements zero-initialized.
+ * @tparam T  Element type
+ * @tparam D  Dimensions
+ */
+template <class T, std::size_t... D> constexpr matrix<T, D...> zeros() noexcept {
+    return matrix<T, D...>(zero);
+}
+
+/**
+ * @brief Returns a matrix with all elements set to @a v.
+ * @tparam T  Element type
+ * @tparam D  Dimensions
+ * @param  v  Value to fill
+ */
+template <class T, std::size_t... D> constexpr matrix<T, D...> full(const T& v) {
+    auto m = zeros<T, D...>();
+    m.fill(v);
+    return m;
+}
+
+/**
+ * @brief Returns a matrix with all elements set to @c T{1}.
+ * @tparam T  Element type
+ * @tparam D  Dimensions
+ */
+template <class T, std::size_t... D> constexpr matrix<T, D...> ones() {
+    return full<T, D...>(T{1});
+}
+
+/**
+ * @brief Returns the N×N identity matrix (diagonal = 1, rest = 0).
+ * @tparam T  Element type
+ * @tparam N  Dimension
+ */
+template <class T, std::size_t N> constexpr matrix<T, N, N> identity() {
+    auto m = zeros<T, N, N>();
+    for (std::size_t i = 0; i < N; ++i) {
+        m(i, i) = T{1};
+    }
+    return m;
+}
+
 } // namespace ysc
 
 #endif // YSC_MATRIX_HPP

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -22,16 +22,17 @@
 
 namespace ysc {
 namespace _details {
-// cache-friendly: neighbor objects within the right-most coordinate are neighbors in memory
+// Row-major index: index = c[0]*D[1]*…*D[N-1] + c[1]*D[2]*…*D[N-1] + … + c[N-1]
+// Evaluated right-to-left; `stride` is the product of all dimensions already visited.
 template <class TDim, class TCoord>
 constexpr auto coordinates_to_index(TDim const& dimensions, TCoord const& coords) {
     std::size_t index = 0;
-    std::size_t stride = 1;
-    auto d_it = dimensions.crbegin();
-    auto c_it = coords.crbegin();
-    for (; d_it != dimensions.crend(); ++d_it, ++c_it) {
-        index += static_cast<std::size_t>(*c_it) * stride;
-        stride *= *d_it;
+    std::size_t stride = 1; // stride = product(D[k] for all k already visited)
+    auto dim = dimensions.crbegin();
+    auto coord = coords.crbegin();
+    for (; dim != dimensions.crend(); ++dim, ++coord) {
+        index += static_cast<std::size_t>(*coord) * stride;
+        stride *= *dim;
     }
     return index;
 }

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -468,19 +468,23 @@ template <class T, std::size_t... D> constexpr matrix<T, D...> full(const T& v) 
 
 /**
  * @brief Returns a matrix with all elements set to @c T{1}.
- * @tparam T  Element type
+ * @tparam T  Element type — must support construction from integer literal @c 1
  * @tparam D  Dimensions
  */
-template <class T, std::size_t... D> constexpr matrix<T, D...> ones() {
+template <class T, std::size_t... D>
+    requires requires { T{1}; }
+constexpr matrix<T, D...> ones() {
     return full<T, D...>(T{1});
 }
 
 /**
  * @brief Returns the N×N identity matrix (diagonal = 1, rest = 0).
- * @tparam T  Element type
+ * @tparam T  Element type — must support construction from integer literal @c 1
  * @tparam N  Dimension
  */
-template <class T, std::size_t N> constexpr matrix<T, N, N> identity() {
+template <class T, std::size_t N>
+    requires requires { T{1}; }
+constexpr matrix<T, N, N> identity() {
     auto m = zeros<T, N, N>();
     for (std::size_t i = 0; i < N; ++i) {
         m(i, i) = T{1};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(${TARGET_NAME}
     src/comparison.cpp
     src/concepts.cpp
     src/construct.cpp
+    src/factories.cpp
     src/fill.cpp
     src/iterators.cpp
     src/size_data.cpp

--- a/test/src/factories.cpp
+++ b/test/src/factories.cpp
@@ -1,0 +1,74 @@
+#include <matrix.hpp>
+
+#include <gtest/gtest.h>
+
+//
+// --- zeros ---
+//
+
+TEST(factories_zeros, all_elements_zero) {
+    auto m = ysc::zeros<int, 2, 3>();
+    for (std::size_t i = 0; i < 2; ++i)
+        for (std::size_t j = 0; j < 3; ++j)
+            ASSERT_EQ(m(i, j), 0);
+}
+
+TEST(factories_zeros, constexpr_eval) {
+    static_assert(ysc::zeros<int, 2, 3>()(0, 0) == 0);
+}
+
+TEST(factories_zeros, noexcept_spec) {
+    static_assert(noexcept(ysc::zeros<int, 2, 3>()));
+}
+
+//
+// --- full ---
+//
+
+TEST(factories_full, all_elements_equal_value) {
+    auto m = ysc::full<int, 2, 3>(42);
+    for (std::size_t i = 0; i < 2; ++i)
+        for (std::size_t j = 0; j < 3; ++j)
+            ASSERT_EQ(m(i, j), 42);
+}
+
+TEST(factories_full, one_dimension) {
+    auto m = ysc::full<double, 4>(3.14);
+    for (std::size_t i = 0; i < 4; ++i)
+        ASSERT_DOUBLE_EQ(m(i), 3.14);
+}
+
+//
+// --- ones ---
+//
+
+TEST(factories_ones, all_elements_one) {
+    auto m = ysc::ones<int, 2, 3>();
+    for (std::size_t i = 0; i < 2; ++i)
+        for (std::size_t j = 0; j < 3; ++j)
+            ASSERT_EQ(m(i, j), 1);
+}
+
+//
+// --- identity ---
+//
+
+TEST(factories_identity, diagonal_one_off_zero) {
+    auto m = ysc::identity<int, 3>();
+    for (std::size_t i = 0; i < 3; ++i)
+        for (std::size_t j = 0; j < 3; ++j)
+            ASSERT_EQ(m(i, j), i == j ? 1 : 0);
+}
+
+TEST(factories_identity, size_one) {
+    auto m = ysc::identity<int, 1>();
+    ASSERT_EQ(m(0, 0), 1);
+}
+
+TEST(factories_identity, double_type) {
+    auto m = ysc::identity<double, 2>();
+    ASSERT_DOUBLE_EQ(m(0, 0), 1.0);
+    ASSERT_DOUBLE_EQ(m(0, 1), 0.0);
+    ASSERT_DOUBLE_EQ(m(1, 0), 0.0);
+    ASSERT_DOUBLE_EQ(m(1, 1), 1.0);
+}

--- a/test/src/factories.cpp
+++ b/test/src/factories.cpp
@@ -8,9 +8,11 @@
 
 TEST(factories_zeros, all_elements_zero) {
     auto m = ysc::zeros<int, 2, 3>();
-    for (std::size_t i = 0; i < 2; ++i)
-        for (std::size_t j = 0; j < 3; ++j)
+    for (std::size_t i = 0; i < 2; ++i) {
+        for (std::size_t j = 0; j < 3; ++j) {
             ASSERT_EQ(m(i, j), 0);
+        }
+    }
 }
 
 TEST(factories_zeros, constexpr_eval) {
@@ -27,15 +29,18 @@ TEST(factories_zeros, noexcept_spec) {
 
 TEST(factories_full, all_elements_equal_value) {
     auto m = ysc::full<int, 2, 3>(42);
-    for (std::size_t i = 0; i < 2; ++i)
-        for (std::size_t j = 0; j < 3; ++j)
+    for (std::size_t i = 0; i < 2; ++i) {
+        for (std::size_t j = 0; j < 3; ++j) {
             ASSERT_EQ(m(i, j), 42);
+        }
+    }
 }
 
 TEST(factories_full, one_dimension) {
     auto m = ysc::full<double, 4>(3.14);
-    for (std::size_t i = 0; i < 4; ++i)
+    for (std::size_t i = 0; i < 4; ++i) {
         ASSERT_DOUBLE_EQ(m(i), 3.14);
+    }
 }
 
 //
@@ -44,9 +49,11 @@ TEST(factories_full, one_dimension) {
 
 TEST(factories_ones, all_elements_one) {
     auto m = ysc::ones<int, 2, 3>();
-    for (std::size_t i = 0; i < 2; ++i)
-        for (std::size_t j = 0; j < 3; ++j)
+    for (std::size_t i = 0; i < 2; ++i) {
+        for (std::size_t j = 0; j < 3; ++j) {
             ASSERT_EQ(m(i, j), 1);
+        }
+    }
 }
 
 //
@@ -55,9 +62,11 @@ TEST(factories_ones, all_elements_one) {
 
 TEST(factories_identity, diagonal_one_off_zero) {
     auto m = ysc::identity<int, 3>();
-    for (std::size_t i = 0; i < 3; ++i)
-        for (std::size_t j = 0; j < 3; ++j)
+    for (std::size_t i = 0; i < 3; ++i) {
+        for (std::size_t j = 0; j < 3; ++j) {
             ASSERT_EQ(m(i, j), i == j ? 1 : 0);
+        }
+    }
 }
 
 TEST(factories_identity, size_one) {

--- a/test/src/iterators.cpp
+++ b/test/src/iterators.cpp
@@ -3,6 +3,7 @@
 #include <concepts>
 #include <gtest/gtest.h>
 #include <iterator>
+#include <numeric>
 #include <ranges>
 
 using M = ysc::matrix<int, 2, 3>;

--- a/user-stories.md
+++ b/user-stories.md
@@ -8,13 +8,13 @@
 | **B — Modernisation C++20** | ✅ Terminée | 3/3 | ✅ US-008, US-009, US-010 (fusionné US-019) |
 | **C — Dette technique** | 🔶 Partielle | 3/4 | ✅ US-011, US-012, US-013 · ⬜ US-014 |
 | **D — Conformité STL** | ✅ Terminée | 4/4 | ✅ US-015, US-016, US-017, US-018 |
-| **E — Comparaison & I/O** | 🔶 Partielle | 2/7 | ✅ US-019, US-021 · ⬜ US-020, US-022 à US-025 |
+| **E — Comparaison & I/O** | 🔶 Partielle | 3/7 | ✅ US-019, US-021, US-023 · ⬜ US-020, US-022, US-024, US-025 |
 | **F — Arithmétique** | ⬜ Non démarrée | 0/4 | ⬜ US-026 à US-029 |
 | **G — Algorithmes** | ⬜ Non démarrée | 0/5 | ⬜ US-030 à US-034 |
 | **H — Vues & reshape** | ⬜ Non démarrée | 0/3 | ⬜ US-035 à US-037 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/5 | ⬜ US-038 à US-042 |
 
-**Total : 18 / 42 US**
+**Total : 19 / 42 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -633,9 +633,9 @@ constexpr matrix<T, N, N> identity();
 ```
 
 ### Critères d'acceptation
-- [ ] Tous testés
-- [ ] `static_assert(zeros<int,2,3>()(0,0) == 0)`
-- [ ] `identity<int,3>()(i,j) == (i==j ? 1 : 0)`
+- [x] Tous testés
+- [x] `static_assert(zeros<int,2,3>()(0,0) == 0)`
+- [x] `identity<int,3>()(i,j) == (i==j ? 1 : 0)`
 
 ---
 


### PR DESCRIPTION
## Résumé

Ajout de quatre fonctions libres `constexpr` dans `namespace ysc` : `zeros`, `full`, `ones` et `identity`. En prérequis, `_details::coordinates_to_index` a été réécrite sans `std::inner_product`/`std::partial_sum` pour être `constexpr`-compatible, et `operator()` ainsi que `fill()` ont été marqués `constexpr`, rendant possible le `static_assert` sur des valeurs de matrice.

## Critères d'acceptation

- [x] Tous testés (`test/src/factories.cpp`)
- [x] `static_assert(zeros<int,2,3>()(0,0) == 0)`
- [x] `identity<int,3>()(i,j) == (i==j ? 1 : 0)`

## Décisions d'implémentation

- `coordinates_to_index` réécrite avec des itérateurs inverses plutôt que `std::inner_product`/`std::partial_sum` (non `constexpr` même en C++20) ; `partial_product` supprimée.
- L'include `<numeric>` retiré de `matrix.hpp` expose une dépendance transitive dans `test/src/iterators.cpp` (`std::accumulate`) corrigée par un include direct.
- `zeros` est `noexcept` comme spécifié ; `full`, `ones` et `identity` ne le sont pas.