### PR TITLE
Release v0.3.0

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "test/**"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.20)
 project(ysc-matrix)
 
 set(VERSION_MAJOR   0   CACHE STRING "Project major version number.")
-set(VERSION_MINOR   2   CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   4   CACHE STRING "Project patch version number.")
+set(VERSION_MINOR   3   CACHE STRING "Project minor version number.")
+set(VERSION_PATCH   0   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,1 @@
-comment:
-  layout: "reach, diff, flags, files"
-  require_changes: true
-  require_base: true
-  require_head: true
+comment: false

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -20,6 +20,11 @@
 #include <ostream>
 #include <stdexcept>
 #include <type_traits>
+// Clang < 17 cannot compile libstdc++-14's <format> due to unicode.h incompatibility
+#if __has_include(<format>) && (!defined(__clang__) || __clang_major__ >= 17)
+#include <format>
+#include <sstream>
+#endif
 
 namespace ysc {
 namespace detail {
@@ -586,5 +591,39 @@ std::ostream& operator<<(std::ostream& os, const matrix<T, Dims...>& m) {
 }
 
 } // namespace ysc
+
+#if defined(__cpp_lib_format) && __cpp_lib_format >= 201907L
+
+/**
+ * @brief Specialization of @c std::formatter for @c ysc::matrix.
+ * @tparam T     Element type — must be streamable via @c operator<<(std::ostream&, const T&)
+ * @tparam D     Dimensions of the matrix
+ * @tparam CharT Character type for the format context
+ *
+ * Enables `std::format("{}", m)` and produces the same nested-bracket output as
+ * `operator<<`: `[e0, e1, …]` for 1D, `[[e00, e01], [e10, e11]]` for 2D, and so on.
+ *
+ * Only available when the @c <format> library feature is present
+ * (@c __cpp_lib_format ≥ 201907L).
+ *
+ * @code
+ * ysc::matrix<int, 2, 2> m{1, 2, 3, 4};
+ * std::string s = std::format("{}", m);  // "[[1, 2], [3, 4]]"
+ * @endcode
+ *
+ * @ingroup ysc_io
+ */
+template <class T, std::size_t... D, class CharT>
+    requires ysc::detail::ostream_streamable<T>
+struct std::formatter<ysc::matrix<T, D...>, CharT> : std::formatter<std::string, CharT> {
+    template <class FormatContext>
+    auto format(const ysc::matrix<T, D...>& m, FormatContext& ctx) const {
+        std::ostringstream oss;
+        oss << m;
+        return std::formatter<std::string, CharT>::format(oss.str(), ctx);
+    }
+};
+
+#endif // defined(__cpp_lib_format) && __cpp_lib_format >= 201907L
 
 #endif // YSC_MATRIX_HPP

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -16,6 +16,7 @@
 #include <array>
 #include <compare>
 #include <concepts>
+#include <functional>
 #include <iterator>
 #include <ostream>
 #include <stdexcept>
@@ -591,6 +592,39 @@ std::ostream& operator<<(std::ostream& os, const matrix<T, Dims...>& m) {
 }
 
 } // namespace ysc
+
+/**
+ * @defgroup ysc_hash Hash support
+ * @brief `std::hash` specialization for `ysc::matrix`.
+ */
+
+/**
+ * @brief Specialization of `std::hash` for `ysc::matrix`.
+ * @tparam T  Element type — must be hashable via `std::hash<T>`
+ * @tparam D  Dimensions of the matrix
+ *
+ * Combines element hashes using the boost::hash_combine mixing strategy,
+ * so that two matrices with the same elements in the same order produce
+ * equal hashes, and matrices differing in at least one element are very
+ * likely to produce different hashes.
+ *
+ * @code
+ * std::unordered_set<ysc::matrix<int, 3>> s;
+ * s.insert({1, 2, 3});
+ * @endcode
+ *
+ * @ingroup ysc_hash
+ */
+template <class T, std::size_t... D> struct std::hash<ysc::matrix<T, D...>> {
+    std::size_t operator()(const ysc::matrix<T, D...>& m) const noexcept {
+        std::size_t h = 0;
+        std::hash<T> hasher;
+        for (const auto& v : m) {
+            h ^= hasher(v) + 0x9e3779b9 + (h << 6) + (h >> 2);
+        }
+        return h;
+    }
+};
 
 #if defined(__cpp_lib_format) && __cpp_lib_format >= 201907L
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(${TARGET_NAME}
     src/factories.cpp
     src/fill.cpp
     src/formatter.cpp
+    src/hash.cpp
     src/nested_init.cpp
     src/iterators.cpp
     src/ostream.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(${TARGET_NAME}
     src/construct.cpp
     src/factories.cpp
     src/fill.cpp
+    src/formatter.cpp
     src/nested_init.cpp
     src/iterators.cpp
     src/ostream.cpp

--- a/test/src/formatter.cpp
+++ b/test/src/formatter.cpp
@@ -1,0 +1,41 @@
+#include <matrix.hpp>
+
+#include <gtest/gtest.h>
+
+#if defined(__cpp_lib_format) && __cpp_lib_format >= 201907L
+#include <format>
+#include <sstream>
+
+TEST(formatter, format_1d) {
+    // Acceptance criterion from US-025: std::format("{}", matrix<int,2>{1,2}) → "[1, 2]"
+    ASSERT_EQ(std::format("{}", ysc::matrix<int, 2>{1, 2}), "[1, 2]");
+}
+
+TEST(formatter, format_2d) {
+    ASSERT_EQ(std::format("{}", ysc::matrix<int, 2, 2>{1, 2, 3, 4}), "[[1, 2], [3, 4]]");
+}
+
+TEST(formatter, format_3d) {
+    ysc::matrix<int, 2, 2, 2> m{1, 2, 3, 4, 5, 6, 7, 8};
+    ASSERT_EQ(std::format("{}", m), "[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]");
+}
+
+TEST(formatter, format_double) {
+    ysc::matrix<double, 2> m{1.5, 2.5};
+    ASSERT_EQ(std::format("{}", m), "[1.5, 2.5]");
+}
+
+TEST(formatter, matches_ostream) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    std::ostringstream oss;
+    oss << m;
+    ASSERT_EQ(std::format("{}", m), oss.str());
+}
+
+#else
+
+TEST(formatter, not_available) {
+    GTEST_SKIP() << "std::format not available on this compiler";
+}
+
+#endif // defined(__cpp_lib_format) && __cpp_lib_format >= 201907L

--- a/test/src/hash.cpp
+++ b/test/src/hash.cpp
@@ -1,0 +1,36 @@
+#include "matrix.hpp"
+
+#include <gtest/gtest.h>
+
+#include <unordered_set>
+
+TEST(hash, unordered_set_compiles_and_works) {
+    std::unordered_set<ysc::matrix<int, 3>> s;
+    s.insert({1, 2, 3});
+    s.insert({4, 5, 6});
+    s.insert({1, 2, 3});
+
+    EXPECT_EQ(s.size(), 2U);
+    EXPECT_EQ(s.count({1, 2, 3}), 1U);
+    EXPECT_EQ(s.count({4, 5, 6}), 1U);
+    EXPECT_EQ(s.count({7, 8, 9}), 0U);
+}
+
+TEST(hash, equal_matrices_have_equal_hashes) {
+    std::hash<ysc::matrix<int, 2, 2>> h;
+    ysc::matrix<int, 2, 2> m1{1, 2, 3, 4};
+    ysc::matrix<int, 2, 2> m2{1, 2, 3, 4};
+
+    EXPECT_EQ(h(m1), h(m2));
+}
+
+TEST(hash, different_matrices_have_different_hashes) {
+    std::hash<ysc::matrix<int, 3>> h;
+    ysc::matrix<int, 3> a{1, 2, 3};
+    ysc::matrix<int, 3> b{1, 2, 4};
+    ysc::matrix<int, 3> c{0, 2, 3};
+
+    EXPECT_NE(h(a), h(b));
+    EXPECT_NE(h(a), h(c));
+    EXPECT_NE(h(b), h(c));
+}

--- a/user-stories.md
+++ b/user-stories.md
@@ -8,13 +8,13 @@
 | **B — Modernisation C++20** | ✅ Terminée | 3/3 | ✅ US-008, US-009, US-010 (fusionné US-019) |
 | **C — Dette technique** | ✅ Terminée | 4/4 | ✅ US-011, US-012, US-013, US-014 |
 | **D — Conformité STL** | ✅ Terminée | 4/4 | ✅ US-015, US-016, US-017, US-018 |
-| **E — Comparaison & I/O** | 🔶 Partielle | 6/7 | ✅ US-019, US-021, US-022, US-023, US-024, US-025 · ⬜ US-020 |
+| **E — Comparaison & I/O** | ✅ Terminée | 7/7 | ✅ US-019, US-020, US-021, US-022, US-023, US-024, US-025 |
 | **F — Arithmétique** | ⬜ Non démarrée | 0/4 | ⬜ US-026 à US-029 |
 | **G — Algorithmes** | ⬜ Non démarrée | 0/5 | ⬜ US-030 à US-034 |
 | **H — Vues & reshape** | ⬜ Non démarrée | 0/3 | ⬜ US-035 à US-037 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/6 | ⬜ US-038 à US-043 |
 
-**Total : 23 / 43 US**
+**Total : 24 / 43 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -568,8 +568,8 @@ namespace std {
 ```
 
 ### Critères d'acceptation
-- [ ] `std::unordered_set<matrix<int,3>>` compile et fonctionne
-- [ ] Hash égal pour matrices égales, distinct pour matrices différentes (statistique)
+- [x] `std::unordered_set<matrix<int,3>>` compile et fonctionne
+- [x] Hash égal pour matrices égales, distinct pour matrices différentes (statistique)
 
 ---
 

--- a/user-stories.md
+++ b/user-stories.md
@@ -8,13 +8,13 @@
 | **B — Modernisation C++20** | ✅ Terminée | 3/3 | ✅ US-008, US-009, US-010 (fusionné US-019) |
 | **C — Dette technique** | ✅ Terminée | 4/4 | ✅ US-011, US-012, US-013, US-014 |
 | **D — Conformité STL** | ✅ Terminée | 4/4 | ✅ US-015, US-016, US-017, US-018 |
-| **E — Comparaison & I/O** | 🔶 Partielle | 5/7 | ✅ US-019, US-021, US-022, US-023, US-024 · ⬜ US-020, US-025 |
+| **E — Comparaison & I/O** | 🔶 Partielle | 6/7 | ✅ US-019, US-021, US-022, US-023, US-024, US-025 · ⬜ US-020 |
 | **F — Arithmétique** | ⬜ Non démarrée | 0/4 | ⬜ US-026 à US-029 |
 | **G — Algorithmes** | ⬜ Non démarrée | 0/5 | ⬜ US-030 à US-034 |
 | **H — Vues & reshape** | ⬜ Non démarrée | 0/3 | ⬜ US-035 à US-037 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/6 | ⬜ US-038 à US-043 |
 
-**Total : 22 / 43 US**
+**Total : 23 / 43 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -682,8 +682,8 @@ struct std::formatter<ysc::matrix<T, D...>, CharT>;
 Permet `std::format("{}", m)`. Réutilise la logique de US-024.
 
 ### Critères d'acceptation
-- [ ] `std::format("{}", matrix<int,2>{1,2})` retourne `"[1, 2]"`
-- [ ] Si compilateur sans `<format>` complet (Apple Clang 14), guard `#if __cpp_lib_format >= 201907L`
+- [x] `std::format("{}", matrix<int,2>{1,2})` retourne `"[1, 2]"`
+- [x] Si compilateur sans `<format>` complet (Apple Clang 14), guard `#if __cpp_lib_format >= 201907L`
 
 ---
 


### PR DESCRIPTION
Release v0.3.0


| Épopée | Statut | Progression | Détail |
|--------|--------|-------------|--------|
| **A — Infrastructure & CI/CD** | ✅ Terminée | 7/7 | ✅ US-001, US-002, US-003, US-004, US-005, US-006, US-007 |
| **B — Modernisation C++20** | ✅ Terminée | 3/3 | ✅ US-008, US-009, US-010 (fusionné US-019) |
| **C — Dette technique** | ✅ Terminée | 4/4 | ✅ US-011, US-012, US-013, US-014 |
| **D — Conformité STL** | ✅ Terminée | 4/4 | ✅ US-015, US-016, US-017, US-018 |
| **E — Comparaison & I/O** | ✅ Terminée | 7/7 | ✅ US-019, US-020, US-021, US-022, US-023, US-024, US-025 |
| **F — Arithmétique** | ⬜ Non démarrée | 0/4 | ⬜ US-026 à US-029 |
| **G — Algorithmes** | ⬜ Non démarrée | 0/5 | ⬜ US-030 à US-034 |
| **H — Vues & reshape** | ⬜ Non démarrée | 0/3 | ⬜ US-035 à US-037 |
| **I — Finition & release** | ⬜ Non démarrée | 0/6 | ⬜ US-038 à US-043 |

**Total : 24 / 43 US**