### PR TITLE
US-025 — Spécialisation std::formatter pour ysc::matrix

### DIFF
--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -20,6 +20,10 @@
 #include <ostream>
 #include <stdexcept>
 #include <type_traits>
+#if __has_include(<format>)
+#include <format>
+#include <sstream>
+#endif
 
 namespace ysc {
 namespace detail {
@@ -586,5 +590,39 @@ std::ostream& operator<<(std::ostream& os, const matrix<T, Dims...>& m) {
 }
 
 } // namespace ysc
+
+#if defined(__cpp_lib_format) && __cpp_lib_format >= 201907L
+
+/**
+ * @brief Specialization of @c std::formatter for @c ysc::matrix.
+ * @tparam T     Element type — must be streamable via @c operator<<(std::ostream&, const T&)
+ * @tparam D     Dimensions of the matrix
+ * @tparam CharT Character type for the format context
+ *
+ * Enables `std::format("{}", m)` and produces the same nested-bracket output as
+ * `operator<<`: `[e0, e1, …]` for 1D, `[[e00, e01], [e10, e11]]` for 2D, and so on.
+ *
+ * Only available when the @c <format> library feature is present
+ * (@c __cpp_lib_format ≥ 201907L).
+ *
+ * @code
+ * ysc::matrix<int, 2, 2> m{1, 2, 3, 4};
+ * std::string s = std::format("{}", m);  // "[[1, 2], [3, 4]]"
+ * @endcode
+ *
+ * @ingroup ysc_io
+ */
+template <class T, std::size_t... D, class CharT>
+    requires ysc::detail::ostream_streamable<T>
+struct std::formatter<ysc::matrix<T, D...>, CharT> : std::formatter<std::string, CharT> {
+    template <class FormatContext>
+    auto format(const ysc::matrix<T, D...>& m, FormatContext& ctx) const {
+        std::ostringstream oss;
+        oss << m;
+        return std::formatter<std::string, CharT>::format(oss.str(), ctx);
+    }
+};
+
+#endif // defined(__cpp_lib_format) && __cpp_lib_format >= 201907L
 
 #endif // YSC_MATRIX_HPP

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -20,7 +20,8 @@
 #include <ostream>
 #include <stdexcept>
 #include <type_traits>
-#if __has_include(<format>)
+// Clang < 17 cannot compile libstdc++-14's <format> due to unicode.h incompatibility
+#if __has_include(<format>) && (!defined(__clang__) || __clang_major__ >= 17)
 #include <format>
 #include <sstream>
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(${TARGET_NAME}
     src/construct.cpp
     src/factories.cpp
     src/fill.cpp
+    src/formatter.cpp
     src/nested_init.cpp
     src/iterators.cpp
     src/ostream.cpp

--- a/test/src/formatter.cpp
+++ b/test/src/formatter.cpp
@@ -1,0 +1,40 @@
+#include <matrix.hpp>
+
+#include <gtest/gtest.h>
+
+#if defined(__cpp_lib_format) && __cpp_lib_format >= 201907L
+#include <format>
+
+TEST(formatter, format_1d) {
+    // Acceptance criterion from US-025: std::format("{}", matrix<int,2>{1,2}) → "[1, 2]"
+    ASSERT_EQ(std::format("{}", ysc::matrix<int, 2>{1, 2}), "[1, 2]");
+}
+
+TEST(formatter, format_2d) {
+    ASSERT_EQ(std::format("{}", ysc::matrix<int, 2, 2>{1, 2, 3, 4}), "[[1, 2], [3, 4]]");
+}
+
+TEST(formatter, format_3d) {
+    ysc::matrix<int, 2, 2, 2> m{1, 2, 3, 4, 5, 6, 7, 8};
+    ASSERT_EQ(std::format("{}", m), "[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]");
+}
+
+TEST(formatter, format_double) {
+    ysc::matrix<double, 2> m{1.5, 2.5};
+    ASSERT_EQ(std::format("{}", m), "[1.5, 2.5]");
+}
+
+TEST(formatter, matches_ostream) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    std::ostringstream oss;
+    oss << m;
+    ASSERT_EQ(std::format("{}", m), oss.str());
+}
+
+#else
+
+TEST(formatter, not_available) {
+    GTEST_SKIP() << "std::format not available on this compiler";
+}
+
+#endif // defined(__cpp_lib_format) && __cpp_lib_format >= 201907L

--- a/test/src/formatter.cpp
+++ b/test/src/formatter.cpp
@@ -4,6 +4,7 @@
 
 #if defined(__cpp_lib_format) && __cpp_lib_format >= 201907L
 #include <format>
+#include <sstream>
 
 TEST(formatter, format_1d) {
     // Acceptance criterion from US-025: std::format("{}", matrix<int,2>{1,2}) → "[1, 2]"

--- a/user-stories.md
+++ b/user-stories.md
@@ -8,13 +8,13 @@
 | **B — Modernisation C++20** | ✅ Terminée | 3/3 | ✅ US-008, US-009, US-010 (fusionné US-019) |
 | **C — Dette technique** | ✅ Terminée | 4/4 | ✅ US-011, US-012, US-013, US-014 |
 | **D — Conformité STL** | ✅ Terminée | 4/4 | ✅ US-015, US-016, US-017, US-018 |
-| **E — Comparaison & I/O** | 🔶 Partielle | 5/7 | ✅ US-019, US-021, US-022, US-023, US-024 · ⬜ US-020, US-025 |
+| **E — Comparaison & I/O** | 🔶 Partielle | 6/7 | ✅ US-019, US-021, US-022, US-023, US-024, US-025 · ⬜ US-020 |
 | **F — Arithmétique** | ⬜ Non démarrée | 0/4 | ⬜ US-026 à US-029 |
 | **G — Algorithmes** | ⬜ Non démarrée | 0/5 | ⬜ US-030 à US-034 |
 | **H — Vues & reshape** | ⬜ Non démarrée | 0/3 | ⬜ US-035 à US-037 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/6 | ⬜ US-038 à US-043 |
 
-**Total : 22 / 43 US**
+**Total : 23 / 43 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -682,8 +682,8 @@ struct std::formatter<ysc::matrix<T, D...>, CharT>;
 Permet `std::format("{}", m)`. Réutilise la logique de US-024.
 
 ### Critères d'acceptation
-- [ ] `std::format("{}", matrix<int,2>{1,2})` retourne `"[1, 2]"`
-- [ ] Si compilateur sans `<format>` complet (Apple Clang 14), guard `#if __cpp_lib_format >= 201907L`
+- [x] `std::format("{}", matrix<int,2>{1,2})` retourne `"[1, 2]"`
+- [x] Si compilateur sans `<format>` complet (Apple Clang 14), guard `#if __cpp_lib_format >= 201907L`
 
 ---
 


### PR DESCRIPTION
## Résumé

Ajout de la spécialisation `std::formatter<ysc::matrix<T, D...>, CharT>` dans `matrix.hpp`, permettant d'utiliser `std::format("{}", m)`. L'implémentation délègue à `std::formatter<std::string, CharT>` en capturant la sortie de `operator<<` via `std::ostringstream`, garantissant un format identique à US-024 (notation crochets imbriqués). La spécialisation est gardée par `#if defined(__cpp_lib_format) && __cpp_lib_format >= 201907L` pour les compilateurs sans `<format>` complet (Apple Clang 14).

## Critères d'acceptation

- [x] `std::format("{}", matrix<int,2>{1,2})` retourne `"[1, 2]"`
- [x] Guard `#if __cpp_lib_format >= 201907L` pour Apple Clang 14

## Tests

`test/src/formatter.cpp` — 5 cas : 1D, 2D, 3D, double, cohérence avec `operator<<`. Sur les compilateurs sans `<format>`, les tests sont sautés via `GTEST_SKIP()`.