### PR TITLE
US-032 — transpose() (2D)

### DIFF
--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -10,11 +10,11 @@
 | **D — Conformité STL** | ✅ Terminée | 4/4 | ✅ US-015, US-016, US-017, US-018 |
 | **E — Comparaison & I/O** | ✅ Terminée | 7/7 | ✅ US-019, US-020, US-021, US-022, US-023, US-024, US-025 |
 | **F — Arithmétique** | ✅ Terminée | 4/4 | ✅ US-026, ✅ US-027, ✅ US-028, ✅ US-029 |
-| **G — Algorithmes** | 🔄 En cours | 2/5 | ✅ US-030, ✅ US-031, ⬜ US-032 à US-034 |
+| **G — Algorithmes** | 🔄 En cours | 3/5 | ✅ US-030, ✅ US-031, ✅ US-032, ⬜ US-033, ⬜ US-034 |
 | **H — Vues & reshape** | ⬜ Non démarrée | 0/3 | ⬜ US-035 à US-037 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/6 | ⬜ US-038 à US-043 |
 
-**Total : 30 / 43 US**
+**Total : 31 / 43 US**
 
 ## EPIC A — Infrastructure & CI/CD
 

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -1110,6 +1110,38 @@ constexpr matrix<T, N, N> identity() {
 }
 
 /**
+ * @defgroup ysc_linalg Linear algebra
+ * @brief Linear algebra operations on @c ysc::matrix.
+ */
+
+/**
+ * @brief Returns the transpose of a 2D matrix.
+ * @tparam T  Element type
+ * @tparam R  Number of rows of the input matrix
+ * @tparam C  Number of columns of the input matrix
+ * @param  m  Matrix to transpose
+ * @return New @c matrix<T,C,R> where `result(j, i) == m(i, j)` for all valid @a i, @a j
+ *
+ * @code
+ * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+ * auto t = ysc::transpose(m);  // t is ysc::matrix<int, 3, 2>
+ * // t(0,0)==1, t(0,1)==4, t(1,0)==2, t(1,1)==5, t(2,0)==3, t(2,1)==6
+ * @endcode
+ *
+ * @ingroup ysc_linalg
+ */
+template <class T, std::size_t R, std::size_t C>
+[[nodiscard]] constexpr matrix<T, C, R> transpose(const matrix<T, R, C>& m) {
+    matrix<T, C, R> result(zero);
+    for (std::size_t i = 0; i < R; ++i) {
+        for (std::size_t j = 0; j < C; ++j) {
+            result(j, i) = m(i, j);
+        }
+    }
+    return result;
+}
+
+/**
  * @defgroup ysc_io I/O
  * @brief Stream output for `ysc::matrix`.
  */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(${TARGET_NAME}
     src/iterators.cpp
     src/ostream.cpp
     src/reductions.cpp
+    src/transpose.cpp
     src/size_data.cpp
     src/typedefs.cpp
     src/main.cpp

--- a/test/src/transpose.cpp
+++ b/test/src/transpose.cpp
@@ -1,0 +1,67 @@
+#include "matrix.hpp"
+#include <gtest/gtest.h>
+
+TEST(MatrixTranspose, ReturnTypeIsTransposed) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    auto t = ysc::transpose(m);
+    static_assert(std::is_same_v<decltype(t), ysc::matrix<int, 3, 2>>);
+    (void)t;
+}
+
+TEST(MatrixTranspose, ValuesAreCorrectlySwapped) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    auto t = ysc::transpose(m);
+    // m(0,0)=1 m(0,1)=2 m(0,2)=3
+    // m(1,0)=4 m(1,1)=5 m(1,2)=6
+    // t(j,i) == m(i,j)
+    EXPECT_EQ(t(0, 0), 1);
+    EXPECT_EQ(t(0, 1), 4);
+    EXPECT_EQ(t(1, 0), 2);
+    EXPECT_EQ(t(1, 1), 5);
+    EXPECT_EQ(t(2, 0), 3);
+    EXPECT_EQ(t(2, 1), 6);
+}
+
+TEST(MatrixTranspose, TransposeOfTransposeEqualsOriginal) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    EXPECT_EQ(ysc::transpose(ysc::transpose(m)), m);
+}
+
+TEST(MatrixTranspose, SquareMatrixTranspose) {
+    ysc::matrix<int, 2, 2> m{1, 2, 3, 4};
+    auto t = ysc::transpose(m);
+    static_assert(std::is_same_v<decltype(t), ysc::matrix<int, 2, 2>>);
+    EXPECT_EQ(t(0, 0), 1);
+    EXPECT_EQ(t(0, 1), 3);
+    EXPECT_EQ(t(1, 0), 2);
+    EXPECT_EQ(t(1, 1), 4);
+}
+
+TEST(MatrixTranspose, IdentityTransposeIsIdentity) {
+    auto id = ysc::identity<int, 3>();
+    EXPECT_EQ(ysc::transpose(id), id);
+}
+
+TEST(MatrixTranspose, SingleRowMatrix) {
+    ysc::matrix<int, 1, 4> m{1, 2, 3, 4};
+    auto t = ysc::transpose(m);
+    static_assert(std::is_same_v<decltype(t), ysc::matrix<int, 4, 1>>);
+    EXPECT_EQ(t(0, 0), 1);
+    EXPECT_EQ(t(1, 0), 2);
+    EXPECT_EQ(t(2, 0), 3);
+    EXPECT_EQ(t(3, 0), 4);
+}
+
+TEST(MatrixTranspose, WorksWithDoubleElements) {
+    ysc::matrix<double, 2, 2> m{1.5, 2.5, 3.5, 4.5};
+    auto t = ysc::transpose(m);
+    EXPECT_DOUBLE_EQ(t(0, 1), 3.5);
+    EXPECT_DOUBLE_EQ(t(1, 0), 2.5);
+}
+
+// constexpr verification
+static_assert([] {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    auto t = ysc::transpose(m);
+    return t(0, 0) == 1 && t(0, 1) == 4 && t(2, 1) == 6;
+}());


### PR DESCRIPTION
## Résumé

Implémente la fonction libre `ysc::transpose<T, R, C>` dans `namespace ysc`.
Elle retourne une `matrix<T, C, R>` dont l'élément `(j, i)` est égal à `m(i, j)`.
L'implémentation est `constexpr`, documentée Doxygen dans le groupe `ysc_linalg`.

## Critères d'acceptation

- [x] `transpose(matrix<int,2,3>{...})` retourne `matrix<int,3,2>`
- [x] `transpose(transpose(m)) == m`

## Tests ajoutés (`test/src/transpose.cpp`)

- `ReturnTypeIsTransposed` — `static_assert` sur le type retourné
- `ValuesAreCorrectlySwapped` — vérification case-par-case sur une matrice 2×3
- `TransposeOfTransposeEqualsOriginal` — propriété idempotente
- `SquareMatrixTranspose` — matrice carrée 2×2
- `IdentityTransposeIsIdentity` — `transpose(identity<int,3>()) == identity<int,3>()`
- `SingleRowMatrix` — matrice 1×4 → 4×1
- `WorksWithDoubleElements` — type `double`
- `static_assert` constexpr en dehors des tests GoogleTest

## Décisions notables

- Fonction libre plutôt que méthode membre (cohérent avec la spécification US-032 et le style des factories)
- Nouveau groupe Doxygen `ysc_linalg` créé pour accueillir cette fonction et les suivantes (US-033, US-034)
- Pas de spécialisation pour matrices carrées : l'implémentation générique couvre tous les cas