### PR TITLE
US-028 + US-029 — Arithmétique scalaire et opérateurs unaires

### DIFF
--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -568,6 +568,233 @@ public:
         return lhs /= rhs;
     }
 
+    // scalar arithmetic operators
+    /**
+     * @brief Multiplies every element of this matrix by scalar @a s and assigns the result.
+     * @tparam Scalar Scalar type — must support compound assignment: `T a; a *= Scalar`
+     * @param  s      Scalar multiplier
+     * @return @c *this
+     *
+     * @code
+     * ysc::matrix<int, 3> m{1, 2, 3};
+     * m *= 2;  // m == ysc::matrix<int, 3>{2, 4, 6}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    template <class Scalar>
+    matrix& operator*=(const Scalar& s)
+        requires requires(T a, const Scalar& b) { a *= b; }
+    {
+        std::transform(_data.begin(), _data.end(), _data.begin(),
+                       [&s](T a) -> T { return a *= s; });
+        return *this;
+    }
+
+    /**
+     * @brief Divides every element of this matrix by scalar @a s and assigns the result.
+     * @tparam Scalar Scalar type — must support compound assignment: `T a; a /= Scalar`
+     * @param  s      Scalar divisor
+     * @return @c *this
+     *
+     * @code
+     * ysc::matrix<int, 3> m{6, 4, 2};
+     * m /= 2;  // m == ysc::matrix<int, 3>{3, 2, 1}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    template <class Scalar>
+    matrix& operator/=(const Scalar& s)
+        requires requires(T a, const Scalar& b) { a /= b; }
+    {
+        std::transform(_data.begin(), _data.end(), _data.begin(),
+                       [&s](T a) -> T { return a /= s; });
+        return *this;
+    }
+
+    /**
+     * @brief Adds scalar @a s to every element of this matrix and assigns the result.
+     * @tparam Scalar Scalar type — must support compound assignment: `T a; a += Scalar`
+     * @param  s      Scalar addend
+     * @return @c *this
+     *
+     * @code
+     * ysc::matrix<int, 3> m{1, 2, 3};
+     * m += 10;  // m == ysc::matrix<int, 3>{11, 12, 13}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    template <class Scalar>
+    matrix& operator+=(const Scalar& s)
+        requires requires(T a, const Scalar& b) { a += b; }
+    {
+        std::transform(_data.begin(), _data.end(), _data.begin(),
+                       [&s](T a) -> T { return a += s; });
+        return *this;
+    }
+
+    /**
+     * @brief Subtracts scalar @a s from every element of this matrix and assigns the result.
+     * @tparam Scalar Scalar type — must support compound assignment: `T a; a -= Scalar`
+     * @param  s      Scalar subtrahend
+     * @return @c *this
+     *
+     * @code
+     * ysc::matrix<int, 3> m{11, 12, 13};
+     * m -= 10;  // m == ysc::matrix<int, 3>{1, 2, 3}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    template <class Scalar>
+    matrix& operator-=(const Scalar& s)
+        requires requires(T a, const Scalar& b) { a -= b; }
+    {
+        std::transform(_data.begin(), _data.end(), _data.begin(),
+                       [&s](T a) -> T { return a -= s; });
+        return *this;
+    }
+
+    /**
+     * @brief Returns the element-wise product of a matrix and a scalar.
+     * @tparam Scalar Scalar type — must support compound assignment: `T a; a *= Scalar`
+     * @param  lhs    Matrix operand
+     * @param  s      Scalar multiplier
+     * @return New matrix with each element multiplied by @a s
+     *
+     * @code
+     * ysc::matrix<int, 3> m{1, 2, 3};
+     * auto r = m * 2;  // r == ysc::matrix<int, 3>{2, 4, 6}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    template <class Scalar>
+    [[nodiscard]] friend matrix operator*(matrix lhs, const Scalar& s)
+        requires requires(T a, const Scalar& b) { a *= b; }
+    {
+        return lhs *= s;
+    }
+
+    /**
+     * @brief Returns the element-wise product of a scalar and a matrix (commutative).
+     * @tparam Scalar Scalar type — must support compound assignment: `T a; a *= Scalar`
+     * @param  s      Scalar multiplier
+     * @param  rhs    Matrix operand
+     * @return New matrix with each element multiplied by @a s
+     *
+     * @code
+     * ysc::matrix<int, 3> m{1, 2, 3};
+     * auto r = 2 * m;  // r == ysc::matrix<int, 3>{2, 4, 6}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    template <class Scalar>
+    [[nodiscard]] friend matrix operator*(const Scalar& s, matrix rhs)
+        requires requires(T a, const Scalar& b) { a *= b; }
+    {
+        return rhs *= s;
+    }
+
+    /**
+     * @brief Returns a new matrix with every element divided by scalar @a s.
+     * @tparam Scalar Scalar type — must support compound assignment: `T a; a /= Scalar`
+     * @param  lhs    Matrix operand
+     * @param  s      Scalar divisor
+     * @return New matrix with each element divided by @a s
+     *
+     * @code
+     * ysc::matrix<int, 3> m{6, 4, 2};
+     * auto r = m / 2;  // r == ysc::matrix<int, 3>{3, 2, 1}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    template <class Scalar>
+    [[nodiscard]] friend matrix operator/(matrix lhs, const Scalar& s)
+        requires requires(T a, const Scalar& b) { a /= b; }
+    {
+        return lhs /= s;
+    }
+
+    /**
+     * @brief Returns a new matrix with scalar @a s added to every element.
+     * @tparam Scalar Scalar type — must support compound assignment: `T a; a += Scalar`
+     * @param  lhs    Matrix operand
+     * @param  s      Scalar addend
+     * @return New matrix with @a s added to each element
+     *
+     * @code
+     * ysc::matrix<int, 3> m{1, 2, 3};
+     * auto r = m + 10;  // r == ysc::matrix<int, 3>{11, 12, 13}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    template <class Scalar>
+    [[nodiscard]] friend matrix operator+(matrix lhs, const Scalar& s)
+        requires requires(T a, const Scalar& b) { a += b; }
+    {
+        return lhs += s;
+    }
+
+    /**
+     * @brief Returns a new matrix with scalar @a s subtracted from every element.
+     * @tparam Scalar Scalar type — must support compound assignment: `T a; a -= Scalar`
+     * @param  lhs    Matrix operand
+     * @param  s      Scalar subtrahend
+     * @return New matrix with @a s subtracted from each element
+     *
+     * @code
+     * ysc::matrix<int, 3> m{11, 12, 13};
+     * auto r = m - 10;  // r == ysc::matrix<int, 3>{1, 2, 3}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    template <class Scalar>
+    [[nodiscard]] friend matrix operator-(matrix lhs, const Scalar& s)
+        requires requires(T a, const Scalar& b) { a -= b; }
+    {
+        return lhs -= s;
+    }
+
+    // unary arithmetic operators
+    /**
+     * @brief Returns a copy of the matrix (unary plus).
+     * @return Copy of @c *this, unchanged
+     *
+     * @code
+     * ysc::matrix<int, 3> m{1, 2, 3};
+     * auto r = +m;  // r == m
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    [[nodiscard]] matrix operator+() const { return *this; }
+
+    /**
+     * @brief Returns a matrix with all elements negated (unary minus).
+     * @return New matrix where each element @c e is replaced by @c -e
+     *
+     * @code
+     * ysc::matrix<int, 3> m{1, -2, 3};
+     * auto r = -m;  // r == ysc::matrix<int, 3>{-1, 2, -3}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    [[nodiscard]] matrix operator-() const
+        requires requires(const T& a) { -a; }
+    {
+        matrix result(zero);
+        std::transform(cbegin(), cend(), result.begin(), [](const T& a) -> T { return -a; });
+        return result;
+    }
+
     // modifiers
     /**
      * @brief Assigns the given value to all elements of the matrix.

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -400,6 +400,174 @@ public:
     /** @brief Three-way comparison — lexicographic on the flat row-major storage. */
     friend auto operator<=>(const matrix& lhs, const matrix& rhs) = default;
 
