### PR TITLE
US-034 — dot() produit scalaire 1D

### DIFF
--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -10,11 +10,11 @@
 | **D — Conformité STL** | ✅ Terminée | 4/4 | ✅ US-015, US-016, US-017, US-018 |
 | **E — Comparaison & I/O** | ✅ Terminée | 7/7 | ✅ US-019, US-020, US-021, US-022, US-023, US-024, US-025 |
 | **F — Arithmétique** | ✅ Terminée | 4/4 | ✅ US-026, ✅ US-027, ✅ US-028, ✅ US-029 |
-| **G — Algorithmes** | 🔄 En cours | 4/5 | ✅ US-030, ✅ US-031, ✅ US-032, ✅ US-033, ⬜ US-034 |
+| **G — Algorithmes** | ✅ Terminée | 5/5 | ✅ US-030, ✅ US-031, ✅ US-032, ✅ US-033, ✅ US-034 |
 | **H — Vues & reshape** | ⬜ Non démarrée | 0/3 | ⬜ US-035 à US-037 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/6 | ⬜ US-038 à US-043 |
 
-**Total : 32 / 43 US**
+**Total : 33 / 43 US**
 
 ## EPIC A — Infrastructure & CI/CD
 

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -1174,6 +1174,31 @@ template <class T, std::size_t M, std::size_t N, std::size_t P>
 }
 
 /**
+ * @brief Returns the dot product of two 1D matrices (vectors) of the same length.
+ * @tparam T Element type — must support `operator*` and `operator+=`
+ * @tparam N Number of elements
+ * @param  a First vector
+ * @param  b Second vector
+ * @return Scalar value `sum(a[i] * b[i])` for `i` in `[0, N)`
+ *
+ * @code
+ * ysc::matrix<int, 3> a{1, 2, 3};
+ * ysc::matrix<int, 3> b{4, 5, 6};
+ * int r = ysc::dot(a, b);  // r == 32
+ * @endcode
+ *
+ * @ingroup ysc_linalg
+ */
+template <class T, std::size_t N>
+[[nodiscard]] constexpr T dot(const matrix<T, N>& a, const matrix<T, N>& b) {
+    T result{};
+    for (std::size_t i = 0; i < N; ++i) {
+        result += a(i) * b(i);
+    }
+    return result;
+}
+
+/**
  * @defgroup ysc_io I/O
  * @brief Stream output for `ysc::matrix`.
  */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(${TARGET_NAME}
     src/instantiation.cpp
     src/nested_init.cpp
     src/iterators.cpp
+    src/dot.cpp
     src/matmul.cpp
     src/ostream.cpp
     src/reductions.cpp

--- a/test/src/dot.cpp
+++ b/test/src/dot.cpp
@@ -1,0 +1,53 @@
+#include "matrix.hpp"
+#include <gtest/gtest.h>
+
+TEST(MatrixDot, BasicExample) {
+    ysc::matrix<int, 3> a{1, 2, 3};
+    ysc::matrix<int, 3> b{4, 5, 6};
+    EXPECT_EQ(ysc::dot(a, b), 32);
+}
+
+TEST(MatrixDot, ReturnTypeMatchesElementType) {
+    ysc::matrix<int, 2> a{1, 2};
+    ysc::matrix<int, 2> b{3, 4};
+    static_assert(std::is_same_v<decltype(ysc::dot(a, b)), int>);
+    (void)a;
+    (void)b;
+}
+
+TEST(MatrixDot, Commutativity) {
+    ysc::matrix<int, 4> a{1, 2, 3, 4};
+    ysc::matrix<int, 4> b{5, 6, 7, 8};
+    EXPECT_EQ(ysc::dot(a, b), ysc::dot(b, a));
+}
+
+TEST(MatrixDot, ZeroVector) {
+    ysc::matrix<int, 3> a{1, 2, 3};
+    ysc::matrix<int, 3> z(ysc::zero);
+    EXPECT_EQ(ysc::dot(a, z), 0);
+}
+
+TEST(MatrixDot, SingleElement) {
+    ysc::matrix<int, 1> a{7};
+    ysc::matrix<int, 1> b{6};
+    EXPECT_EQ(ysc::dot(a, b), 42);
+}
+
+TEST(MatrixDot, WorksWithDouble) {
+    ysc::matrix<double, 3> a{1.0, 2.0, 3.0};
+    ysc::matrix<double, 3> b{0.1, 0.2, 0.3};
+    EXPECT_DOUBLE_EQ(ysc::dot(a, b), 1.4);
+}
+
+TEST(MatrixDot, Orthogonal) {
+    ysc::matrix<int, 2> a{1, 0};
+    ysc::matrix<int, 2> b{0, 1};
+    EXPECT_EQ(ysc::dot(a, b), 0);
+}
+
+// constexpr verification
+static_assert([] {
+    ysc::matrix<int, 3> a{1, 2, 3};
+    ysc::matrix<int, 3> b{4, 5, 6};
+    return ysc::dot(a, b) == 32;
+}());


### PR DESCRIPTION
## Résumé

Implémentation de `ysc::dot()`, fonction libre constexpr calculant le produit scalaire de deux vecteurs (matrices 1D) de même longueur. La fonction est ajoutée dans le groupe Doxygen `ysc_linalg` aux côtés de `transpose()` et `matmul()`.

## Critères d'acceptation

- [x] `dot({1,2,3}, {4,5,6}) == 32`

## Décisions d'implémentation

- Initialisation par `T result{}` (value-initialization) pour garantir le comportement correct pour tous les types scalaires sans requérir une valeur sentinelle comme `zero`.
- Boucle simple sur les indices : pas d'`std::inner_product` pour rester cohérent avec `matmul` et conserver le `constexpr`.
- 7 tests + 1 `static_assert` constexpr dans `test/src/dot.cpp`.