### PR TITLE
fix: épingler git-cliff v2.13.1 dans le workflow de release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,8 +74,9 @@ jobs:
       - name: Install git-cliff
         run: |
           curl -sSfL \
-            "https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-x86_64-unknown-linux-musl.tar.gz" \
-            | tar -xz --strip-components=1 -C /usr/local/bin git-cliff-*/git-cliff
+            "https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.13.1-x86_64-unknown-linux-musl.tar.gz" \
+            | tar -xz --strip-components=1 -C /usr/local/bin \
+                "git-cliff-2.13.1-x86_64-unknown-linux-musl/git-cliff"
 
       - name: Generate CHANGELOG
         run: git cliff --tag "$GITHUB_REF_NAME" --output CHANGELOG.md


### PR DESCRIPTION
## Résumé

Le job `release` échouait à l'étape « Install git-cliff » avec une erreur 404.
L'URL `/releases/latest/download/git-cliff-x86_64-unknown-linux-musl.tar.gz` ne fonctionne que si l'asset est publié sans version dans son nom — ce qui n'est pas le cas pour git-cliff (les assets sont nommés `git-cliff-2.13.1-x86_64-unknown-linux-musl.tar.gz`).

La correction épingle explicitement la version **v2.13.1** (dernière disponible au 2026-05-03) et utilise le chemin exact dans l'archive plutôt qu'un glob.

## Checklist

- [x] L'URL de téléchargement pointe vers un asset existant (v2.13.1)
- [x] Le chemin interne dans l'archive est exact (pas de glob)