### PR TITLE
chore: script release.sh + mise à jour CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,16 +58,38 @@ The CHANGELOG is generated automatically from these messages on each release via
 
 ## Releasing
 
-Releases are automated via `.github/workflows/release.yml`. To cut a release:
+`release.sh` at the root of the repository semi-automates the release process.
+It requires `git` and `gh` (GitHub CLI, authenticated).
 
-1. Update `VERSION_MAJOR`, `VERSION_MINOR`, and `VERSION_PATCH` in `CMakeLists.txt`.
-2. Merge the version bump PR into `develop`.
-3. Push a tag matching `vMAJOR.MINOR.PATCH`:
+### Step 1 — Prepare the release
 
 ```bash
-git tag v1.2.3
-git push origin v1.2.3
+./release.sh prepare M.m.p
 ```
 
-The CI will verify that the tag matches the version declared in `CMakeLists.txt`, run the tests,
-generate the CHANGELOG, and publish the GitHub Release automatically.
+This:
+- creates branch `release/vM.m.p` from the current branch
+- bumps `VERSION_MAJOR/MINOR/PATCH` in `CMakeLists.txt`
+- commits (title `Release vM.m.p`, body = epic dashboard from `user-stories.md`)
+- opens a PR `release/vM.m.p` → `master`
+
+### Step 2 — Merge the PR (manual)
+
+Wait for CI to be green, then merge the PR into `master` (merge commit).
+
+### Step 3 — Finalize the release
+
+```bash
+./release.sh finalize M.m.p
+```
+
+This:
+- creates and pushes the signed tag `vM.m.p` on `master`
+- opens a PR `master` → `develop` to bring the tag into `develop`'s history
+
+### Step 4 — Merge the back-merge PR (manual)
+
+Merge the `master` → `develop` PR (merge commit).
+
+The CI triggered by the tag handles the rest: version verification, build,
+CHANGELOG generation, and GitHub Release publication.

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# release.sh — processus de release semi-automatisé pour ysc::matrix
+#
+# Usage :
+#   ./release.sh prepare  M.m.p   — branche release, bump CMakeLists.txt, PR vers master
+#   ./release.sh finalize M.m.p   — tag signé sur master, PR back-merge vers develop
+
+set -euo pipefail
+
+die()         { echo "ERREUR: $*" >&2; exit 1; }
+require_cmd() { command -v "$1" &>/dev/null || die "commande manquante : $1"; }
+separator()   { echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"; }
+
+# ---------------------------------------------------------------------------
+# parse_version VERSION → sets MAJOR MINOR PATCH
+# ---------------------------------------------------------------------------
+parse_version() {
+    local v="$1"
+    [[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+        || die "format de version invalide : '$v' (attendu M.m.p)"
+    MAJOR=$(cut -d. -f1 <<<"$v")
+    MINOR=$(cut -d. -f2 <<<"$v")
+    PATCH=$(cut -d. -f3 <<<"$v")
+}
+
+# ---------------------------------------------------------------------------
+# check_clean_worktree — échoue si des modifications non commitées existent
+# ---------------------------------------------------------------------------
+check_clean_worktree() {
+    git diff --quiet && git diff --cached --quiet \
+        || die "modifications non commitées détectées — stashez ou commitez d'abord"
+}
+
+# ---------------------------------------------------------------------------
+# cmake_version → affiche la version lue dans CMakeLists.txt
+# ---------------------------------------------------------------------------
+cmake_version() {
+    local maj min pat
+    maj=$(grep -oP 'set\(VERSION_MAJOR\s+\K\d+' CMakeLists.txt)
+    min=$(grep -oP 'set\(VERSION_MINOR\s+\K\d+' CMakeLists.txt)
+    pat=$(grep -oP 'set\(VERSION_PATCH\s+\K\d+' CMakeLists.txt)
+    echo "${maj}.${min}.${pat}"
+}
+
+# ---------------------------------------------------------------------------
+# phase_prepare VERSION
+# ---------------------------------------------------------------------------
+phase_prepare() {
+    local version="$1"
+    parse_version "$version"
+    local tag="v${version}"
+    local branch="release/${tag}"
+
+    require_cmd git
+    require_cmd gh
+    check_clean_worktree
+
+    echo "==> Création de la branche ${branch}..."
+    git checkout -b "$branch"
+
+    echo "==> Mise à jour de CMakeLists.txt (${version})..."
+    sed -i -E "s/set\(VERSION_MAJOR[[:space:]]+[0-9]+/set(VERSION_MAJOR   ${MAJOR}/" CMakeLists.txt
+    sed -i -E "s/set\(VERSION_MINOR[[:space:]]+[0-9]+/set(VERSION_MINOR   ${MINOR}/" CMakeLists.txt
+    sed -i -E "s/set\(VERSION_PATCH[[:space:]]+[0-9]+/set(VERSION_PATCH   ${PATCH}/" CMakeLists.txt
+
+    local actual
+    actual=$(cmake_version)
+    [[ "$actual" == "$version" ]] \
+        || die "le bump a échoué : CMakeLists.txt affiche ${actual} au lieu de ${version}"
+
+    echo "==> Extraction du tableau de bord des épopées..."
+    local dashboard
+    dashboard=$(sed -n '/^## Vue par épopée/,/^## EPIC/{/^## EPIC/d; /^## Vue par/d; p}' user-stories.md)
+
+    echo "==> Commit..."
+    git add CMakeLists.txt
+    git commit -m "Release ${tag}" -m "${dashboard}"
+
+    echo "==> Push..."
+    git push -u origin "$branch"
+
+    echo "==> Ouverture de la PR vers master..."
+    local pr_url
+    pr_url=$(gh pr create \
+        --base master \
+        --title "Release ${tag}" \
+        --body "$(printf 'Release %s\n\n%s' "$tag" "$dashboard")")
+
+    separator
+    echo "  PR créée : ${pr_url}"
+    echo ""
+    echo "  Prochaines étapes (manuelles) :"
+    echo "  1. Attendre que la CI soit verte"
+    echo "  2. Merger la PR (merge commit) dans master"
+    echo "  3. Lancer : ./release.sh finalize ${version}"
+    separator
+}
+
+# ---------------------------------------------------------------------------
+# phase_finalize VERSION
+# ---------------------------------------------------------------------------
+phase_finalize() {
+    local version="$1"
+    parse_version "$version"
+    local tag="v${version}"
+
+    require_cmd git
+    require_cmd gh
+    check_clean_worktree
+
+    echo "==> Synchronisation de master..."
+    git fetch origin
+    git checkout master
+    git merge --ff-only origin/master
+
+    local actual
+    actual=$(cmake_version)
+    [[ "$actual" == "$version" ]] \
+        || die "master affiche la version ${actual} et non ${version} — la PR release est-elle mergée ?"
+
+    echo "==> Création du tag signé ${tag}..."
+    git tag -s -a "$tag" -m "Release ${tag}"
+    git push origin "$tag"
+
+    echo "==> Ouverture de la PR back-merge master → develop..."
+    local pr_url
+    pr_url=$(gh pr create \
+        --base develop \
+        --head master \
+        --title "chore: back-merge ${tag} into develop" \
+        --body "Back-merge after release ${tag} — récupère le tag dans l'historique de develop.")
+
+    separator
+    echo "  Tag ${tag} poussé."
+    echo "  PR back-merge créée : ${pr_url}"
+    echo ""
+    echo "  Dernière étape (manuelle) :"
+    echo "  1. Merger la PR back-merge dans develop"
+    separator
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+main() {
+    local phase="${1:-}" version="${2:-}"
+
+    if [[ -z "$phase" || -z "$version" ]]; then
+        echo "Usage: $0 prepare|finalize M.m.p" >&2
+        exit 1
+    fi
+
+    case "$phase" in
+        prepare)  phase_prepare  "$version" ;;
+        finalize) phase_finalize "$version" ;;
+        *) die "phase inconnue : '$phase' (prepare|finalize)" ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
Introduit un script semi-automatisé `release.sh` et met à jour la documentation du processus de release dans `CONTRIBUTING.md`.

## Ce qui change

- **`release.sh`** — deux sous-commandes :
  - `prepare M.m.p` : crée la branche `release/vM.m.p`, bumpe `CMakeLists.txt`, commite avec le tableau de bord des épopées de `user-stories.md` en message, push, ouvre la PR vers `master`
  - `finalize M.m.p` : vérifie que `master` a bien la bonne version, crée et pousse le tag signé (`git tag -s -a`), ouvre la PR back-merge `master` → `develop`
- **`CONTRIBUTING.md`** — remplace l'ancienne section "Releasing" (3 étapes manuelles) par le nouveau processus en 4 étapes documentant `prepare`, merge manuel, `finalize`, merge back-merge

## Ce qui reste manuel

- Merger la PR release dans `master` (après CI verte)
- Merger la PR back-merge dans `develop`

Le CI déclenché par le tag (`v*.*.*`) gère le reste : vérification de version, build, CHANGELOG, GitHub Release.