### PR TITLE
US-024 — operator<< (ostream)

### DIFF
--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -17,11 +17,40 @@
 #include <compare>
 #include <concepts>
 #include <iterator>
+#include <ostream>
 #include <stdexcept>
 #include <type_traits>
 
 namespace ysc {
 namespace detail {
+
+template <class T>
+concept ostream_streamable = requires(std::ostream& os, const T& v) { os << v; };
+
+// Print a hyperslice of a matrix starting at `it`, covering dimension `dim_idx` onward.
+// Returns an iterator past the last element printed.
+// NOLINTNEXTLINE(misc-no-recursion)
+template <class It, class Dims>
+It print_recursive(std::ostream& os, It it, const Dims& dims, std::size_t dim_idx) {
+    os << '[';
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+    const std::size_t count = dims[dim_idx];
+    const bool last_dim = (dim_idx + 1 == dims.size());
+    for (std::size_t i = 0; i < count; ++i) {
+        if (i > 0) {
+            os << ", ";
+        }
+        if (last_dim) {
+            os << *it++;
+        } else {
+            // NOLINTNEXTLINE(misc-no-recursion)
+            it = print_recursive(os, it, dims, dim_idx + 1);
+        }
+    }
+    os << ']';
+    return it;
+}
+
 // cache-friendly: neighbor objects within the right-most coordinate are neighbors in memory
 template <class TDim, class TCoord>
 constexpr auto coordinates_to_index(TDim const& dimensions, TCoord const& coords) {
@@ -521,6 +550,39 @@ constexpr matrix<T, N, N> identity() {
         m(i, i) = T{1};
     }
     return m;
+}
+
+/**
+ * @defgroup ysc_io I/O
+ * @brief Stream output for `ysc::matrix`.
+ */
+
+/**
+ * @brief Writes a matrix to an output stream.
+ * @tparam T    Element type — must be writable to `std::ostream` via `operator<<`
+ * @tparam Dims Dimensions of the matrix
+ * @param  os   Destination stream
+ * @param  m    Matrix to print
+ * @return @a os
+ *
+ * Produces nested bracket notation: `[e0, e1, ...]` for 1D,
+ * `[[e00, e01], [e10, e11]]` for 2D, and so on recursively.
+ *
+ * This overload only participates in overload resolution when `T` is streamable,
+ * so it never causes a hard error for non-streamable element types.
+ *
+ * @code
+ * ysc::matrix<int, 2, 2> m{1, 2, 3, 4};
+ * std::cout << m;  // [[1, 2], [3, 4]]
+ * @endcode
+ *
+ * @ingroup ysc_io
+ */
+template <class T, std::size_t... Dims>
+    requires detail::ostream_streamable<T>
+std::ostream& operator<<(std::ostream& os, const matrix<T, Dims...>& m) {
+    detail::print_recursive(os, m.cbegin(), matrix<T, Dims...>::dimensions, std::size_t{0});
+    return os;
 }
 
 } // namespace ysc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(${TARGET_NAME}
     src/fill.cpp
     src/nested_init.cpp
     src/iterators.cpp
+    src/ostream.cpp
     src/size_data.cpp
     src/typedefs.cpp
     src/main.cpp

--- a/test/src/ostream.cpp
+++ b/test/src/ostream.cpp
@@ -1,0 +1,47 @@
+#include <matrix.hpp>
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+
+TEST(ostream, print_1d) {
+    ysc::matrix<int, 3> m{1, 2, 3};
+    std::ostringstream oss;
+    oss << m;
+    ASSERT_EQ(oss.str(), "[1, 2, 3]");
+}
+
+TEST(ostream, print_2d) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    std::ostringstream oss;
+    oss << m;
+    ASSERT_EQ(oss.str(), "[[1, 2, 3], [4, 5, 6]]");
+}
+
+TEST(ostream, print_2d_spec) {
+    // Acceptance criterion from US-024: [[1, 2], [3, 4]]
+    std::ostringstream oss;
+    oss << ysc::matrix<int, 2, 2>{1, 2, 3, 4};
+    ASSERT_EQ(oss.str(), "[[1, 2], [3, 4]]");
+}
+
+TEST(ostream, print_3d) {
+    ysc::matrix<int, 2, 2, 2> m{1, 2, 3, 4, 5, 6, 7, 8};
+    std::ostringstream oss;
+    oss << m;
+    ASSERT_EQ(oss.str(), "[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]");
+}
+
+TEST(ostream, print_double) {
+    ysc::matrix<double, 2> m{1.5, 2.5};
+    std::ostringstream oss;
+    oss << m;
+    ASSERT_EQ(oss.str(), "[1.5, 2.5]");
+}
+
+TEST(ostream, chaining) {
+    ysc::matrix<int, 2> m{7, 8};
+    std::ostringstream oss;
+    oss << m << "!";
+    ASSERT_EQ(oss.str(), "[7, 8]!");
+}

