### PR TITLE
Release v0.2.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,11 +80,25 @@ jobs:
       - name: Generate CHANGELOG
         run: git cliff --tag "$GITHUB_REF_NAME" --output CHANGELOG.md
 
-      - name: Extract release notes
-        run: git cliff --tag "$GITHUB_REF_NAME" --unreleased --strip all --output release-notes.md
+      - name: Prepare release assets
+        run: |
+          gzip -c src/include/matrix.hpp > matrix.hpp.gz
+          cat > ysc-matrix.cmake <<EOF
+          include(FetchContent)
+          FetchContent_Declare(
+              ysc-matrix
+              GIT_REPOSITORY https://github.com/yscialom/matrix.git
+              GIT_TAG        ${GITHUB_REF_NAME}
+          )
+          FetchContent_MakeAvailable(ysc-matrix)
+          # Then in your target: target_link_libraries(your_target PRIVATE ysc::matrix)
+          EOF
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          body_path: release-notes.md
-          files: CHANGELOG.md
+          body_path: CHANGELOG.md
+          files: |
+            CHANGELOG.md
+            matrix.hpp.gz
+            ysc-matrix.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(ysc-matrix)
 
 set(VERSION_MAJOR   0   CACHE STRING "Project major version number.")
 set(VERSION_MINOR   2   CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   3   CACHE STRING "Project patch version number.")
+set(VERSION_PATCH   4   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 


### PR DESCRIPTION
Release v0.2.4


| Épopée | Statut | Progression | Détail |
|--------|--------|-------------|--------|
| **A — Infrastructure & CI/CD** | ✅ Terminée | 7/7 | ✅ US-001, US-002, US-003, US-004, US-005, US-006, US-007 |
| **B — Modernisation C++20** | ✅ Terminée | 3/3 | ✅ US-008, US-009, US-010 (fusionné US-019) |
| **C — Dette technique** | ✅ Terminée | 4/4 | ✅ US-011, US-012, US-013, US-014 |
| **D — Conformité STL** | ✅ Terminée | 4/4 | ✅ US-015, US-016, US-017, US-018 |
| **E — Comparaison & I/O** | 🔶 Partielle | 5/7 | ✅ US-019, US-021, US-022, US-023, US-024 · ⬜ US-020, US-025 |
| **F — Arithmétique** | ⬜ Non démarrée | 0/4 | ⬜ US-026 à US-029 |
| **G — Algorithmes** | ⬜ Non démarrée | 0/5 | ⬜ US-030 à US-034 |
| **H — Vues & reshape** | ⬜ Non démarrée | 0/3 | ⬜ US-035 à US-037 |
| **I — Finition & release** | ⬜ Non démarrée | 0/6 | ⬜ US-038 à US-043 |

**Total : 22 / 43 US**