### PR TITLE
US-033 — Produit matriciel matmul (2D)

### DIFF
--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -10,11 +10,11 @@
 | **D — Conformité STL** | ✅ Terminée | 4/4 | ✅ US-015, US-016, US-017, US-018 |
 | **E — Comparaison & I/O** | ✅ Terminée | 7/7 | ✅ US-019, US-020, US-021, US-022, US-023, US-024, US-025 |
 | **F — Arithmétique** | ✅ Terminée | 4/4 | ✅ US-026, ✅ US-027, ✅ US-028, ✅ US-029 |
-| **G — Algorithmes** | 🔄 En cours | 3/5 | ✅ US-030, ✅ US-031, ✅ US-032, ⬜ US-033, ⬜ US-034 |
+| **G — Algorithmes** | 🔄 En cours | 4/5 | ✅ US-030, ✅ US-031, ✅ US-032, ✅ US-033, ⬜ US-034 |
 | **H — Vues & reshape** | ⬜ Non démarrée | 0/3 | ⬜ US-035 à US-037 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/6 | ⬜ US-038 à US-043 |
 
-**Total : 31 / 43 US**
+**Total : 32 / 43 US**
 
 ## EPIC A — Infrastructure & CI/CD
 

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -1142,6 +1142,38 @@ template <class T, std::size_t R, std::size_t C>
 }
 
 /**
+ * @brief Computes the matrix product of two 2D matrices.
+ * @tparam T  Element type — must support `operator*` and `operator+=`
+ * @tparam M  Number of rows of @a a and the result
+ * @tparam N  Shared inner dimension (columns of @a a, rows of @a b)
+ * @tparam P  Number of columns of @a b and the result
+ * @param  a  Left-hand matrix of size M×N
+ * @param  b  Right-hand matrix of size N×P
+ * @return New @c matrix<T,M,P> equal to the matrix product `a × b`
+ *
+ * @code
+ * ysc::matrix<int, 2, 3> a{1, 2, 3, 4, 5, 6};
+ * ysc::matrix<int, 3, 2> b{7, 8, 9, 10, 11, 12};
+ * auto c = ysc::matmul(a, b);  // c is ysc::matrix<int, 2, 2>
+ * // c(0,0) == 58, c(0,1) == 64, c(1,0) == 139, c(1,1) == 154
+ * @endcode
+ *
+ * @ingroup ysc_linalg
+ */
+template <class T, std::size_t M, std::size_t N, std::size_t P>
+[[nodiscard]] constexpr matrix<T, M, P> matmul(const matrix<T, M, N>& a, const matrix<T, N, P>& b) {
+    matrix<T, M, P> result(zero);
+    for (std::size_t i = 0; i < M; ++i) {
+        for (std::size_t k = 0; k < N; ++k) {
+            for (std::size_t j = 0; j < P; ++j) {
+                result(i, j) += a(i, k) * b(k, j);
+            }
+        }
+    }
+    return result;
+}
+
+/**
  * @defgroup ysc_io I/O
  * @brief Stream output for `ysc::matrix`.
  */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(${TARGET_NAME}
     src/instantiation.cpp
     src/nested_init.cpp
     src/iterators.cpp
+    src/matmul.cpp
     src/ostream.cpp
     src/reductions.cpp
     src/transpose.cpp

--- a/test/src/matmul.cpp
+++ b/test/src/matmul.cpp
@@ -1,0 +1,76 @@
+#include "matrix.hpp"
+#include <gtest/gtest.h>
+
+TEST(MatrixMatmul, ReturnTypeIsCorrect) {
+    ysc::matrix<int, 2, 3> a{1, 2, 3, 4, 5, 6};
+    ysc::matrix<int, 3, 4> b{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0};
+    auto c = ysc::matmul(a, b);
+    static_assert(std::is_same_v<decltype(c), ysc::matrix<int, 2, 4>>);
+    (void)c;
+}
+
+TEST(MatrixMatmul, SquareMatrices) {
+    // [[1,2],[3,4]] * [[5,6],[7,8]] = [[19,22],[43,50]]
+    ysc::matrix<int, 2, 2> a{1, 2, 3, 4};
+    ysc::matrix<int, 2, 2> b{5, 6, 7, 8};
+    auto c = ysc::matmul(a, b);
+    EXPECT_EQ(c(0, 0), 19);
+    EXPECT_EQ(c(0, 1), 22);
+    EXPECT_EQ(c(1, 0), 43);
+    EXPECT_EQ(c(1, 1), 50);
+}
+
+TEST(MatrixMatmul, NonSquareMatrices) {
+    // [[1,2,3],[4,5,6]] * [[7,8],[9,10],[11,12]] = [[58,64],[139,154]]
+    ysc::matrix<int, 2, 3> a{1, 2, 3, 4, 5, 6};
+    ysc::matrix<int, 3, 2> b{7, 8, 9, 10, 11, 12};
+    auto c = ysc::matmul(a, b);
+    EXPECT_EQ(c(0, 0), 58);
+    EXPECT_EQ(c(0, 1), 64);
+    EXPECT_EQ(c(1, 0), 139);
+    EXPECT_EQ(c(1, 1), 154);
+}
+
+TEST(MatrixMatmul, IdentityLeftNeutral) {
+    ysc::matrix<int, 3, 2> m{1, 2, 3, 4, 5, 6};
+    auto result = ysc::matmul(ysc::identity<int, 3>(), m);
+    EXPECT_EQ(result, m);
+}
+
+TEST(MatrixMatmul, IdentityRightNeutral) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    auto result = ysc::matmul(m, ysc::identity<int, 3>());
+    EXPECT_EQ(result, m);
+}
+
+TEST(MatrixMatmul, SquareIdentity) {
+    ysc::matrix<int, 3, 3> m{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    auto id = ysc::identity<int, 3>();
+    EXPECT_EQ(ysc::matmul(id, m), m);
+}
+
+TEST(MatrixMatmul, ResultIsZeroWhenInputIsZero) {
+    ysc::matrix<int, 2, 3> a(ysc::zero);
+    ysc::matrix<int, 3, 4> b(ysc::zero);
+    auto c = ysc::matmul(a, b);
+    ysc::matrix<int, 2, 4> expected(ysc::zero);
+    EXPECT_EQ(c, expected);
+}
+
+TEST(MatrixMatmul, WorksWithDouble) {
+    ysc::matrix<double, 2, 2> a{1.0, 2.0, 3.0, 4.0};
+    ysc::matrix<double, 2, 2> b{0.5, 0.0, 0.0, 0.5};
+    auto c = ysc::matmul(a, b);
+    EXPECT_DOUBLE_EQ(c(0, 0), 0.5);
+    EXPECT_DOUBLE_EQ(c(0, 1), 1.0);
+    EXPECT_DOUBLE_EQ(c(1, 0), 1.5);
+    EXPECT_DOUBLE_EQ(c(1, 1), 2.0);
+}
+
+// constexpr verification
+static_assert([] {
+    ysc::matrix<int, 2, 2> a{1, 2, 3, 4};
+    ysc::matrix<int, 2, 2> b{5, 6, 7, 8};
+    auto c = ysc::matmul(a, b);
+    return c(0, 0) == 19 && c(0, 1) == 22 && c(1, 0) == 43 && c(1, 1) == 50;
+}());


### PR DESCRIPTION
## Résumé

Ajout de la fonction libre `ysc::matmul<T,M,N,P>` dans le groupe Doxygen `ysc_linalg`. L'implémentation est naïve O(MNP) avec une boucle triplement imbriquée en ordre i-k-j, qui est cache-friendly avec le layout row-major de `ysc::matrix`. Le check sur les dimensions intérieures (N commun à `a` et `b`) est garanti à la compilation par le système de types.

## Critères d'acceptation

- [x] Test contre matrices identités (`IdentityLeftNeutral`, `IdentityRightNeutral`, `SquareIdentity`)
- [x] Test contre matrices non-carrées (`NonSquareMatrices`, `ReturnTypeIsCorrect`)
- [x] Test : `matmul(identity<int,3>(), m) == m`
- [x] Compile-time check sur dimensions intérieures (garanti par la signature template `matrix<T,M,N>` × `matrix<T,N,P>`)
- [x] `static_assert` constexpr
- [x] Build et tests verts
- [x] Aucun avertissement clang-format
- [x] Aucun avertissement clang-tidy
- [x] Documentation Doxygen complète (`@brief`, `@tparam`, `@param`, `@return`, `@code`, `@ingroup`)