--- a/user-stories.md
+++ b/user-stories.md
@@ -8,13 +8,13 @@
 | **B — Modernisation C++20** | ✅ Terminée | 3/3 | ✅ US-008, US-009, US-010 (fusionné US-019) |
 | **C — Dette technique** | ✅ Terminée | 4/4 | ✅ US-011, US-012, US-013, US-014 |
 | **D — Conformité STL** | ✅ Terminée | 4/4 | ✅ US-015, US-016, US-017, US-018 |
-| **E — Comparaison & I/O** | 🔶 Partielle | 4/7 | ✅ US-019, US-021, US-022, US-023 · ⬜ US-020, US-024, US-025 |
+| **E — Comparaison & I/O** | 🔶 Partielle | 5/7 | ✅ US-019, US-021, US-022, US-023, US-024 · ⬜ US-020, US-025 |
 | **F — Arithmétique** | ⬜ Non démarrée | 0/4 | ⬜ US-026 à US-029 |
 | **G — Algorithmes** | ⬜ Non démarrée | 0/5 | ⬜ US-030 à US-034 |
 | **H — Vues & reshape** | ⬜ Non démarrée | 0/3 | ⬜ US-035 à US-037 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/6 | ⬜ US-038 à US-043 |
 
-**Total : 21 / 43 US**
+**Total : 22 / 43 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -665,8 +665,8 @@ constexpr matrix<T, N, N> identity();
 - Utilise `<<` de `T` (donc T doit être streamable, mais SFINAE/concept friendly : pas de hard error si T pas streamable, simplement opérateur indisponible)
 
 ### Critères d'acceptation
-- [ ] `std::cout << matrix<int,2,2>{1,2,3,4}` → `[[1, 2], [3, 4]]`
-- [ ] Test `ostream.cpp`
+- [x] `std::cout << matrix<int,2,2>{1,2,3,4}` → `[[1, 2], [3, 4]]`
+- [x] Test `ostream.cpp`
 
 ---
 


### PR DESCRIPTION
## Résumé

Implémente `operator<<` pour `ysc::matrix`, produisant une notation en crochets imbriqués : `[e0, e1, ...]` pour 1D, `[[e00, e01], [e10, e11]]` pour 2D, et récursivement pour N-D. L'opérateur ne participe à la résolution de surcharge que si `T` est streamable (concept `detail::ostream_streamable`), sans jamais causer d'erreur dure.

## Critères d'acceptation

- [x] `std::cout << matrix<int,2,2>{1,2,3,4}` → `[[1, 2], [3, 4]]`
- [x] Test `ostream.cpp` (6 cas : 1D, 2D, 2D spec, 3D, double, chaînage)

## Décisions d'implémentation

- `detail::print_recursive` : fonction template récursive sur l'indice de dimension, utilise `NOLINTNEXTLINE(misc-no-recursion)` pour clang-tidy.
- Accès à `dims[dim_idx]` protégé par `NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)` car l'invariant de bornes est garanti par la récursion.
- `operator<<` est une fonction libre dans `namespace ysc`, rattachée au groupe Doxygen `ysc_io` (`@defgroup ysc_io I/O`).