### PR TITLE
config: silence Codecov PR comments when coverage is unchanged

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+comment:
+  layout: "reach, diff, flags, files"
+  require_changes: true
+  require_base: true
+  require_head: true


### PR DESCRIPTION
## Résumé

Ajoute `codecov.yml` pour que Codecov ne commente les PR que lorsque la couverture change réellement. Supprime le bruit des commentaires systématiques sur les PR vertes sans impact sur la couverture.

## Changements

- `require_changes: true` — commentaire uniquement si la couverture évolue
- `require_base: true` + `require_head: true` — attend d'avoir les deux mesures avant de commenter
- `layout` conservé pour garder un rapport lisible quand le commentaire apparaît