### PR TITLE
ci: exclure test/ du rapport Codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "test/**"


### PR DESCRIPTION
## Résumé

Le répertoire `test/` apparaissait dans le tableau de bord Codecov (338 lignes trackées), alors que seul `src/include/` devrait y figurer. Le filtre `lcov --remove '*/test/*'` dans le workflow CI n'était pas suffisant — Codecov scanne aussi le dépôt directement.

Ce PR ajoute un fichier `.codecov.yml` à la racine pour exclure explicitement `test/**` côté Codecov.

## Changements

- [x] Ajout de `.codecov.yml` avec `ignore: ["test/**"]`

## Effet attendu

Après merge, le rapport Codecov n'affichera plus que `src/include/` (la librairie), et le taux de couverture reflètera uniquement le code de production.