### PR TITLE
ci: désactiver les commentaires Codecov sur les PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,1 @@
-comment:
-  layout: "reach, diff, flags, files"
-  require_changes: true
-  require_base: true
-  require_head: true
+comment: false


### PR DESCRIPTION
## Résumé

Désactive les commentaires automatiques de Codecov sur les pull requests en remplaçant la section `comment` détaillée par `comment: false` dans `codecov.yml`.

Les rapports de couverture restent disponibles sur le tableau de bord Codecov, mais Codecov ne postera plus de commentaires sur les PRs.