### PR TITLE
US-030 — apply() et map() (algorithmes élément-par-élément)

### DIFF
--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -795,6 +795,60 @@ public:
         return result;
     }
 
+    // algorithms
+    /**
+     * @defgroup ysc_algorithms Algorithms
+     * @brief Element-wise functional algorithms on @c ysc::matrix.
+     */
+
+    /**
+     * @brief Applies a function to every element in place.
+     * @tparam F Callable type — must accept `T&`
+     * @param  f Function to apply to each element
+     *
+     * Visits every element in row-major order and calls @a f with a reference to the element.
+     * @a f may modify the element; the matrix is mutated in place.
+     *
+     * @code
+     * ysc::matrix<int, 3> m{1, 2, 3};
+     * m.apply([](int& v) { v *= 2; });
+     * // m == ysc::matrix<int, 3>{2, 4, 6}
+     * @endcode
+     *
+     * @ingroup ysc_algorithms
+     */
+    template <std::invocable<T&> F>
+    void apply(F f) {
+        for (T& v : _data) {
+            std::invoke(f, v);
+        }
+    }
+
+    /**
+     * @brief Returns a new matrix obtained by applying a function to every element.
+     * @tparam F  Callable type — must accept `const T&`
+     * @param  f  Function to apply to each element
+     * @return A new matrix whose element type is `std::invoke_result_t<F, const T&>`
+     *         and whose dimensions are identical to @c *this.
+     *
+     * Does not modify the original matrix.
+     *
+     * @code
+     * ysc::matrix<int, 3> m{1, 2, 3};
+     * auto s = m.map([](int v) { return std::to_string(v); });
+     * // s is ysc::matrix<std::string, 3>{"1", "2", "3"}
+     * @endcode
+     *
+     * @ingroup ysc_algorithms
+     */
+    template <std::invocable<const T&> F>
+    [[nodiscard]] auto map(F f) const -> matrix<std::invoke_result_t<F, const T&>, Dimensions...> {
+        matrix<std::invoke_result_t<F, const T&>, Dimensions...> result(zero);
+        std::transform(_data.cbegin(), _data.cend(), result.begin(),
+                       [&f](const T& v) { return std::invoke(f, v); });
+        return result;
+    }
+
     // modifiers
     /**
      * @brief Assigns the given value to all elements of the matrix.

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -803,7 +803,7 @@ public:
 
     /**
      * @brief Applies a function to every element in place.
-     * @tparam F Callable type — must accept `T&`
+     * @tparam F Callable type — must satisfy `std::invocable<F, T&>`
      * @param  f Function to apply to each element
      *
      * Visits every element in row-major order and calls @a f with a reference to the element.
@@ -817,7 +817,8 @@ public:
      *
      * @ingroup ysc_algorithms
      */
