### PR TITLE
fix: epic G review — constexpr apply/map, concept += matmul/dot, doc sum

### DIFF
--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -820,7 +820,7 @@ public:
      */
     template <class F>
         requires std::invocable<F, T&>
-    void apply(F f) {
+    constexpr void apply(F f) {
         for (T& v : _data) {
             std::invoke(f, v);
         }
@@ -845,7 +845,8 @@ public:
      */
     template <class F>
         requires std::invocable<F, const T&>
-    [[nodiscard]] auto map(F f) const -> matrix<std::invoke_result_t<F, const T&>, Dimensions...> {
+    [[nodiscard]] constexpr auto map(F f) const
+        -> matrix<std::invoke_result_t<F, const T&>, Dimensions...> {
         matrix<std::invoke_result_t<F, const T&>, Dimensions...> result(zero);
         std::transform(_data.cbegin(), _data.cend(), result.begin(),
                        [&f](const T& v) { return std::invoke(f, v); });
@@ -855,7 +856,7 @@ public:
     /**
      * @brief Returns the sum of all elements.
      * @tparam U  Deduced as @c T; do not specify explicitly.
-     * @return Sum of all elements, starting from @c T{}
+     * @return Sum of all elements, with the accumulator initialized to @c T{}
      *
      * @code
      * ysc::matrix<int, 3> m{1, 2, 3};
@@ -1162,7 +1163,9 @@ template <class T, std::size_t R, std::size_t C>
  * @ingroup ysc_linalg
  */
 template <class Ta, class Tb, std::size_t M, std::size_t N, std::size_t P>
-    requires std::invocable<std::multiplies<>, const Ta&, const Tb&>
+    requires std::invocable<std::multiplies<>, const Ta&, const Tb&> &&
+             requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc, const Ta& a,
+                      const Tb& b) { tc += a * b; }
 [[nodiscard]] constexpr auto matmul(const matrix<Ta, M, N>& a, const matrix<Tb, N, P>& b)
     -> matrix<std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>, M, P> {
     using Tc = std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>;
@@ -1196,7 +1199,9 @@ template <class Ta, class Tb, std::size_t M, std::size_t N, std::size_t P>
  * @ingroup ysc_linalg
  */
 template <class Ta, class Tb, std::size_t N>
-    requires std::invocable<std::multiplies<>, const Ta&, const Tb&>
+    requires std::invocable<std::multiplies<>, const Ta&, const Tb&> &&
+             requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc, const Ta& a,
+                      const Tb& b) { tc += a * b; }
 [[nodiscard]] constexpr auto dot(const matrix<Ta, N>& a, const matrix<Tb, N>& b)
     -> std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> {
     using Tc = std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>;

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -845,8 +845,8 @@ public:
      */
     template <class F>
         requires std::invocable<F, const T&>
-    [[nodiscard]] constexpr auto map(F f) const
-        -> matrix<std::invoke_result_t<F, const T&>, Dimensions...> {
+    [[nodiscard]] constexpr auto
+    map(F f) const -> matrix<std::invoke_result_t<F, const T&>, Dimensions...> {
         matrix<std::invoke_result_t<F, const T&>, Dimensions...> result(zero);
         std::transform(_data.cbegin(), _data.cend(), result.begin(),
                        [&f](const T& v) { return std::invoke(f, v); });
@@ -1164,8 +1164,8 @@ template <class T, std::size_t R, std::size_t C>
  */
 template <class Ta, class Tb, std::size_t M, std::size_t N, std::size_t P>
     requires std::invocable<std::multiplies<>, const Ta&, const Tb&> &&
-             requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc, const Ta& a,
-                      const Tb& b) { tc += a * b; }
+                 requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc,
+                          const Ta& a, const Tb& b) { tc += a * b; }
 [[nodiscard]] constexpr auto matmul(const matrix<Ta, M, N>& a, const matrix<Tb, N, P>& b)
     -> matrix<std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>, M, P> {
     using Tc = std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>;
@@ -1200,8 +1200,8 @@ template <class Ta, class Tb, std::size_t M, std::size_t N, std::size_t P>
  */
 template <class Ta, class Tb, std::size_t N>
     requires std::invocable<std::multiplies<>, const Ta&, const Tb&> &&
-             requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc, const Ta& a,
-                      const Tb& b) { tc += a * b; }
+                 requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc,
+                          const Ta& a, const Tb& b) { tc += a * b; }
 [[nodiscard]] constexpr auto dot(const matrix<Ta, N>& a, const matrix<Tb, N>& b)
     -> std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> {
     using Tc = std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>;

--- a/test/src/algorithms.cpp
+++ b/test/src/algorithms.cpp
@@ -2,6 +2,18 @@
 #include <gtest/gtest.h>
 #include <string>
 
+// constexpr static checks
+static_assert([] {
+    ysc::matrix<int, 3> m{1, 2, 3};
+    m.apply([](int& v) { v *= 2; });
+    return m == ysc::matrix<int, 3>{2, 4, 6};
+}());
+static_assert([] {
+    ysc::matrix<int, 3> m{1, 2, 3};
+    auto r = m.map([](int v) { return v * 2; });
+    return r == ysc::matrix<int, 3>{2, 4, 6};
+}());
+
 // --- apply ---
 
 TEST(MatrixApply, MutatesElementsInPlace) {


### PR DESCRIPTION
## Résumé

Corrections issues de la revue de code de l'epic G avant la release 0.5.0.

## Changements

### `apply()` et `map()` — ajout de `constexpr`

Ces deux méthodes manquaient `constexpr` alors que toutes les autres fonctions de l'epic G (`sum`, `min`, `max`, `all`, `any`, `transpose`, `matmul`, `dot`) l'ont. En C++20, `std::invoke` et `std::transform` sont `constexpr`, donc rien ne s'y opposait.

Tests ajoutés : deux `static_assert` dans `algorithms.cpp` pour vérifier l'évaluation compile-time.

### `matmul()` et `dot()` — concept complété (`Tc::operator+=`)

Le concept ne vérifiait que `Ta * Tb` (via `std::invocable<std::multiplies<>, ...>`), mais pas que le type résultat `Tc` supporte `+=`, qui est pourtant utilisé dans l'implémentation. Ajout d'une clause :

```cpp
requires std::invocable<std::multiplies<>, const Ta&, const Tb&> &&
         requires(... tc, const Ta& a, const Tb& b) { tc += a * b; }
```

### `sum()` — `@return` clarifié

"starting from T{}" pouvait s'interpréter comme un élément de départ dans la séquence itérée. Reformulé en "with the accumulator initialized to T{}".

## Checklist

- [x] Build et tests verts
- [x] clang-format appliqué
- [x] Doxygen inchangée (sauf la correction `sum()`)
- [x] Aucun breaking change