### PR TITLE
US-031 — Réductions : sum, min, max, all, any

### DIFF
--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -18,6 +18,7 @@
 #include <concepts>
 #include <functional>
 #include <iterator>
+#include <numeric>
 #include <ostream>
 #include <stdexcept>
 #include <type_traits>
@@ -849,6 +850,105 @@ public:
         std::transform(_data.cbegin(), _data.cend(), result.begin(),
                        [&f](const T& v) { return std::invoke(f, v); });
         return result;
+    }
+
+    /**
+     * @brief Returns the sum of all elements.
+     * @tparam U  Deduced as @c T; do not specify explicitly.
+     * @return Sum of all elements, starting from @c T{}
+     *
+     * @code
+     * ysc::matrix<int, 3> m{1, 2, 3};
+     * assert(m.sum() == 6);
+     * @endcode
+     *
+     * @ingroup ysc_algorithms
+     */
+    template <class U = T>
+        requires std::same_as<U, T>
+    [[nodiscard]] constexpr U sum() const
+        requires std::default_initializable<T> && requires(T a, const T& b) { a += b; }
+    {
+        return std::accumulate(cbegin(), cend(), U{},
+                               [](U acc, const U& v) -> U { return acc += v; });
+    }
+
+    /**
+     * @brief Returns the smallest element.
+     * @tparam U  Deduced as @c T; do not specify explicitly.
+     * @return Minimum element in row-major order
+     *
+     * @code
+     * ysc::matrix<int, 3> m{3, 1, 2};
+     * assert(m.min() == 1);
+     * @endcode
+     *
+     * @ingroup ysc_algorithms
+     */
+    template <class U = T>
+        requires std::same_as<U, T>
+    [[nodiscard]] constexpr U min() const
+        requires(linear_size > 0) && std::totally_ordered<T>
+    {
+        return std::ranges::min(_data);
+    }
+
+    /**
+     * @brief Returns the largest element.
+     * @tparam U  Deduced as @c T; do not specify explicitly.
+     * @return Maximum element in row-major order
+     *
+     * @code
+     * ysc::matrix<int, 3> m{3, 1, 2};
+     * assert(m.max() == 3);
+     * @endcode
+     *
+     * @ingroup ysc_algorithms
+     */
+    template <class U = T>
+        requires std::same_as<U, T>
+    [[nodiscard]] constexpr U max() const
+        requires(linear_size > 0) && std::totally_ordered<T>
+    {
+        return std::ranges::max(_data);
+    }
+
+    /**
+     * @brief Returns @c true if every element converts to @c true.
+     * @return @c true iff all elements are truthy
+     *
+     * @code
+     * ysc::matrix<int, 3> m{1, 2, 3};
+     * assert(m.all() == true);
+     * ysc::matrix<int, 3> n{1, 0, 3};
+     * assert(n.all() == false);
+     * @endcode
+     *
+     * @ingroup ysc_algorithms
+     */
+    [[nodiscard]] constexpr bool all() const
+        requires std::convertible_to<T, bool>
+    {
+        return std::ranges::all_of(_data, [](const T& v) { return static_cast<bool>(v); });
+    }
+
+    /**
+     * @brief Returns @c true if at least one element converts to @c true.
+     * @return @c true iff at least one element is truthy
+     *
+     * @code
+     * ysc::matrix<int, 3> m{0, 0, 3};
+     * assert(m.any() == true);
+     * ysc::matrix<int, 3> n{0, 0, 0};
+     * assert(n.any() == false);
+     * @endcode
+     *
+     * @ingroup ysc_algorithms
+     */
+    [[nodiscard]] constexpr bool any() const
+        requires std::convertible_to<T, bool>
+    {
+        return std::ranges::any_of(_data, [](const T& v) { return static_cast<bool>(v); });
     }
 
     // modifiers

