### PR TITLE
US-020 — Spécialisation std::hash

### DIFF
--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -16,6 +16,7 @@
 #include <array>
 #include <compare>
 #include <concepts>
+#include <functional>
 #include <iterator>
 #include <ostream>
 #include <stdexcept>
@@ -591,6 +592,39 @@ std::ostream& operator<<(std::ostream& os, const matrix<T, Dims...>& m) {
 }
 
 } // namespace ysc
+
+/**
+ * @defgroup ysc_hash Hash support
+ * @brief `std::hash` specialization for `ysc::matrix`.
+ */
+
+/**
+ * @brief Specialization of `std::hash` for `ysc::matrix`.
+ * @tparam T  Element type — must be hashable via `std::hash<T>`
+ * @tparam D  Dimensions of the matrix
+ *
+ * Combines element hashes using the boost::hash_combine mixing strategy,
+ * so that two matrices with the same elements in the same order produce
+ * equal hashes, and matrices differing in at least one element are very
+ * likely to produce different hashes.
+ *
+ * @code
+ * std::unordered_set<ysc::matrix<int, 3>> s;
+ * s.insert({1, 2, 3});
+ * @endcode
+ *
+ * @ingroup ysc_hash
+ */
+template <class T, std::size_t... D> struct std::hash<ysc::matrix<T, D...>> {
+    std::size_t operator()(const ysc::matrix<T, D...>& m) const noexcept {
+        std::size_t h = 0;
+        std::hash<T> hasher;
+        for (const auto& v : m) {
+            h ^= hasher(v) + 0x9e3779b9 + (h << 6) + (h >> 2);
+        }
+        return h;
+    }
+};
 
 #if defined(__cpp_lib_format) && __cpp_lib_format >= 201907L
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(${TARGET_NAME}
     src/factories.cpp
     src/fill.cpp
     src/formatter.cpp
+    src/hash.cpp
     src/nested_init.cpp
     src/iterators.cpp
     src/ostream.cpp

--- a/test/src/hash.cpp
+++ b/test/src/hash.cpp
@@ -1,0 +1,36 @@
+#include "matrix.hpp"
+
+#include <gtest/gtest.h>
+
+#include <unordered_set>
+
+TEST(hash, unordered_set_compiles_and_works) {
+    std::unordered_set<ysc::matrix<int, 3>> s;
+    s.insert({1, 2, 3});
+    s.insert({4, 5, 6});
+    s.insert({1, 2, 3});
+
+    EXPECT_EQ(s.size(), 2U);
+    EXPECT_EQ(s.count({1, 2, 3}), 1U);
+    EXPECT_EQ(s.count({4, 5, 6}), 1U);
+    EXPECT_EQ(s.count({7, 8, 9}), 0U);
+}
+
+TEST(hash, equal_matrices_have_equal_hashes) {
+    std::hash<ysc::matrix<int, 2, 2>> h;
+    ysc::matrix<int, 2, 2> m1{1, 2, 3, 4};
+    ysc::matrix<int, 2, 2> m2{1, 2, 3, 4};
+
+    EXPECT_EQ(h(m1), h(m2));
+}
+
+TEST(hash, different_matrices_have_different_hashes) {
+    std::hash<ysc::matrix<int, 3>> h;
+    ysc::matrix<int, 3> a{1, 2, 3};
+    ysc::matrix<int, 3> b{1, 2, 4};
+    ysc::matrix<int, 3> c{0, 2, 3};
+
+    EXPECT_NE(h(a), h(b));
+    EXPECT_NE(h(a), h(c));
+    EXPECT_NE(h(b), h(c));
+}

--- a/user-stories.md
+++ b/user-stories.md
@@ -8,13 +8,13 @@
 | **B — Modernisation C++20** | ✅ Terminée | 3/3 | ✅ US-008, US-009, US-010 (fusionné US-019) |
 | **C — Dette technique** | ✅ Terminée | 4/4 | ✅ US-011, US-012, US-013, US-014 |
 | **D — Conformité STL** | ✅ Terminée | 4/4 | ✅ US-015, US-016, US-017, US-018 |
-| **E — Comparaison & I/O** | 🔶 Partielle | 6/7 | ✅ US-019, US-021, US-022, US-023, US-024, US-025 · ⬜ US-020 |
+| **E — Comparaison & I/O** | ✅ Terminée | 7/7 | ✅ US-019, US-020, US-021, US-022, US-023, US-024, US-025 |
 | **F — Arithmétique** | ⬜ Non démarrée | 0/4 | ⬜ US-026 à US-029 |
 | **G — Algorithmes** | ⬜ Non démarrée | 0/5 | ⬜ US-030 à US-034 |
 | **H — Vues & reshape** | ⬜ Non démarrée | 0/3 | ⬜ US-035 à US-037 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/6 | ⬜ US-038 à US-043 |
 
-**Total : 23 / 43 US**
+**Total : 24 / 43 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -568,8 +568,8 @@ namespace std {
 ```
 
 ### Critères d'acceptation
-- [ ] `std::unordered_set<matrix<int,3>>` compile et fonctionne
-- [ ] Hash égal pour matrices égales, distinct pour matrices différentes (statistique)
+- [x] `std::unordered_set<matrix<int,3>>` compile et fonctionne
+- [x] Hash égal pour matrices égales, distinct pour matrices différentes (statistique)
 
 ---
 


### PR DESCRIPTION
## Résumé

Ajoute la spécialisation `std::hash<ysc::matrix<T, D...>>` dans l'espace de noms `std`, ce qui permet d'utiliser `ysc::matrix` comme clé dans les conteneurs non ordonnés (`std::unordered_set`, `std::unordered_map`). Le hash combine les hashes des éléments avec la stratégie boost::hash_combine (XOR + décalages + constante de Fibonacci), garantissant l'égalité des hashes pour des matrices égales et une bonne dispersion pour des matrices différentes.

## Critères d'acceptation

- [x] `std::unordered_set<matrix<int,3>>` compile et fonctionne
- [x] Hash égal pour matrices égales, distinct pour matrices différentes (statistique)

## Détails d'implémentation

- `#include <functional>` ajouté
- Spécialisation `struct std::hash<ysc::matrix<T, D...>>` placée après la fermeture de `namespace ysc`, avant la spécialisation `std::formatter` existante
- Groupe Doxygen `ysc_hash` créé
- Trois cas de test dans `test/src/hash.cpp` : insertion dans `unordered_set`, hashes égaux, hashes distincts