### PR TITLE
US-014 — Renommer namespace `_details` → `detail`

### DIFF
--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -21,7 +21,7 @@
 #include <type_traits>
 
 namespace ysc {
-namespace _details {
+namespace detail {
 // cache-friendly: neighbor objects within the right-most coordinate are neighbors in memory
 template <class TDim, class TCoord>
 constexpr auto coordinates_to_index(TDim const& dimensions, TCoord const& coords) {
@@ -37,7 +37,7 @@ constexpr auto coordinates_to_index(TDim const& dimensions, TCoord const& coords
     }
     return index;
 }
-} // namespace _details
+} // namespace detail
 
 /**
  * @brief Satisfied when `U` is convertible to `T`.
@@ -421,7 +421,7 @@ public:
     constexpr T const& operator()(Coords... coordinates) const {
         // Intentional: unchecked access on the performance path. Use at() for bounds checking.
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
-        return _data[_details::coordinates_to_index(dimensions, std::array{coordinates...})];
+        return _data[detail::coordinates_to_index(dimensions, std::array{coordinates...})];
     }
 
     /**
@@ -436,7 +436,7 @@ public:
     constexpr T& operator()(Coords... coordinates) {
         // Intentional: unchecked access on the performance path. Use at() for bounds checking.
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
-        return _data[_details::coordinates_to_index(dimensions, std::array{coordinates...})];
+        return _data[detail::coordinates_to_index(dimensions, std::array{coordinates...})];
     }
 
     /**

--- a/user-stories.md
+++ b/user-stories.md
@@ -6,7 +6,7 @@
 |--------|--------|-------------|--------|
 | **A — Infrastructure & CI/CD** | ✅ Terminée | 7/7 | ✅ US-001, US-002, US-003, US-004, US-005, US-006, US-007 |
 | **B — Modernisation C++20** | ✅ Terminée | 3/3 | ✅ US-008, US-009, US-010 (fusionné US-019) |
-| **C — Dette technique** | 🔶 Partielle | 3/4 | ✅ US-011, US-012, US-013 · ⬜ US-014 |
+| **C — Dette technique** | ✅ Terminée | 4/4 | ✅ US-011, US-012, US-013, US-014 |
 | **D — Conformité STL** | ✅ Terminée | 4/4 | ✅ US-015, US-016, US-017, US-018 |
 | **E — Comparaison & I/O** | 🔶 Partielle | 4/7 | ✅ US-019, US-021, US-022, US-023 · ⬜ US-020, US-024, US-025 |
 | **F — Arithmétique** | ⬜ Non démarrée | 0/4 | ⬜ US-026 à US-029 |
@@ -14,7 +14,7 @@
 | **H — Vues & reshape** | ⬜ Non démarrée | 0/3 | ⬜ US-035 à US-037 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/6 | ⬜ US-038 à US-043 |
 
-**Total : 20 / 43 US**
+**Total : 21 / 43 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -423,8 +423,8 @@ C'est de l'**UB** (function returning non-void sans return). Idem pour la versio
 - Pas de breaking change utilisateur (namespace interne)
 
 ### Critères d'acceptation
-- [ ] Tous les usages renommés
-- [ ] Build vert
+- [x] Tous les usages renommés
+- [x] Build vert
 
 ---
 


### PR DESCRIPTION
## Résumé

Renommage du namespace interne `ysc::_details` en `ysc::detail`, alignement sur la convention standard (Boost, `std`). Changement purement cosmétique : le namespace est interne et ne fait pas partie de l'API publique.

## Critères d'acceptation

- [x] Tous les usages renommés (`namespace detail`, `} // namespace detail`, deux appels `detail::coordinates_to_index`)
- [x] Build vert et tests verts

## Notes d'implémentation

Quatre occurrences dans `src/include/matrix.hpp`, aucune dans les tests (le namespace interne n'est pas utilisé directement par les tests). Dashboard `user-stories.md` : EPIC C passe à ✅ Terminée (4/4).