### PR TITLE
US-022 — Constructeur depuis initializer_list imbriquée (2D)

### DIFF
--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -237,6 +237,37 @@ public:
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
         : _data{static_cast<T>(std::forward<Args>(args))...} {}
 
+    // nested initializer_list constructor (2D only)
+    /**
+     * @brief Initializes a 2D matrix from a nested initializer list.
+     * @tparam D1 Deduced from @c order; constrained to 2 (do not specify explicitly).
+     * @param init Row-major nested initializer list; must have exactly @c dimensions[0] rows,
+     *             each of exactly @c dimensions[1] elements.
+     *
+     * @throws std::length_error if the number of rows or the size of any row does not match.
+     *
+     * @code
+     * ysc::matrix<int, 2, 3> m{{1, 2, 3}, {4, 5, 6}};
+     * assert(m(1, 2) == 6);
+     * @endcode
+     */
+    template <std::size_t D1 = order>
+        requires(D1 == 2)
+    matrix(std::initializer_list<std::initializer_list<T>> init) : _data{} {
+        if (init.size() != dimensions[0]) {
+            throw std::length_error{"matrix: wrong number of rows"};
+        }
+        auto it = _data.begin();
+        for (auto const& row_list : init) {
+            if (row_list.size() != dimensions[1]) {
+                throw std::length_error{"matrix: wrong number of columns"};
+            }
+            for (auto const& val : row_list) {
+                *it++ = val;
+            }
+        }
+    }
+
     // copy constructors
     /**
      * @brief Initializes the matrix as a copy of another.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(${TARGET_NAME}
     src/construct.cpp
     src/factories.cpp
     src/fill.cpp
+    src/nested_init.cpp
     src/iterators.cpp
     src/size_data.cpp
     src/typedefs.cpp

--- a/test/src/nested_init.cpp
+++ b/test/src/nested_init.cpp
@@ -1,0 +1,39 @@
+#include <matrix.hpp>
+
+#include <gtest/gtest.h>
+
+//
+// --- correct initialization ---
+//
+
+TEST(nested_init, int_2x3) {
+    ysc::matrix<int, 2, 3> m{{1, 2, 3}, {4, 5, 6}};
+    ASSERT_EQ(m(0, 0), 1);
+    ASSERT_EQ(m(0, 1), 2);
+    ASSERT_EQ(m(0, 2), 3);
+    ASSERT_EQ(m(1, 0), 4);
+    ASSERT_EQ(m(1, 1), 5);
+    ASSERT_EQ(m(1, 2), 6);
+}
+
+TEST(nested_init, double_1x1) {
+    ysc::matrix<double, 1, 1> m{{3.14}};
+    ASSERT_DOUBLE_EQ(m(0, 0), 3.14);
+}
+
+TEST(nested_init, square_matrix) {
+    ysc::matrix<int, 3, 3> m{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+    ASSERT_EQ(m(2, 2), 9);
+}
+
+//
+// --- runtime error cases ---
+//
+
+TEST(nested_init, wrong_row_count_throws) {
+    ASSERT_THROW((ysc::matrix<int, 2, 3>{{1, 2, 3}}), std::length_error);
+}
+
+TEST(nested_init, wrong_column_count_throws) {
+    ASSERT_THROW((ysc::matrix<int, 2, 3>{{1, 2}, {3, 4}}), std::length_error);
+}

--- a/user-stories.md
+++ b/user-stories.md
@@ -12,9 +12,9 @@
 | **F — Arithmétique** | ⬜ Non démarrée | 0/4 | ⬜ US-026 à US-029 |
 | **G — Algorithmes** | ⬜ Non démarrée | 0/5 | ⬜ US-030 à US-034 |
 | **H — Vues & reshape** | ⬜ Non démarrée | 0/3 | ⬜ US-035 à US-037 |
-| **I — Finition & release** | ⬜ Non démarrée | 0/5 | ⬜ US-038 à US-042 |
+| **I — Finition & release** | ⬜ Non démarrée | 0/6 | ⬜ US-038 à US-043 |
 
-**Total : 19 / 42 US**
+**Total : 19 / 43 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -76,6 +76,21 @@
 - Chaque PR doit laisser le build vert et les tests verts
 - Pas de breaking change sans bump majeur
 
+### Définition of Done (DoD) — critères transverses
+
+Toute US est considérée **Done** quand, en plus de ses critères d'acceptation propres :
+
+- Build et tests verts (`cmake --build build --target check`)
+- Aucun avertissement clang-format (`cmake --build build --target format-check`)
+- Aucun avertissement clang-tidy (`cmake --build build --target lint`)
+- **Documentation :** toute fonction publique (membre ou libre) ajoutée ou modifiée est documentée avec Doxygen :
+  - `@brief` — description en une phrase
+  - `@tparam` pour chaque paramètre template (si applicable)
+  - `@param` pour chaque paramètre de fonction (si applicable)
+  - `@return` si la valeur de retour est non-void
+  - Un exemple compilable dans `@code`…`@endcode`
+- Toute nouvelle fonction est rattachée à un groupe `@ingroup` existant (ou un nouveau groupe `@defgroup` créé), afin d'être accessible depuis la page principale de la doc Doxygen en ≤ 2 clics
+
 ---
 
 ## Épopées et dépendances
@@ -120,6 +135,7 @@ EPIC I — Finition & release
   US-040 (README + examples)
   US-041 (100% coverage gate)
   US-042 (release v2.0.0)
+  US-043 (documentation API complète)
 ```
 
 ---
@@ -991,3 +1007,54 @@ Reshape = juste un changement de vue, zero-copy.
 - [ ] Release v2.0.0 visible sur GitHub
 - [ ] Doc à jour, badges verts
 - [ ] CHANGELOG complet
+
+---
+
+## US-043 — Documentation Doxygen complète de l'API publique
+
+**Priorité :** P1 — **Dépend de :** US-006, US-023 (toutes les US d'API déjà mergées) — **Bloque :** US-042
+
+### Story
+En tant qu'utilisateur de la bibliothèque, je veux que chaque fonction publique soit documentée avec Doxygen (description, paramètres, exemple de code) et accessible en ≤ 2 clics depuis la page principale de la doc.
+
+### Spécification technique
+
+**Contenu de chaque documentation :**
+- `@brief` — une phrase décrivant le comportement
+- `@tparam` pour chaque paramètre template (si applicable)
+- `@param[in]`/`@param[out]` pour chaque paramètre de fonction (si applicable)
+- `@return` si la valeur de retour est non-void
+- `@throws` si une exception peut être levée
+- Un exemple compilable dans `@code`…`@endcode`
+
+**Organisation par groupes (`@defgroup` / `@ingroup`) :**
+
+| Groupe | Contenu |
+|--------|---------|
+| `construction` | Constructeurs, `operator=`, factories (`zeros`, `ones`, `full`, `identity`) |
+| `element_access` | `operator()`, `at()` |
+| `iterators` | `begin`, `end`, `cbegin`, `cend`, `rbegin`, `rend`, et variantes const |
+| `capacity` | `size`, `max_size`, `empty`, `data` |
+| `modifiers` | `fill`, `swap` |
+| `comparison` | `operator==`, `operator<=>` |
+
+**Page principale (`@mainpage`) :**
+- Fichier `docs/mainpage.dox` (ou bloc `@mainpage` dans `matrix.hpp`)
+- Courte description de la bibliothèque
+- Tableau listant les 6 groupes avec liens (`@ref`)
+- Exemple "Quick Start" complet
+
+**Vérification Doxygen :**
+- `WARN_AS_ERROR = YES` dans `Doxyfile` pour que tout warning devienne une erreur
+- `cmake --build build --target doc` doit se terminer sans aucun avertissement
+
+**Job CI :**
+- Étendre le job `docs` (US-006) avec `WARN_AS_ERROR = YES` en CI
+- Ou ajouter une étape `doxygen-check` dédiée (sans déploiement)
+
+### Critères d'acceptation
+- [ ] Chaque fonction publique de `matrix.hpp` possède `@brief`, `@tparam`/`@param`/`@return`/`@throws` selon applicable, et un exemple `@code`…`@endcode`
+- [ ] Toutes les fonctions sont rattachées à l'un des 6 groupes ci-dessus via `@ingroup`
+- [ ] La page `@mainpage` liste les 6 groupes ; chaque groupe est accessible en 1 clic depuis la page principale
+- [ ] `cmake --build build --target doc` produit zéro avertissement Doxygen
+- [ ] La CI est rouge si un avertissement Doxygen est introduit (`WARN_AS_ERROR = YES`)

--- a/user-stories.md
+++ b/user-stories.md
@@ -8,13 +8,13 @@
 | **B — Modernisation C++20** | ✅ Terminée | 3/3 | ✅ US-008, US-009, US-010 (fusionné US-019) |
 | **C — Dette technique** | 🔶 Partielle | 3/4 | ✅ US-011, US-012, US-013 · ⬜ US-014 |
 | **D — Conformité STL** | ✅ Terminée | 4/4 | ✅ US-015, US-016, US-017, US-018 |
-| **E — Comparaison & I/O** | 🔶 Partielle | 3/7 | ✅ US-019, US-021, US-023 · ⬜ US-020, US-022, US-024, US-025 |
+| **E — Comparaison & I/O** | 🔶 Partielle | 4/7 | ✅ US-019, US-021, US-022, US-023 · ⬜ US-020, US-024, US-025 |
 | **F — Arithmétique** | ⬜ Non démarrée | 0/4 | ⬜ US-026 à US-029 |
 | **G — Algorithmes** | ⬜ Non démarrée | 0/5 | ⬜ US-030 à US-034 |
 | **H — Vues & reshape** | ⬜ Non démarrée | 0/3 | ⬜ US-035 à US-037 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/6 | ⬜ US-038 à US-043 |
 
-**Total : 19 / 43 US**
+**Total : 20 / 43 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -621,9 +621,9 @@ Permet : `matrix<int,2,3> m{{1,2,3},{4,5,6}};`
 - N-D : non couvert par cette US (complexité disproportionnée — alternative : factory `make_matrix`)
 
 ### Critères d'acceptation
-- [ ] Init 2D fonctionne
-- [ ] Mauvaise taille → `std::length_error`
-- [ ] Test `nested_init.cpp`
+- [x] Init 2D fonctionne
+- [x] Mauvaise taille → `std::length_error`
+- [x] Test `nested_init.cpp`
 
 ---
 


### PR DESCRIPTION
## Résumé

Ajout d'un constructeur de `ysc::matrix` acceptant une `std::initializer_list<std::initializer_list<T>>`, limité aux matrices 2D par contrainte `requires (D1 == 2)`. Le constructeur vérifie à l'exécution que le nombre de lignes et la taille de chaque ligne correspondent aux dimensions déclarées, et lève `std::length_error` en cas d'écart.

## Critères d'acceptation

- [x] Init 2D fonctionne (`matrix<int,2,3> m{{1,2,3},{4,5,6}}`)
- [x] Mauvaise taille → `std::length_error`
- [x] Test `nested_init.cpp`

## Notes d'implémentation

- La contrainte `template <std::size_t D1 = order> requires (D1 == 2)` rend l'expression dépendante pour éviter une erreur dure à l'instanciation pour les matrices non-2D.
- `_data` est zero-initialisé dans la liste d'initialisation (`: _data{}`), puis les valeurs sont écrasées ligne par ligne via un itérateur.
- Ce commit inclut également un commit préliminaire `docs:` ajoutant la section DoD transverse et US-043 dans `user-stories.md`.