### PR TITLE
ci: enrichir les assets de la GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,11 +80,25 @@ jobs:
       - name: Generate CHANGELOG
         run: git cliff --tag "$GITHUB_REF_NAME" --output CHANGELOG.md
 
-      - name: Extract release notes
-        run: git cliff --tag "$GITHUB_REF_NAME" --unreleased --strip all --output release-notes.md
+      - name: Prepare release assets
+        run: |
+          gzip -c src/include/matrix.hpp > matrix.hpp.gz
+          cat > ysc-matrix.cmake <<EOF
+          include(FetchContent)
+          FetchContent_Declare(
+              ysc-matrix
+              GIT_REPOSITORY https://github.com/yscialom/matrix.git
+              GIT_TAG        ${GITHUB_REF_NAME}
+          )
+          FetchContent_MakeAvailable(ysc-matrix)
+          # Then in your target: target_link_libraries(your_target PRIVATE ysc::matrix)
+          EOF
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          body_path: release-notes.md
-          files: CHANGELOG.md
+          body_path: CHANGELOG.md
+          files: |
+            CHANGELOG.md
+            matrix.hpp.gz
+            ysc-matrix.cmake


### PR DESCRIPTION
## Résumé

Améliore le contenu de chaque GitHub Release automatique :

- **Description** : remplace les notes de version partielles par le `CHANGELOG.md` complet (généré par git-cliff pour toutes les versions).
- **`matrix.hpp.gz`** : le header compressé, pour une installation manuelle sans cloner le dépôt.
- **`ysc-matrix.cmake`** : snippet FetchContent prêt à l'emploi, avec le tag de la release substitué dynamiquement — l'utilisateur télécharge ce fichier et l'inclut dans son `CMakeLists.txt`.

## Plan de test

- [ ] Vérifier que la CI (`verify-version`, `build-and-test`) passe
- [ ] Vérifier à la prochaine release que la description contient bien le CHANGELOG complet
- [ ] Vérifier que `matrix.hpp.gz` est bien attaché et contient le bon header
- [ ] Vérifier que `ysc-matrix.cmake` contient le bon tag et un snippet FetchContent valide