-    template <std::invocable<T&> F>
+    template <class F>
+        requires std::invocable<F, T&>
     void apply(F f) {
         for (T& v : _data) {
             std::invoke(f, v);
@@ -826,7 +827,7 @@ public:
 
     /**
      * @brief Returns a new matrix obtained by applying a function to every element.
-     * @tparam F  Callable type — must accept `const T&`
+     * @tparam F  Callable type — must satisfy `std::invocable<F, const T&>`
      * @param  f  Function to apply to each element
      * @return A new matrix whose element type is `std::invoke_result_t<F, const T&>`
      *         and whose dimensions are identical to @c *this.
@@ -841,7 +842,8 @@ public:
      *
      * @ingroup ysc_algorithms
      */
-    template <std::invocable<const T&> F>
+    template <class F>
+        requires std::invocable<F, const T&>
     [[nodiscard]] auto map(F f) const -> matrix<std::invoke_result_t<F, const T&>, Dimensions...> {
         matrix<std::invoke_result_t<F, const T&>, Dimensions...> result(zero);
         std::transform(_data.cbegin(), _data.cend(), result.begin(),

--- a/test/src/algorithms.cpp
+++ b/test/src/algorithms.cpp
@@ -1,0 +1,82 @@
+#include "matrix.hpp"
+#include <gtest/gtest.h>
+#include <string>
+
+// --- apply ---
+
+TEST(MatrixApply, MutatesElementsInPlace) {
+    ysc::matrix<int, 3> m{1, 2, 3};
+    m.apply([](int& v) { v *= 2; });
+    EXPECT_EQ(m, (ysc::matrix<int, 3>{2, 4, 6}));
+}
+
+TEST(MatrixApply, DoesNotModifyOtherElements) {
+    ysc::matrix<int, 2, 2> m{1, 2, 3, 4};
+    ysc::matrix<int, 2, 2> original = m;
+    m.apply([](int& v) { v += 10; });
+    for (std::size_t i = 0; i < 2; ++i) {
+        for (std::size_t j = 0; j < 2; ++j) {
+            EXPECT_EQ(m(i, j), original(i, j) + 10);
+        }
+    }
+}
+
+TEST(MatrixApply, WorksOnFloatMatrix) {
+    ysc::matrix<double, 3> m{1.0, 2.0, 3.0};
+    m.apply([](double& v) { v = v * v; });
+    EXPECT_DOUBLE_EQ(m(0), 1.0);
+    EXPECT_DOUBLE_EQ(m(1), 4.0);
+    EXPECT_DOUBLE_EQ(m(2), 9.0);
+}
+
+TEST(MatrixApply, RowMajorOrderIsRespected) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    int counter = 0;
+    m.apply([&counter](int& v) { v = counter++; });
+    EXPECT_EQ(m(0, 0), 0);
+    EXPECT_EQ(m(0, 1), 1);
+    EXPECT_EQ(m(0, 2), 2);
+    EXPECT_EQ(m(1, 0), 3);
+    EXPECT_EQ(m(1, 1), 4);
+    EXPECT_EQ(m(1, 2), 5);
+}
+
+// --- map ---
+
+TEST(MatrixMap, ReturnsSameTypeMatrix) {
+    ysc::matrix<int, 3> m{1, 2, 3};
+    auto result = m.map([](int v) { return v * 2; });
+    EXPECT_EQ(result, (ysc::matrix<int, 3>{2, 4, 6}));
+}
+
+TEST(MatrixMap, DoesNotMutateOriginal) {
+    ysc::matrix<int, 3> m{1, 2, 3};
+    ysc::matrix<int, 3> original = m;
+    auto result = m.map([](int v) { return v * 10; });
+    EXPECT_EQ(m, original);
+    (void)result;
+}
+
+TEST(MatrixMap, ReturnsDifferentTypeMatrix) {
+    ysc::matrix<int, 3> m{1, 2, 3};
+    auto result = m.map([](int v) { return std::to_string(v); });
+    static_assert(std::is_same_v<decltype(result), ysc::matrix<std::string, 3>>);
+    EXPECT_EQ(result(0), "1");
+    EXPECT_EQ(result(1), "2");
+    EXPECT_EQ(result(2), "3");
+}
+
+TEST(MatrixMap, WorksOn2DMatrix) {
+    ysc::matrix<int, 2, 2> m{1, 2, 3, 4};
+    auto result = m.map([](int v) { return v + 10; });
+    EXPECT_EQ(result, (ysc::matrix<int, 2, 2>{11, 12, 13, 14}));
+}
+
+TEST(MatrixMap, WorksWithFloatToDouble) {
+    ysc::matrix<float, 3> m{1.0f, 2.0f, 3.0f};
+    auto result = m.map([](float v) -> double { return static_cast<double>(v) * 0.5; });
+    static_assert(std::is_same_v<decltype(result), ysc::matrix<double, 3>>);
+    EXPECT_DOUBLE_EQ(result(0), 0.5);
+    EXPECT_DOUBLE_EQ(result(1), 1.0);
+    EXPECT_DOUBLE_EQ(result(2), 1.5);
+}

--- a/user-stories.md
+++ b/user-stories.md
@@ -10,11 +10,11 @@
 | **D — Conformité STL** | ✅ Terminée | 4/4 | ✅ US-015, US-016, US-017, US-018 |
 | **E — Comparaison & I/O** | ✅ Terminée | 7/7 | ✅ US-019, US-020, US-021, US-022, US-023, US-024, US-025 |
 | **F — Arithmétique** | ✅ Terminée | 4/4 | ✅ US-026, ✅ US-027, ✅ US-028, ✅ US-029 |
-| **G — Algorithmes** | ⬜ Non démarrée | 0/5 | ⬜ US-030 à US-034 |
+| **G — Algorithmes** | 🔄 En cours | 1/5 | ✅ US-030, ⬜ US-031 à US-034 |
 | **H — Vues & reshape** | ⬜ Non démarrée | 0/3 | ⬜ US-035 à US-037 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/6 | ⬜ US-038 à US-043 |
 
-**Total : 28 / 43 US**
+**Total : 29 / 43 US**
 
 ## EPIC A — Infrastructure & CI/CD
 


### PR DESCRIPTION
## Résumé

Implémentation de US-030 : deux méthodes membres `apply()` et `map()` dans `ysc::matrix`, formant la base de l'EPIC G (Algorithmes).

## Acceptance criteria

- [x] `m.apply([](int& v){ v *= 2; })` mute `m` en place
- [x] `m.map([](int v){ return std::to_string(v); })` retourne `matrix<string, ...>` sans modifier `m`
- [x] Tests dans `test/src/algorithms.cpp` couvrant : mutation en place, non-régression de l'original, matrices 1D/2D, changement de type, types flottants, ordre row-major

## Décisions d'implémentation

- `apply` et `map` prennent le callable **par valeur** (`F f`) et non par référence universelle (`F&& f`) : les deux appellent le callable sur chaque élément (boucle), forwarding multiple d'une rvalue-ref serait incorrect. La prise par valeur permet la move-construction depuis un rvalue au site d'appel.
- `map` construit d'abord la matrice résultat via `(zero)` (valeur-initialisation), puis `std::transform` écrase tous les éléments.
- Groupe Doxygen `ysc_algorithms` créé (`@defgroup`).