+    // arithmetic operators
+    /**
+     * @defgroup ysc_arithmetic Arithmetic operators
+     * @brief Element-wise arithmetic operations on @c ysc::matrix.
+     */
+
+    /**
+     * @brief Adds @a other to this matrix element-wise and assigns the result.
+     * @param other Matrix to add
+     * @return @c *this
+     *
+     * @code
+     * ysc::matrix<int, 2> a{1, 2}, b{3, 4};
+     * a += b;  // a == ysc::matrix<int, 2>{4, 6}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    matrix& operator+=(const matrix& other)
+        requires requires(T a, const T& b) { a += b; }
+    {
+        std::transform(_data.begin(), _data.end(), other._data.cbegin(), _data.begin(),
+                       [](T a, const T& b) -> T { return a += b; });
+        return *this;
+    }
+
+    /**
+     * @brief Subtracts @a other from this matrix element-wise and assigns the result.
+     * @param other Matrix to subtract
+     * @return @c *this
+     *
+     * @code
+     * ysc::matrix<int, 2> a{5, 6}, b{1, 2};
+     * a -= b;  // a == ysc::matrix<int, 2>{4, 4}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    matrix& operator-=(const matrix& other)
+        requires requires(T a, const T& b) { a -= b; }
+    {
+        std::transform(_data.begin(), _data.end(), other._data.cbegin(), _data.begin(),
+                       [](T a, const T& b) -> T { return a -= b; });
+        return *this;
+    }
+
+    /**
+     * @brief Returns the element-wise sum of two matrices.
+     * @param lhs Left-hand matrix
+     * @param rhs Right-hand matrix
+     * @return New matrix containing element-wise sums
+     *
+     * @code
+     * ysc::matrix<int, 2> a{1, 2}, b{3, 4};
+     * auto c = a + b;  // c == ysc::matrix<int, 2>{4, 6}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    [[nodiscard]] friend matrix operator+(matrix lhs, const matrix& rhs)
+        requires requires(T a, const T& b) { a += b; }
+    {
+        return lhs += rhs;
+    }
+
+    /**
+     * @brief Returns the element-wise difference of two matrices.
+     * @param lhs Left-hand matrix
+     * @param rhs Right-hand matrix
+     * @return New matrix containing element-wise differences
+     *
+     * @code
+     * ysc::matrix<int, 2> a{5, 6}, b{1, 2};
+     * auto c = a - b;  // c == ysc::matrix<int, 2>{4, 4}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    [[nodiscard]] friend matrix operator-(matrix lhs, const matrix& rhs)
+        requires requires(T a, const T& b) { a -= b; }
+    {
+        return lhs -= rhs;
+    }
+
+    /**
+     * @brief Multiplies this matrix by @a other element-wise (Hadamard product) and assigns.
+     * @param other Matrix to multiply by
+     * @return @c *this
+     *
+     * @note This is the Hadamard (element-wise) product, not the matrix product.
+     *       The matrix product will be available as @c ysc::matmul.
+     *
+     * @code
+     * ysc::matrix<int, 2> a{2, 3}, b{4, 5};
+     * a *= b;  // a == ysc::matrix<int, 2>{8, 15}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    matrix& operator*=(const matrix& other)
+        requires requires(T a, const T& b) { a *= b; }
+    {
+        std::transform(_data.begin(), _data.end(), other._data.cbegin(), _data.begin(),
+                       [](T a, const T& b) -> T { return a *= b; });
+        return *this;
+    }
+
+    /**
+     * @brief Divides this matrix by @a other element-wise and assigns the result.
+     * @param other Divisor matrix
+     * @return @c *this
+     *
+     * @code
+     * ysc::matrix<int, 2> a{6, 8}, b{2, 4};
+     * a /= b;  // a == ysc::matrix<int, 2>{3, 2}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    matrix& operator/=(const matrix& other)
+        requires requires(T a, const T& b) { a /= b; }
+    {
+        std::transform(_data.begin(), _data.end(), other._data.cbegin(), _data.begin(),
+                       [](T a, const T& b) -> T { return a /= b; });
+        return *this;
+    }
+
+    /**
+     * @brief Returns the element-wise (Hadamard) product of two matrices.
+     * @param lhs Left-hand matrix
+     * @param rhs Right-hand matrix
+     * @return New matrix containing element-wise products
+     *
+     * @note This is the Hadamard (element-wise) product, not the matrix product.
+     *       The matrix product will be available as @c ysc::matmul.
+     *
+     * @code
+     * ysc::matrix<int, 2> a{2, 3}, b{4, 5};
+     * auto c = a * b;  // c == ysc::matrix<int, 2>{8, 15}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    [[nodiscard]] friend matrix operator*(matrix lhs, const matrix& rhs)
+        requires requires(T a, const T& b) { a *= b; }
+    {
+        return lhs *= rhs;
+    }
+
+    /**
+     * @brief Returns the element-wise quotient of two matrices.
+     * @param lhs Left-hand matrix (dividend)
+     * @param rhs Right-hand matrix (divisor)
+     * @return New matrix containing element-wise quotients
+     *
+     * @code
+     * ysc::matrix<int, 2> a{6, 8}, b{2, 4};
+     * auto c = a / b;  // c == ysc::matrix<int, 2>{3, 2}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    [[nodiscard]] friend matrix operator/(matrix lhs, const matrix& rhs)
+        requires requires(T a, const T& b) { a /= b; }
+    {
+        return lhs /= rhs;
+    }
+
     // modifiers
     /**
      * @brief Assigns the given value to all elements of the matrix.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,8 @@ add_executable(${TARGET_NAME}
     src/accessors.cpp
     src/arithmetic_elementwise.cpp
     src/arithmetic_hadamard.cpp
+    src/arithmetic_scalar.cpp
+    src/arithmetic_unary.cpp
     src/assignment_returns_self.cpp
     src/comparison.cpp
     src/concepts.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,8 @@ set(TARGET_NAME matrix-test)
 add_executable(${TARGET_NAME}
     src/access.cpp
     src/accessors.cpp
+    src/arithmetic_elementwise.cpp
+    src/arithmetic_hadamard.cpp
     src/assignment_returns_self.cpp
     src/comparison.cpp
     src/concepts.cpp

--- a/test/src/arithmetic_elementwise.cpp
+++ b/test/src/arithmetic_elementwise.cpp
@@ -1,0 +1,136 @@
+#include <matrix.hpp>
+
+#include <gtest/gtest.h>
+
+//
+// --- ADDITION ---
+//
+
+TEST(arithmetic_add, compound_add_correct_values) {
+    ysc::matrix<int, 3> a{1, 2, 3};
+    const ysc::matrix<int, 3> b{10, 20, 30};
+    a += b;
+    ASSERT_EQ(a, (ysc::matrix<int, 3>{11, 22, 33}));
+}
+
+TEST(arithmetic_add, compound_add_returns_self) {
+    ysc::matrix<int, 2> a{1, 2};
+    const ysc::matrix<int, 2> b{3, 4};
+    ysc::matrix<int, 2>& ref = (a += b);
+    ASSERT_EQ(&ref, &a);
+}
+
+TEST(arithmetic_add, compound_add_does_not_modify_rhs) {
+    ysc::matrix<int, 2> a{1, 2};
+    const ysc::matrix<int, 2> b{3, 4};
+    const ysc::matrix<int, 2> b_copy = b;
+    a += b;
+    ASSERT_EQ(b, b_copy);
+}
+
+TEST(arithmetic_add, binary_plus_correct_values) {
+    const ysc::matrix<int, 3> a{1, 2, 3};
+    const ysc::matrix<int, 3> b{10, 20, 30};
+    const auto c = a + b;
+    ASSERT_EQ(c, (ysc::matrix<int, 3>{11, 22, 33}));
+}
+
+TEST(arithmetic_add, binary_plus_does_not_modify_operands) {
+    const ysc::matrix<int, 2> a{1, 2};
+    const ysc::matrix<int, 2> b{3, 4};
+    const auto c = a + b;
+    ASSERT_EQ(c, (ysc::matrix<int, 2>{4, 6}));
+    ASSERT_EQ(a, (ysc::matrix<int, 2>{1, 2}));
+    ASSERT_EQ(b, (ysc::matrix<int, 2>{3, 4}));
+}
+
+TEST(arithmetic_add, add_float) {
+    ysc::matrix<double, 2> a{1.5, 2.5};
+    a += ysc::matrix<double, 2>{0.5, 0.5};
+    ASSERT_DOUBLE_EQ(a(0), 2.0);
+    ASSERT_DOUBLE_EQ(a(1), 3.0);
+}
+
+TEST(arithmetic_add, add_2d_matrix) {
+    ysc::matrix<int, 2, 2> a{1, 2, 3, 4};
+    const ysc::matrix<int, 2, 2> b{5, 6, 7, 8};
+    const auto c = a + b;
+    ASSERT_EQ(c, (ysc::matrix<int, 2, 2>{6, 8, 10, 12}));
+}
+
+//
+// --- SUBTRACTION ---
+//
+
+TEST(arithmetic_sub, compound_sub_correct_values) {
+    ysc::matrix<int, 3> a{10, 20, 30};
+    const ysc::matrix<int, 3> b{1, 2, 3};
+    a -= b;
+    ASSERT_EQ(a, (ysc::matrix<int, 3>{9, 18, 27}));
+}
+
+TEST(arithmetic_sub, compound_sub_returns_self) {
+    ysc::matrix<int, 2> a{5, 6};
+    const ysc::matrix<int, 2> b{1, 2};
+    ysc::matrix<int, 2>& ref = (a -= b);
+    ASSERT_EQ(&ref, &a);
+}
+
+TEST(arithmetic_sub, compound_sub_does_not_modify_rhs) {
+    ysc::matrix<int, 2> a{5, 6};
+    const ysc::matrix<int, 2> b{1, 2};
+    const ysc::matrix<int, 2> b_copy = b;
+    a -= b;
+    ASSERT_EQ(b, b_copy);
+}
+
+TEST(arithmetic_sub, binary_minus_correct_values) {
+    const ysc::matrix<int, 3> a{10, 20, 30};
+    const ysc::matrix<int, 3> b{1, 2, 3};
+    const auto c = a - b;
+    ASSERT_EQ(c, (ysc::matrix<int, 3>{9, 18, 27}));
+}
+
+TEST(arithmetic_sub, binary_minus_does_not_modify_operands) {
+    const ysc::matrix<int, 2> a{5, 6};
+    const ysc::matrix<int, 2> b{1, 2};
+    const auto c = a - b;
+    ASSERT_EQ(c, (ysc::matrix<int, 2>{4, 4}));
+    ASSERT_EQ(a, (ysc::matrix<int, 2>{5, 6}));
+    ASSERT_EQ(b, (ysc::matrix<int, 2>{1, 2}));
+}
+
+//
+// --- COMPILE-TIME CONSTRAINTS ---
+//
+
+struct no_arithmetic {
+    int val;
+    bool operator==(const no_arithmetic&) const = default;
+};
+
+// Helper concepts — GCC does not support bare requires-expressions in static_assert
+// when all candidates are constrained out (same workaround as in concepts.cpp).
+template <class M>
+concept matrix_add_assignable = requires(M& a, const M& b) { a += b; };
+template <class M>
+concept matrix_addable = requires(const M& a, const M& b) { a + b; };
+template <class M>
+concept matrix_sub_assignable = requires(M& a, const M& b) { a -= b; };
+template <class M>
+concept matrix_subtractable = requires(const M& a, const M& b) { a - b; };
+
+static_assert(!matrix_add_assignable<ysc::matrix<no_arithmetic, 2>>);
+static_assert(!matrix_addable<ysc::matrix<no_arithmetic, 2>>);
+static_assert(!matrix_sub_assignable<ysc::matrix<no_arithmetic, 2>>);
+static_assert(!matrix_subtractable<ysc::matrix<no_arithmetic, 2>>);
+
+static_assert(matrix_add_assignable<ysc::matrix<int, 2>>);
+static_assert(matrix_addable<ysc::matrix<int, 2>>);
+static_assert(matrix_sub_assignable<ysc::matrix<int, 2>>);
+static_assert(matrix_subtractable<ysc::matrix<int, 2>>);
+
+TEST(arithmetic_elementwise, concept_constraints_checked_at_compile_time) {
+    // Runtime witness that the static_asserts above were checked.
+    SUCCEED();
+}

--- a/test/src/arithmetic_elementwise.cpp
+++ b/test/src/arithmetic_elementwise.cpp
@@ -111,24 +111,17 @@ struct no_arithmetic {
 
 // Helper concepts — GCC does not support bare requires-expressions in static_assert
 // when all candidates are constrained out (same workaround as in concepts.cpp).
+// Note: operator+ and operator- delegate to +=/−=, so testing += and -= is sufficient.
 template <class M>
 concept matrix_add_assignable = requires(M& a, const M& b) { a += b; };
 template <class M>
-concept matrix_addable = requires(const M& a, const M& b) { a + b; };
-template <class M>
 concept matrix_sub_assignable = requires(M& a, const M& b) { a -= b; };
-template <class M>
-concept matrix_subtractable = requires(const M& a, const M& b) { a - b; };
 
 static_assert(!matrix_add_assignable<ysc::matrix<no_arithmetic, 2>>);
-static_assert(!matrix_addable<ysc::matrix<no_arithmetic, 2>>);
 static_assert(!matrix_sub_assignable<ysc::matrix<no_arithmetic, 2>>);
-static_assert(!matrix_subtractable<ysc::matrix<no_arithmetic, 2>>);
 
 static_assert(matrix_add_assignable<ysc::matrix<int, 2>>);
-static_assert(matrix_addable<ysc::matrix<int, 2>>);
 static_assert(matrix_sub_assignable<ysc::matrix<int, 2>>);
-static_assert(matrix_subtractable<ysc::matrix<int, 2>>);
 
 TEST(arithmetic_elementwise, concept_constraints_checked_at_compile_time) {
     // Runtime witness that the static_asserts above were checked.

--- a/test/src/arithmetic_hadamard.cpp
+++ b/test/src/arithmetic_hadamard.cpp
@@ -112,24 +112,17 @@ struct no_mul {
 
 // Helper concepts — GCC does not support bare requires-expressions in static_assert
 // when all candidates are constrained out (same workaround as in concepts.cpp).
+// Note: operator* and operator/ delegate to *=/=/=, so testing *= and /= is sufficient.
 template <class M>
 concept matrix_mul_assignable = requires(M& a, const M& b) { a *= b; };
 template <class M>
-concept matrix_multipliable = requires(const M& a, const M& b) { a * b; };
-template <class M>
 concept matrix_div_assignable = requires(M& a, const M& b) { a /= b; };
-template <class M>
-concept matrix_divisible = requires(const M& a, const M& b) { a / b; };
 
 static_assert(!matrix_mul_assignable<ysc::matrix<no_mul, 2>>);
-static_assert(!matrix_multipliable<ysc::matrix<no_mul, 2>>);
 static_assert(!matrix_div_assignable<ysc::matrix<no_mul, 2>>);
-static_assert(!matrix_divisible<ysc::matrix<no_mul, 2>>);
 
 static_assert(matrix_mul_assignable<ysc::matrix<int, 2>>);
-static_assert(matrix_multipliable<ysc::matrix<int, 2>>);
 static_assert(matrix_div_assignable<ysc::matrix<int, 2>>);
-static_assert(matrix_divisible<ysc::matrix<int, 2>>);
 
 TEST(arithmetic_hadamard, concept_constraints_checked_at_compile_time) {
     // Runtime witness that the static_asserts above were checked.

--- a/test/src/arithmetic_hadamard.cpp
+++ b/test/src/arithmetic_hadamard.cpp
@@ -1,0 +1,137 @@
+#include <matrix.hpp>
+
+#include <gtest/gtest.h>
+
+//
+// --- HADAMARD PRODUCT (element-wise *) ---
+//
+
+TEST(arithmetic_hadamard, compound_mul_correct_values) {
+    ysc::matrix<int, 3> a{2, 3, 4};
+    const ysc::matrix<int, 3> b{5, 6, 7};
+    a *= b;
+    ASSERT_EQ(a, (ysc::matrix<int, 3>{10, 18, 28}));
+}
+
+TEST(arithmetic_hadamard, compound_mul_returns_self) {
+    ysc::matrix<int, 2> a{2, 3};
+    const ysc::matrix<int, 2> b{4, 5};
+    ysc::matrix<int, 2>& ref = (a *= b);
+    ASSERT_EQ(&ref, &a);
+}
+
+TEST(arithmetic_hadamard, compound_mul_does_not_modify_rhs) {
+    ysc::matrix<int, 2> a{2, 3};
+    const ysc::matrix<int, 2> b{4, 5};
+    const ysc::matrix<int, 2> b_copy = b;
+    a *= b;
+    ASSERT_EQ(b, b_copy);
+}
+
+TEST(arithmetic_hadamard, binary_mul_correct_values) {
+    const ysc::matrix<int, 3> a{2, 3, 4};
+    const ysc::matrix<int, 3> b{5, 6, 7};
+    const auto c = a * b;
+    ASSERT_EQ(c, (ysc::matrix<int, 3>{10, 18, 28}));
+}
+
+TEST(arithmetic_hadamard, binary_mul_does_not_modify_operands) {
+    const ysc::matrix<int, 2> a{2, 3};
+    const ysc::matrix<int, 2> b{4, 5};
+    const auto c = a * b;
+    ASSERT_EQ(c, (ysc::matrix<int, 2>{8, 15}));
+    ASSERT_EQ(a, (ysc::matrix<int, 2>{2, 3}));
+    ASSERT_EQ(b, (ysc::matrix<int, 2>{4, 5}));
+}
+
+TEST(arithmetic_hadamard, mul_float) {
+    const ysc::matrix<double, 2> a{1.5, 2.0};
+    const ysc::matrix<double, 2> b{2.0, 3.0};
+    const auto c = a * b;
+    ASSERT_DOUBLE_EQ(c(0), 3.0);
+    ASSERT_DOUBLE_EQ(c(1), 6.0);
+}
+
+TEST(arithmetic_hadamard, mul_2d_matrix) {
+    const ysc::matrix<int, 2, 2> a{1, 2, 3, 4};
+    const ysc::matrix<int, 2, 2> b{5, 6, 7, 8};
+    const auto c = a * b;
+    ASSERT_EQ(c, (ysc::matrix<int, 2, 2>{5, 12, 21, 32}));
+}
+
+//
+// --- ELEMENT-WISE DIVISION ---
+//
+
+TEST(arithmetic_hadamard, compound_div_correct_values) {
+    ysc::matrix<int, 3> a{10, 18, 28};
+    const ysc::matrix<int, 3> b{2, 3, 4};
+    a /= b;
+    ASSERT_EQ(a, (ysc::matrix<int, 3>{5, 6, 7}));
+}
+
+TEST(arithmetic_hadamard, compound_div_returns_self) {
+    ysc::matrix<int, 2> a{6, 8};
+    const ysc::matrix<int, 2> b{2, 4};
+    ysc::matrix<int, 2>& ref = (a /= b);
+    ASSERT_EQ(&ref, &a);
+}
+
+TEST(arithmetic_hadamard, compound_div_does_not_modify_rhs) {
+    ysc::matrix<int, 2> a{6, 8};
+    const ysc::matrix<int, 2> b{2, 4};
+    const ysc::matrix<int, 2> b_copy = b;
+    a /= b;
+    ASSERT_EQ(b, b_copy);
+}
+
+TEST(arithmetic_hadamard, binary_div_correct_values) {
+    const ysc::matrix<int, 3> a{10, 18, 28};
+    const ysc::matrix<int, 3> b{2, 3, 4};
+    const auto c = a / b;
+    ASSERT_EQ(c, (ysc::matrix<int, 3>{5, 6, 7}));
+}
+
+TEST(arithmetic_hadamard, binary_div_does_not_modify_operands) {
+    const ysc::matrix<int, 2> a{6, 8};
+    const ysc::matrix<int, 2> b{2, 4};
+    const auto c = a / b;
+    ASSERT_EQ(c, (ysc::matrix<int, 2>{3, 2}));
+    ASSERT_EQ(a, (ysc::matrix<int, 2>{6, 8}));
+    ASSERT_EQ(b, (ysc::matrix<int, 2>{2, 4}));
+}
+
+//
+// --- COMPILE-TIME CONSTRAINTS ---
+//
+
+struct no_mul {
+    int val;
+    bool operator==(const no_mul&) const = default;
+};
+
+// Helper concepts — GCC does not support bare requires-expressions in static_assert
+// when all candidates are constrained out (same workaround as in concepts.cpp).
+template <class M>
+concept matrix_mul_assignable = requires(M& a, const M& b) { a *= b; };
+template <class M>
+concept matrix_multipliable = requires(const M& a, const M& b) { a * b; };
+template <class M>
+concept matrix_div_assignable = requires(M& a, const M& b) { a /= b; };
+template <class M>
+concept matrix_divisible = requires(const M& a, const M& b) { a / b; };
+
+static_assert(!matrix_mul_assignable<ysc::matrix<no_mul, 2>>);
+static_assert(!matrix_multipliable<ysc::matrix<no_mul, 2>>);
+static_assert(!matrix_div_assignable<ysc::matrix<no_mul, 2>>);
+static_assert(!matrix_divisible<ysc::matrix<no_mul, 2>>);
+
+static_assert(matrix_mul_assignable<ysc::matrix<int, 2>>);
+static_assert(matrix_multipliable<ysc::matrix<int, 2>>);
+static_assert(matrix_div_assignable<ysc::matrix<int, 2>>);
+static_assert(matrix_divisible<ysc::matrix<int, 2>>);
+
+TEST(arithmetic_hadamard, concept_constraints_checked_at_compile_time) {
+    // Runtime witness that the static_asserts above were checked.
+    SUCCEED();
+}

--- a/test/src/arithmetic_scalar.cpp
+++ b/test/src/arithmetic_scalar.cpp
@@ -1,0 +1,178 @@
+#include <matrix.hpp>
+
+#include <gtest/gtest.h>
+
+//
+// --- SCALAR MULTIPLICATION ---
+//
+
+TEST(arithmetic_scalar_mul, compound_mul_correct_values) {
+    ysc::matrix<int, 3> m{1, 2, 3};
+    m *= 2;
+    ASSERT_EQ(m, (ysc::matrix<int, 3>{2, 4, 6}));
+}
+
+TEST(arithmetic_scalar_mul, compound_mul_returns_self) {
+    ysc::matrix<int, 2> m{1, 2};
+    ysc::matrix<int, 2>& ref = (m *= 3);
+    ASSERT_EQ(&ref, &m);
+}
+
+TEST(arithmetic_scalar_mul, binary_matrix_times_scalar) {
+    const ysc::matrix<int, 3> m{1, 2, 3};
+    const auto result = m * 2;
+    ASSERT_EQ(result, (ysc::matrix<int, 3>{2, 4, 6}));
+}
+
+TEST(arithmetic_scalar_mul, binary_scalar_times_matrix) {
+    const ysc::matrix<int, 3> m{1, 2, 3};
+    const auto result = 2 * m;
+    ASSERT_EQ(result, (ysc::matrix<int, 3>{2, 4, 6}));
+}
+
+TEST(arithmetic_scalar_mul, binary_commutativity) {
+    const ysc::matrix<int, 2> m{3, 4};
+    ASSERT_EQ(m * 5, 5 * m);
+}
+
+TEST(arithmetic_scalar_mul, binary_does_not_modify_operands) {
+    const ysc::matrix<int, 2> m{3, 4};
+    const auto result = m * 5;
+    ASSERT_EQ(result, (ysc::matrix<int, 2>{15, 20}));
+    ASSERT_EQ(m, (ysc::matrix<int, 2>{3, 4}));
+}
+
+TEST(arithmetic_scalar_mul, float_scalar) {
+    ysc::matrix<double, 2> m{1.0, 2.0};
+    m *= 1.5;
+    ASSERT_DOUBLE_EQ(m(0), 1.5);
+    ASSERT_DOUBLE_EQ(m(1), 3.0);
+}
+
+TEST(arithmetic_scalar_mul, mul_2d_matrix) {
+    const ysc::matrix<int, 2, 2> m{1, 2, 3, 4};
+    const auto result = m * 3;
+    ASSERT_EQ(result, (ysc::matrix<int, 2, 2>{3, 6, 9, 12}));
+}
+
+//
+// --- SCALAR DIVISION ---
+//
+
+TEST(arithmetic_scalar_div, compound_div_correct_values) {
+    ysc::matrix<int, 3> m{6, 8, 10};
+    m /= 2;
+    ASSERT_EQ(m, (ysc::matrix<int, 3>{3, 4, 5}));
+}
+
+TEST(arithmetic_scalar_div, compound_div_returns_self) {
+    ysc::matrix<int, 2> m{6, 8};
+    ysc::matrix<int, 2>& ref = (m /= 2);
+    ASSERT_EQ(&ref, &m);
+}
+
+TEST(arithmetic_scalar_div, binary_div_correct_values) {
+    const ysc::matrix<int, 3> m{6, 8, 10};
+    const auto result = m / 2;
+    ASSERT_EQ(result, (ysc::matrix<int, 3>{3, 4, 5}));
+}
+
+TEST(arithmetic_scalar_div, binary_does_not_modify_operands) {
+    const ysc::matrix<int, 2> m{6, 8};
+    const auto result = m / 2;
+    ASSERT_EQ(result, (ysc::matrix<int, 2>{3, 4}));
+    ASSERT_EQ(m, (ysc::matrix<int, 2>{6, 8}));
+}
+
+//
+// --- SCALAR ADDITION ---
+//
+
+TEST(arithmetic_scalar_add, compound_add_correct_values) {
+    ysc::matrix<int, 3> m{1, 2, 3};
+    m += 10;
+    ASSERT_EQ(m, (ysc::matrix<int, 3>{11, 12, 13}));
+}
+
+TEST(arithmetic_scalar_add, compound_add_returns_self) {
+    ysc::matrix<int, 2> m{1, 2};
+    ysc::matrix<int, 2>& ref = (m += 5);
+    ASSERT_EQ(&ref, &m);
+}
+
+TEST(arithmetic_scalar_add, binary_add_correct_values) {
+    const ysc::matrix<int, 3> m{1, 2, 3};
+    const auto result = m + 10;
+    ASSERT_EQ(result, (ysc::matrix<int, 3>{11, 12, 13}));
+}
+
+TEST(arithmetic_scalar_add, binary_does_not_modify_operands) {
+    const ysc::matrix<int, 2> m{1, 2};
+    const auto result = m + 5;
+    ASSERT_EQ(result, (ysc::matrix<int, 2>{6, 7}));
+    ASSERT_EQ(m, (ysc::matrix<int, 2>{1, 2}));
+}
+
+//
+// --- SCALAR SUBTRACTION ---
+//
+
+TEST(arithmetic_scalar_sub, compound_sub_correct_values) {
+    ysc::matrix<int, 3> m{11, 12, 13};
+    m -= 10;
+    ASSERT_EQ(m, (ysc::matrix<int, 3>{1, 2, 3}));
+}
+
+TEST(arithmetic_scalar_sub, compound_sub_returns_self) {
+    ysc::matrix<int, 2> m{5, 6};
+    ysc::matrix<int, 2>& ref = (m -= 3);
+    ASSERT_EQ(&ref, &m);
+}
+
+TEST(arithmetic_scalar_sub, binary_sub_correct_values) {
+    const ysc::matrix<int, 3> m{11, 12, 13};
+    const auto result = m - 10;
+    ASSERT_EQ(result, (ysc::matrix<int, 3>{1, 2, 3}));
+}
+
+TEST(arithmetic_scalar_sub, binary_does_not_modify_operands) {
+    const ysc::matrix<int, 2> m{5, 6};
+    const auto result = m - 3;
+    ASSERT_EQ(result, (ysc::matrix<int, 2>{2, 3}));
+    ASSERT_EQ(m, (ysc::matrix<int, 2>{5, 6}));
+}
+
+//
+// --- COMPILE-TIME CONSTRAINTS ---
+//
+
+struct no_scalar_arithmetic {
+    int val;
+    bool operator==(const no_scalar_arithmetic&) const = default;
+};
+
+// Helper concepts — GCC does not support bare requires-expressions in static_assert
+// when all candidates are constrained out (same workaround as in concepts.cpp).
+template <class M, class S>
+concept matrix_scalar_mul_assignable = requires(M& m, const S& s) { m *= s; };
+template <class M, class S>
+concept matrix_scalar_div_assignable = requires(M& m, const S& s) { m /= s; };
+template <class M, class S>
+concept matrix_scalar_add_assignable = requires(M& m, const S& s) { m += s; };
+template <class M, class S>
+concept matrix_scalar_sub_assignable = requires(M& m, const S& s) { m -= s; };
+
+static_assert(!matrix_scalar_mul_assignable<ysc::matrix<no_scalar_arithmetic, 2>, int>);
+static_assert(!matrix_scalar_div_assignable<ysc::matrix<no_scalar_arithmetic, 2>, int>);
+static_assert(!matrix_scalar_add_assignable<ysc::matrix<no_scalar_arithmetic, 2>, int>);
+static_assert(!matrix_scalar_sub_assignable<ysc::matrix<no_scalar_arithmetic, 2>, int>);
+
+static_assert(matrix_scalar_mul_assignable<ysc::matrix<int, 2>, int>);
+static_assert(matrix_scalar_div_assignable<ysc::matrix<int, 2>, int>);
+static_assert(matrix_scalar_add_assignable<ysc::matrix<int, 2>, int>);
+static_assert(matrix_scalar_sub_assignable<ysc::matrix<int, 2>, int>);
+
+TEST(arithmetic_scalar, concept_constraints_checked_at_compile_time) {
+    // Runtime witness that the static_asserts above were checked.
+    SUCCEED();
+}

--- a/test/src/arithmetic_unary.cpp
+++ b/test/src/arithmetic_unary.cpp
@@ -1,0 +1,64 @@
+#include <matrix.hpp>
+
+#include <gtest/gtest.h>
+
+//
+// --- UNARY PLUS ---
+//
+
+TEST(arithmetic_unary, unary_plus_equal_to_original) {
+    const ysc::matrix<int, 3> m{1, 2, 3};
+    ASSERT_EQ(+m, m);
+}
+
+TEST(arithmetic_unary, unary_plus_does_not_modify_operand) {
+    const ysc::matrix<int, 2> m{5, 6};
+    const auto result = +m;
+    ASSERT_EQ(m, (ysc::matrix<int, 2>{5, 6}));
+    (void)result;
+}
+
+TEST(arithmetic_unary, unary_plus_returns_copy) {
+    ysc::matrix<int, 2> m{1, 2};
+    const auto& result = +m;
+    ASSERT_NE(&result, &m);
+}
+
+//
+// --- UNARY MINUS ---
+//
+
+TEST(arithmetic_unary, unary_minus_negates_elements) {
+    const ysc::matrix<int, 3> m{1, -2, 3};
+    const auto result = -m;
+    ASSERT_EQ(result, (ysc::matrix<int, 3>{-1, 2, -3}));
+}
+
+TEST(arithmetic_unary, unary_minus_all_positive) {
+    const ysc::matrix<int, 3> m{1, 2, 3};
+    ASSERT_EQ(-m, (ysc::matrix<int, 3>{-1, -2, -3}));
+}
+
+TEST(arithmetic_unary, unary_minus_does_not_modify_operand) {
+    const ysc::matrix<int, 2> m{3, 4};
+    const auto result = -m;
+    ASSERT_EQ(result, (ysc::matrix<int, 2>{-3, -4}));
+    ASSERT_EQ(m, (ysc::matrix<int, 2>{3, 4}));
+}
+
+TEST(arithmetic_unary, unary_minus_double) {
+    const ysc::matrix<double, 2> m{1.5, -2.5};
+    const auto result = -m;
+    ASSERT_DOUBLE_EQ(result(0), -1.5);
+    ASSERT_DOUBLE_EQ(result(1), 2.5);
+}
+
+TEST(arithmetic_unary, double_negation_equals_original) {
+    const ysc::matrix<int, 3> m{1, 2, 3};
+    ASSERT_EQ(-(-m), m);
+}
+
+TEST(arithmetic_unary, unary_minus_2d_matrix) {
+    const ysc::matrix<int, 2, 2> m{1, -2, 3, -4};
+    ASSERT_EQ(-m, (ysc::matrix<int, 2, 2>{-1, 2, -3, 4}));
+}

--- a/user-stories.md
+++ b/user-stories.md
@@ -9,12 +9,12 @@
 | **C — Dette technique** | ✅ Terminée | 4/4 | ✅ US-011, US-012, US-013, US-014 |
 | **D — Conformité STL** | ✅ Terminée | 4/4 | ✅ US-015, US-016, US-017, US-018 |
 | **E — Comparaison & I/O** | ✅ Terminée | 7/7 | ✅ US-019, US-020, US-021, US-022, US-023, US-024, US-025 |
-| **F — Arithmétique** | 🔄 En cours | 2/4 | ✅ US-026, ✅ US-027, ⬜ US-028, ⬜ US-029 |
+| **F — Arithmétique** | ✅ Terminée | 4/4 | ✅ US-026, ✅ US-027, ✅ US-028, ✅ US-029 |
 | **G — Algorithmes** | ⬜ Non démarrée | 0/5 | ⬜ US-030 à US-034 |
 | **H — Vues & reshape** | ⬜ Non démarrée | 0/3 | ⬜ US-035 à US-037 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/6 | ⬜ US-038 à US-043 |
 
-**Total : 26 / 43 US**
+**Total : 28 / 43 US**
 
 ## EPIC A — Infrastructure & CI/CD
 

--- a/user-stories.md
+++ b/user-stories.md
@@ -9,12 +9,12 @@
 | **C — Dette technique** | ✅ Terminée | 4/4 | ✅ US-011, US-012, US-013, US-014 |
 | **D — Conformité STL** | ✅ Terminée | 4/4 | ✅ US-015, US-016, US-017, US-018 |
 | **E — Comparaison & I/O** | ✅ Terminée | 7/7 | ✅ US-019, US-020, US-021, US-022, US-023, US-024, US-025 |
-| **F — Arithmétique** | ⬜ Non démarrée | 0/4 | ⬜ US-026 à US-029 |
+| **F — Arithmétique** | 🔄 En cours | 2/4 | ✅ US-026, ✅ US-027, ⬜ US-028, ⬜ US-029 |
 | **G — Algorithmes** | ⬜ Non démarrée | 0/5 | ⬜ US-030 à US-034 |
 | **H — Vues & reshape** | ⬜ Non démarrée | 0/3 | ⬜ US-035 à US-037 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/6 | ⬜ US-038 à US-043 |
 
-**Total : 24 / 43 US**
+**Total : 26 / 43 US**
 
 ## EPIC A — Infrastructure & CI/CD
 


### PR DESCRIPTION
## Résumé

Cette PR implémente les deux dernières US de l'EPIC F (Arithmétique) :
- **US-028** : opérateurs scalaires composés (`*=`, `/=`, `+=`, `-=` avec un `Scalar` template) et leurs variantes binaires friend ; `*` est commutatif (`m * 2` et `2 * m`). Les contraintes `requires(T a, const Scalar& b) { a OP= b; }` désambiguïsent naturellement avec les opérateurs matrice-matrice existants (contrainte non satisfaite pour les types élémentaires quand Scalar = matrix).
- **US-029** : `operator+()` (retourne une copie) et `operator-()` (négation élément-par-élément, contrainte `requires(const T& a) { -a; }`).

EPIC F est désormais terminée (4/4).

## Critères d'acceptation

### US-028
- [x] `m * 2`, `2 * m`, `m / 2` fonctionnent
- [x] `m += 2`, `m -= 10`, `m /= 2` fonctionnent
- [x] Tests dans `test/src/arithmetic_scalar.cpp`

### US-029
- [x] `-m` retourne une matrice avec éléments négatifs
- [x] `+m == m`
- [x] Tests dans `test/src/arithmetic_unary.cpp`

### DoD transverse
- [x] Build et tests verts (`cmake --build build --target check`)
- [x] Aucun avertissement clang-format
- [x] Aucun avertissement clang-tidy
- [x] Toutes les nouvelles fonctions publiques documentées Doxygen avec `@brief`, `@tparam`, `@param`, `@return`, `@code`…`@endcode`, `@ingroup ysc_arithmetic`

## Notes d'implémentation

- Les contraintes sur les scalaires éliminent automatiquement la surcharge scalaire quand on passe une matrice (ex. `int` n'a pas `operator+=(matrix<int,N>)`), donc aucune ambiguïté avec les opérateurs Hadamard.
- `operator-()` initialise `result` avec `matrix(zero)` pour éviter tout accès à de la mémoire non initialisée.