--- a/test/src/reductions.cpp
+++ b/test/src/reductions.cpp
@@ -1,0 +1,101 @@
+#include "matrix.hpp"
+
+#include <gtest/gtest.h>
+
+// constexpr static checks
+static_assert(ysc::matrix<int, 3>{1, 2, 3}.sum() == 6);
+static_assert(ysc::matrix<int, 3>{3, 1, 2}.min() == 1);
+static_assert(ysc::matrix<int, 3>{3, 1, 2}.max() == 3);
+static_assert(ysc::matrix<int, 3>{1, 2, 3}.all() == true);
+static_assert(ysc::matrix<int, 3>{1, 0, 3}.all() == false);
+static_assert(ysc::matrix<int, 3>{0, 0, 3}.any() == true);
+static_assert(ysc::matrix<int, 3>{0, 0, 0}.any() == false);
+
+TEST(reductions, sum_1d) {
+    ysc::matrix<int, 4> m{1, 2, 3, 4};
+    EXPECT_EQ(m.sum(), 10);
+}
+
+TEST(reductions, sum_2d) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    EXPECT_EQ(m.sum(), 21);
+}
+
+TEST(reductions, sum_single) {
+    ysc::matrix<int, 1> m{42};
+    EXPECT_EQ(m.sum(), 42);
+}
+
+TEST(reductions, min_basic) {
+    ysc::matrix<int, 5> m{3, 1, 4, 1, 5};
+    EXPECT_EQ(m.min(), 1);
+}
+
+TEST(reductions, min_2d) {
+    ysc::matrix<int, 2, 2> m{4, 2, 3, 1};
+    EXPECT_EQ(m.min(), 1);
+}
+
+TEST(reductions, min_negative) {
+    ysc::matrix<int, 3> m{-1, -5, -2};
+    EXPECT_EQ(m.min(), -5);
+}
+
+TEST(reductions, max_basic) {
+    ysc::matrix<int, 5> m{3, 1, 4, 1, 5};
+    EXPECT_EQ(m.max(), 5);
+}
+
+TEST(reductions, max_2d) {
+    ysc::matrix<int, 2, 2> m{4, 2, 3, 1};
+    EXPECT_EQ(m.max(), 4);
+}
+
+TEST(reductions, max_negative) {
+    ysc::matrix<int, 3> m{-1, -5, -2};
+    EXPECT_EQ(m.max(), -1);
+}
+
+TEST(reductions, all_true) {
+    ysc::matrix<int, 3> m{1, 2, 3};
+    EXPECT_TRUE(m.all());
+}
+
+TEST(reductions, all_false_one_zero) {
+    ysc::matrix<int, 3> m{1, 0, 3};
+    EXPECT_FALSE(m.all());
+}
+
+TEST(reductions, all_false_all_zero) {
+    ysc::matrix<int, 3> m{0, 0, 0};
+    EXPECT_FALSE(m.all());
+}
+
+TEST(reductions, all_bool_type) {
+    ysc::matrix<bool, 3> m{true, true, true};
+    EXPECT_TRUE(m.all());
+    ysc::matrix<bool, 3> n{true, false, true};
+    EXPECT_FALSE(n.all());
+}
+
+TEST(reductions, any_one_true) {
+    ysc::matrix<int, 3> m{0, 0, 3};
+    EXPECT_TRUE(m.any());
+}
+
+TEST(reductions, any_all_false) {
+    ysc::matrix<int, 3> m{0, 0, 0};
+    EXPECT_FALSE(m.any());
+}
+
+TEST(reductions, any_all_true) {
+    ysc::matrix<int, 3> m{1, 2, 3};
+    EXPECT_TRUE(m.any());
+}
+
+TEST(reductions, any_bool_type) {
+    ysc::matrix<bool, 3> m{false, false, true};
+    EXPECT_TRUE(m.any());
+    ysc::matrix<bool, 3> n{false, false, false};
+    EXPECT_FALSE(n.any());
+}

--- a/user-stories.md
+++ b/user-stories.md
@@ -10,11 +10,11 @@
 | **D — Conformité STL** | ✅ Terminée | 4/4 | ✅ US-015, US-016, US-017, US-018 |
 | **E — Comparaison & I/O** | ✅ Terminée | 7/7 | ✅ US-019, US-020, US-021, US-022, US-023, US-024, US-025 |
 | **F — Arithmétique** | ✅ Terminée | 4/4 | ✅ US-026, ✅ US-027, ✅ US-028, ✅ US-029 |
-| **G — Algorithmes** | 🔄 En cours | 1/5 | ✅ US-030, ⬜ US-031 à US-034 |
+| **G — Algorithmes** | 🔄 En cours | 2/5 | ✅ US-030, ✅ US-031, ⬜ US-032 à US-034 |
 | **H — Vues & reshape** | ⬜ Non démarrée | 0/3 | ⬜ US-035 à US-037 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/6 | ⬜ US-038 à US-043 |
 
-**Total : 29 / 43 US**
+**Total : 30 / 43 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -802,8 +802,8 @@ bool any()  const;
 Implémentations via `std::accumulate`/`std::ranges::min`/etc.
 
 ### Critères d'acceptation
-- [ ] Tous testés
-- [ ] `static_assert` sur exemples constexpr-able
+- [x] Tous testés
+- [x] `static_assert` sur exemples constexpr-able
 
 ---
 


### PR DESCRIPTION
## Résumé

Implémentation de US-031 (EPIC G — Algorithmes, 2/5). Cinq méthodes membres const de réduction
ajoutées à `ysc::matrix` dans le groupe Doxygen `ysc_algorithms`, juste après `apply` et `map`.

## Critères d'acceptation

- [x] `T sum() const` — via `std::accumulate` avec T{} comme identité
- [x] `T min() const` — via `std::ranges::min`, requires `linear_size > 0`
- [x] `T max() const` — via `std::ranges::max`, requires `linear_size > 0`
- [x] `bool all() const` — via `std::ranges::all_of`, requires `convertible_to<T, bool>`
- [x] `bool any() const` — via `std::ranges::any_of`, requires `convertible_to<T, bool>`
- [x] Tous les opérateurs testés (20 cas dans `test/src/reductions.cpp`)
- [x] `static_assert` sur exemples constexpr-able (7 assertions statiques)

## Décisions d'implémentation

`sum`, `min` et `max` sont des **templates membres** (`template <class U = T> requires std::same_as<U, T>`)
plutôt que des fonctions membres ordinaires. Cette pattern diffère leur instanciation jusqu'à l'appel
effectif, évitant l'erreur *"function returning an array"* quand le type T est un type tableau
(cf. test `construct_default_array_type` qui instancie `matrix<user_defined[1], 1>`).