### PR TITLE
US-035 — matrix_view non-owning read/write view

### DIFF
--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -11,10 +11,10 @@
 | **E — Comparaison & I/O** | ✅ Terminée | 7/7 | ✅ US-019, US-020, US-021, US-022, US-023, US-024, US-025 |
 | **F — Arithmétique** | ✅ Terminée | 4/4 | ✅ US-026, ✅ US-027, ✅ US-028, ✅ US-029 |
 | **G — Algorithmes** | ✅ Terminée | 5/5 | ✅ US-030, ✅ US-031, ✅ US-032, ✅ US-033, ✅ US-034 |
-| **H — Vues & reshape** | ⬜ Non démarrée | 0/3 | ⬜ US-035 à US-037 |
+| **H — Vues & reshape** | 🔄 En cours | 1/3 | ✅ US-035, ⬜ US-036, ⬜ US-037 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/6 | ⬜ US-038 à US-043 |
 
-**Total : 33 / 43 US**
+**Total : 34 / 43 US**
 
 ## EPIC A — Infrastructure & CI/CD
 

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -845,8 +845,8 @@ public:
      */
     template <class F>
         requires std::invocable<F, const T&>
-    [[nodiscard]] constexpr auto map(F f) const
-        -> matrix<std::invoke_result_t<F, const T&>, Dimensions...> {
+    [[nodiscard]] constexpr auto
+    map(F f) const -> matrix<std::invoke_result_t<F, const T&>, Dimensions...> {
         matrix<std::invoke_result_t<F, const T&>, Dimensions...> result(zero);
         std::transform(_data.cbegin(), _data.cend(), result.begin(),
                        [&f](const T& v) { return std::invoke(f, v); });
@@ -1164,8 +1164,8 @@ template <class T, std::size_t R, std::size_t C>
  */
 template <class Ta, class Tb, std::size_t M, std::size_t N, std::size_t P>
     requires std::invocable<std::multiplies<>, const Ta&, const Tb&> &&
-             requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc, const Ta& a,
-                      const Tb& b) { tc += a * b; }
+                 requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc,
+                          const Ta& a, const Tb& b) { tc += a * b; }
 [[nodiscard]] constexpr auto matmul(const matrix<Ta, M, N>& a, const matrix<Tb, N, P>& b)
     -> matrix<std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>, M, P> {
     using Tc = std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>;
@@ -1200,8 +1200,8 @@ template <class Ta, class Tb, std::size_t M, std::size_t N, std::size_t P>
  */
 template <class Ta, class Tb, std::size_t N>
     requires std::invocable<std::multiplies<>, const Ta&, const Tb&> &&
-             requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc, const Ta& a,
-                      const Tb& b) { tc += a * b; }
+                 requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc,
+                          const Ta& a, const Tb& b) { tc += a * b; }
 [[nodiscard]] constexpr auto dot(const matrix<Ta, N>& a, const matrix<Tb, N>& b)
     -> std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> {
     using Tc = std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>;

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -845,8 +845,8 @@ public:
      */
     template <class F>
         requires std::invocable<F, const T&>
-    [[nodiscard]] constexpr auto
-    map(F f) const -> matrix<std::invoke_result_t<F, const T&>, Dimensions...> {
+    [[nodiscard]] constexpr auto map(F f) const
+        -> matrix<std::invoke_result_t<F, const T&>, Dimensions...> {
         matrix<std::invoke_result_t<F, const T&>, Dimensions...> result(zero);
         std::transform(_data.cbegin(), _data.cend(), result.begin(),
                        [&f](const T& v) { return std::invoke(f, v); });
@@ -1164,8 +1164,8 @@ template <class T, std::size_t R, std::size_t C>
  */
 template <class Ta, class Tb, std::size_t M, std::size_t N, std::size_t P>
     requires std::invocable<std::multiplies<>, const Ta&, const Tb&> &&
-                 requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc,
-                          const Ta& a, const Tb& b) { tc += a * b; }
+             requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc, const Ta& a,
+                      const Tb& b) { tc += a * b; }
 [[nodiscard]] constexpr auto matmul(const matrix<Ta, M, N>& a, const matrix<Tb, N, P>& b)
     -> matrix<std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>, M, P> {
     using Tc = std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>;
@@ -1200,8 +1200,8 @@ template <class Ta, class Tb, std::size_t M, std::size_t N, std::size_t P>
  */
 template <class Ta, class Tb, std::size_t N>
     requires std::invocable<std::multiplies<>, const Ta&, const Tb&> &&
-                 requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc,
-                          const Ta& a, const Tb& b) { tc += a * b; }
+             requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc, const Ta& a,
+                      const Tb& b) { tc += a * b; }
 [[nodiscard]] constexpr auto dot(const matrix<Ta, N>& a, const matrix<Tb, N>& b)
     -> std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> {
     using Tc = std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>;

--- a/src/include/matrix_view.hpp
+++ b/src/include/matrix_view.hpp
@@ -1,0 +1,460 @@
+/**
+ * @file matrix_view.hpp
+ * @author Yankel Scialom (YSC) <yankel-pro@scialom.org>
+ * @date 2026
+ *
+ * @copyright This project is released under GNU Lesser General Public License; see
+ *            COPYING and COPYING.LESSER files attached.
+ *
+ * Non-owning view over a ysc::matrix storage.
+ */
+#ifndef YSC_MATRIX_VIEW_HPP
+#define YSC_MATRIX_VIEW_HPP
+
+#include <algorithm>
+#include <array>
+#include <iterator>
+#include <stdexcept>
+
+#include <matrix.hpp>
+
+namespace ysc {
+
+/**
+ * @defgroup ysc_view Views
+ * @brief Non-owning read/write views over @c ysc::matrix storage.
+ */
+
+/**
+ * @brief Non-owning read/write view over a contiguous sequence of @c T elements.
+ *
+ * @tparam T          Element type
+ * @tparam Dimensions Dimensions of the view (same as the underlying @c matrix)
+ *
+ * A @c matrix_view holds a raw pointer and the dimension metadata as template
+ * parameters.  It does **not** own the memory: the lifetime of the underlying
+ * @c matrix (or raw array) must exceed the lifetime of the view.
+ *
+ * @warning Destroying the underlying @c matrix while a @c matrix_view still
+ *          refers to it is undefined behavior.
+ *
+ * Because dimensions are part of the type, @c sizeof(matrix_view<T,D...>) equals
+ * @c sizeof(T*) on every platform (single pointer, no extra bookkeeping).
+ *
+ * @code
+ * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+ * ysc::matrix_view<int, 2, 3> v = m;
+ * v(0, 0) = 99;           // mutation is reflected in m
+ * assert(m(0, 0) == 99);
+ * @endcode
+ *
+ * @ingroup ysc_view
+ */
+template <class T, std::size_t... Dimensions> class matrix_view {
+public:
+    /** @brief Order of the view (number of dimensions). */
+    static constexpr std::size_t order = sizeof...(Dimensions);
+    /** @brief Dimensions of the view. */
+    static constexpr std::array dimensions = {Dimensions...};
+
+private:
+    static constexpr std::size_t linear_size = (Dimensions * ...);
+    T* _ptr;
+
+    // Centralises the single pointer-arithmetic operation so every caller stays clean.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    [[nodiscard]] constexpr T* end_ptr() const noexcept { return _ptr + linear_size; }
+
+public:
+    // ─── typedefs ────────────────────────────────────────────────────────────
+
+    /** @brief Element type. */
+    using value_type = T;
+    /** @brief Unsigned integer type for sizes and counts. */
+    using size_type = std::size_t;
+    /** @brief Signed integer type for differences between iterators. */
+    using difference_type = std::ptrdiff_t;
+    /** @brief Reference to element type. */
+    using reference = T&;
+    /** @brief Const reference to element type. */
+    using const_reference = const T&;
+    /** @brief Pointer to element type. */
+    using pointer = T*;
+    /** @brief Const pointer to element type. */
+    using const_pointer = const T*;
+    /** @brief Contiguous iterator over view elements in row-major order. */
+    using iterator = T*;
+    /** @brief Const contiguous iterator over view elements in row-major order. */
+    using const_iterator = const T*;
+    /** @brief Reverse iterator. */
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    /** @brief Const reverse iterator. */
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    // ─── construction ────────────────────────────────────────────────────────
+
+    matrix_view() = delete;
+
+    /**
+     * @brief Constructs a view over an existing @c matrix.
+     * @param m Matrix to view
+     *
+     * Implicit conversion is intentional: `matrix_view<T,D...> v = m;` should work
+     * as naturally as `std::string_view sv = str;`.
+     *
+     * @code
+     * ysc::matrix<int, 3> m{1, 2, 3};
+     * ysc::matrix_view<int, 3> v = m;
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
+    constexpr matrix_view(matrix<T, Dimensions...>& m) noexcept : _ptr{m.data()} {}
+
+    /**
+     * @brief Constructs a view from a raw pointer to a contiguous sequence of elements.
+     * @param ptr Pointer to the first element
+     *
+     * The caller is responsible for ensuring that @p ptr points to a valid contiguous
+     * sequence of at least @c linear_size elements.
+     *
+     * @code
+     * int buf[6]{};
+     * ysc::matrix_view<int, 2, 3> v{buf};
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    constexpr explicit matrix_view(T* ptr) noexcept : _ptr{ptr} {}
+
+    /** @brief Copies the view (shallow: copies the pointer, not the data). */
+    constexpr matrix_view(const matrix_view&) noexcept = default;
+    /** @brief Copy-assigns the view (shallow). */
+    constexpr matrix_view& operator=(const matrix_view&) noexcept = default;
+    /** @brief Move-constructs the view. */
+    constexpr matrix_view(matrix_view&&) noexcept = default;
+    /** @brief Move-assigns the view. */
+    constexpr matrix_view& operator=(matrix_view&&) noexcept = default;
+    /** @brief Destructor (does not free the underlying storage). */
+    ~matrix_view() = default;
+
+    // ─── iterators ───────────────────────────────────────────────────────────
+
+    /**
+     * @brief Returns an iterator to the first element (row-major order).
+     * @return Iterator to the first element
+     * @ingroup ysc_view
+     */
+    constexpr iterator begin() noexcept { return _ptr; }
+
+    /**
+     * @brief Returns a const iterator to the first element (row-major order).
+     * @return Const iterator to the first element
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] constexpr const_iterator begin() const noexcept { return _ptr; }
+
+    /**
+     * @brief Returns a const iterator to the first element (row-major order).
+     * @return Const iterator to the first element
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] constexpr const_iterator cbegin() const noexcept { return _ptr; }
+
+    /**
+     * @brief Returns an iterator past the last element.
+     * @return Iterator past the last element
+     * @ingroup ysc_view
+     */
+    constexpr iterator end() noexcept { return end_ptr(); }
+
+    /**
+     * @brief Returns a const iterator past the last element.
+     * @return Const iterator past the last element
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] constexpr const_iterator end() const noexcept { return end_ptr(); }
+
+    /**
+     * @brief Returns a const iterator past the last element.
+     * @return Const iterator past the last element
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] constexpr const_iterator cend() const noexcept { return end_ptr(); }
+
+    /**
+     * @brief Returns a reverse iterator to the last element.
+     * @return Reverse iterator to the last element
+     * @ingroup ysc_view
+     */
+    constexpr reverse_iterator rbegin() noexcept { return reverse_iterator{end_ptr()}; }
+
+    /**
+     * @brief Returns a const reverse iterator to the last element.
+     * @return Const reverse iterator to the last element
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] constexpr const_reverse_iterator rbegin() const noexcept {
+        return const_reverse_iterator{end_ptr()};
+    }
+
+    /**
+     * @brief Returns a const reverse iterator to the last element.
+     * @return Const reverse iterator to the last element
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] constexpr const_reverse_iterator crbegin() const noexcept {
+        return const_reverse_iterator{end_ptr()};
+    }
+
+    /**
+     * @brief Returns a reverse iterator past the first element.
+     * @return Reverse iterator past the first element
+     * @ingroup ysc_view
+     */
+    constexpr reverse_iterator rend() noexcept { return reverse_iterator{_ptr}; }
+
+    /**
+     * @brief Returns a const reverse iterator past the first element.
+     * @return Const reverse iterator past the first element
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] constexpr const_reverse_iterator rend() const noexcept {
+        return const_reverse_iterator{_ptr};
+    }
+
+    /**
+     * @brief Returns a const reverse iterator past the first element.
+     * @return Const reverse iterator past the first element
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] constexpr const_reverse_iterator crend() const noexcept {
+        return const_reverse_iterator{_ptr};
+    }
+
+    // ─── capacity ────────────────────────────────────────────────────────────
+
+    /**
+     * @brief Returns the number of elements in the view (product of all dimensions).
+     * @return Number of elements
+     *
+     * @note This function is @c static because the size is a compile-time constant.
+     *
+     * @code
+     * static_assert(ysc::matrix_view<int, 2, 3>::size() == 6);
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] static constexpr size_type size() noexcept { return linear_size; }
+
+    /**
+     * @brief Returns the maximum number of elements the view can address.
+     * @return Maximum number of elements (always equal to @c size())
+     *
+     * @note This function is @c static because the value is a compile-time constant.
+     *
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] static constexpr size_type max_size() noexcept { return linear_size; }
+
+    /**
+     * @brief Returns whether the view has no elements.
+     * @return @c true if @c linear_size == 0
+     *
+     * @note This function is @c static because the value is a compile-time constant.
+     *
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] static constexpr bool empty() noexcept { return linear_size == 0; }
+
+    /**
+     * @brief Returns a pointer to the underlying element storage.
+     * @return Pointer to the first element
+     *
+     * Elements are stored in row-major order (rightmost dimension is contiguous).
+     *
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] constexpr pointer data() noexcept { return _ptr; }
+
+    /**
+     * @brief Returns a const pointer to the underlying element storage.
+     * @return Const pointer to the first element
+     *
+     * Elements are stored in row-major order (rightmost dimension is contiguous).
+     *
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] constexpr const_pointer data() const noexcept { return _ptr; }
+
+    // ─── element access ──────────────────────────────────────────────────────
+
+    /**
+     * @brief Returns a reference to the first element in the view (row-major order).
+     *
+     * Calling @c front() on an empty view is undefined behavior.
+     *
+     * @ingroup ysc_view
+     */
+    constexpr reference front() noexcept { return *_ptr; }
+
+    /**
+     * @brief Returns a const reference to the first element in the view (row-major order).
+     *
+     * Calling @c front() on an empty view is undefined behavior.
+     *
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] constexpr const_reference front() const noexcept { return *_ptr; }
+
+    /**
+     * @brief Returns a reference to the last element in the view (row-major order).
+     *
+     * Calling @c back() on an empty view is undefined behavior.
+     *
+     * @ingroup ysc_view
+     */
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    constexpr reference back() noexcept { return *(end_ptr() - 1); }
+
+    /**
+     * @brief Returns a const reference to the last element in the view (row-major order).
+     *
+     * Calling @c back() on an empty view is undefined behavior.
+     *
+     * @ingroup ysc_view
+     */
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    [[nodiscard]] constexpr const_reference back() const noexcept { return *(end_ptr() - 1); }
+
+    /**
+     * @brief Returns a reference to the element at the given coordinates.
+     * @tparam Coords Integral coordinate types
+     * @param coords  Coordinates of the element
+     * @return Reference to the element
+     *
+     * No bounds checking is performed; if @p coords are outside the view dimensions,
+     * the behavior is undefined.  Use @c at() for bounds-checked access.
+     *
+     * @code
+     * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+     * ysc::matrix_view<int, 2, 3> v = m;
+     * assert(v(1, 2) == 6);
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    template <class... Coords>
+        requires integral_coordinates<Coords...>
+    constexpr T const& operator()(Coords... coords) const noexcept {
+        // Intentional: unchecked access on the performance path. Use at() for bounds checking.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        return _ptr[detail::coordinates_to_index(dimensions, std::array{coords...})];
+    }
+
+    /**
+     * @brief Returns a reference to the element at the given coordinates.
+     * @tparam Coords Integral coordinate types
+     * @param coords  Coordinates of the element
+     * @return Reference to the element
+     *
+     * No bounds checking is performed; if @p coords are outside the view dimensions,
+     * the behavior is undefined.  Use @c at() for bounds-checked access.
+     *
+     * @code
+     * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+     * ysc::matrix_view<int, 2, 3> v = m;
+     * v(0, 0) = 99;
+     * assert(m(0, 0) == 99);
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    template <class... Coords>
+        requires integral_coordinates<Coords...>
+    constexpr T& operator()(Coords... coords) noexcept {
+        // Intentional: unchecked access on the performance path. Use at() for bounds checking.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        return _ptr[detail::coordinates_to_index(dimensions, std::array{coords...})];
+    }
+
+    /**
+     * @brief Returns a reference to the element at the given coordinates, with bounds checking.
+     * @tparam Coords Integral coordinate types
+     * @param coords  Coordinates of the element
+     * @return Reference to the element
+     * @throws std::out_of_range if any coordinate is negative or out of bounds
+     *
+     * @code
+     * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+     * ysc::matrix_view<int, 2, 3> v = m;
+     * assert(v.at(1, 2) == 6);
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    template <class... Coords>
+        requires integral_coordinates<Coords...>
+    [[nodiscard]] const T& at(Coords... coords) const {
+        const bool any_of_coords_is_negative = ((coords < 0) || ...);
+        const bool any_of_coords_is_out_of_bound = ((coords >= Dimensions) || ...);
+        if (any_of_coords_is_negative || any_of_coords_is_out_of_bound) {
+            throw std::out_of_range{"matrix_view::at"};
+        }
+        return (*this)(coords...);
+    }
+
+    /**
+     * @brief Returns a reference to the element at the given coordinates, with bounds checking.
+     * @tparam Coords Integral coordinate types
+     * @param coords  Coordinates of the element
+     * @return Reference to the element
+     * @throws std::out_of_range if any coordinate is negative or out of bounds
+     *
+     * @code
+     * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+     * ysc::matrix_view<int, 2, 3> v = m;
+     * v.at(0, 0) = 99;
+     * assert(m(0, 0) == 99);
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    template <class... Coords>
+        requires integral_coordinates<Coords...>
+    T& at(Coords... coords) {
+        const bool any_of_coords_is_negative = ((coords < 0) || ...);
+        const bool any_of_coords_is_out_of_bound = ((coords >= Dimensions) || ...);
+        if (any_of_coords_is_negative || any_of_coords_is_out_of_bound) {
+            throw std::out_of_range{"matrix_view::at"};
+        }
+        return (*this)(coords...);
+    }
+
+    // ─── modifiers ───────────────────────────────────────────────────────────
+
+    /**
+     * @brief Assigns the given value to all elements of the view.
+     * @param value Value to assign
+     *
+     * Modifications are reflected in the underlying @c matrix.
+     *
+     * @code
+     * ysc::matrix<int, 3> m{1, 2, 3};
+     * ysc::matrix_view<int, 3> v = m;
+     * v.fill(0);
+     * assert(m(0) == 0 && m(2) == 0);
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    constexpr void fill(const T& value) noexcept(std::is_nothrow_copy_assignable_v<T>) {
+        std::fill(begin(), end(), value);
+    }
+};
+
+} // namespace ysc
+
+#endif // YSC_MATRIX_VIEW_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(${TARGET_NAME}
     src/iterators.cpp
     src/dot.cpp
     src/matmul.cpp
+    src/matrix_view.cpp
     src/ostream.cpp
     src/reductions.cpp
     src/transpose.cpp

--- a/test/src/matrix_view.cpp
+++ b/test/src/matrix_view.cpp
@@ -105,6 +105,18 @@ TEST(matrix_view_at, out_of_range_too_large) {
     EXPECT_THROW((void)v.at(2, 0), std::out_of_range);
 }
 
+TEST(matrix_view_at, out_of_range_negative_mutable) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    ysc::matrix_view<int, 2, 3> v = m;
+    EXPECT_THROW((void)v.at(-1, 0), std::out_of_range);
+}
+
+TEST(matrix_view_at, out_of_range_too_large_mutable) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    ysc::matrix_view<int, 2, 3> v = m;
+    EXPECT_THROW((void)v.at(2, 0), std::out_of_range);
+}
+
 TEST(matrix_view_at, const_nominal_read) {
     ysc::matrix<int, 3> m{10, 20, 30};
     const ysc::matrix_view<int, 3> v = m;

--- a/test/src/matrix_view.cpp
+++ b/test/src/matrix_view.cpp
@@ -1,0 +1,240 @@
+#include <matrix.hpp>
+#include <matrix_view.hpp>
+
+#include <algorithm>
+#include <concepts>
+#include <gtest/gtest.h>
+#include <iterator>
+#include <numeric>
+#include <ranges>
+
+// ─── compile-time assertions ──────────────────────────────────────────────────
+
+static_assert(sizeof(ysc::matrix_view<int, 3, 3>) == sizeof(int*));
+static_assert(sizeof(ysc::matrix_view<double, 5>) == sizeof(double*));
+
+static_assert(std::contiguous_iterator<ysc::matrix_view<int, 3>::iterator>);
+static_assert(std::contiguous_iterator<ysc::matrix_view<int, 3>::const_iterator>);
+
+static_assert(ysc::matrix_view<int, 2, 3>::order == 2);
+static_assert(ysc::matrix_view<int, 2, 3>::size() == 6);
+static_assert(!ysc::matrix_view<int, 2, 3>::empty());
+
+static_assert(!std::is_default_constructible_v<ysc::matrix_view<int, 3>>);
+static_assert(std::is_constructible_v<ysc::matrix_view<int, 3>, ysc::matrix<int, 3>&>);
+// Non-const matrix_view cannot be constructed from a const matrix
+static_assert(!std::is_constructible_v<ysc::matrix_view<int, 3>, const ysc::matrix<int, 3>&>);
+
+// ─── construction ─────────────────────────────────────────────────────────────
+
+TEST(matrix_view_construct, from_matrix_implicit) {
+    ysc::matrix<int, 3> m{1, 2, 3};
+    ysc::matrix_view<int, 3> v = m;
+    EXPECT_EQ(v(0), m(0));
+    EXPECT_EQ(v(1), m(1));
+    EXPECT_EQ(v(2), m(2));
+}
+
+TEST(matrix_view_construct, copy_shares_pointer) {
+    ysc::matrix<int, 3> m{10, 20, 30};
+    ysc::matrix_view<int, 3> v1 = m;
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+    ysc::matrix_view<int, 3> v2 = v1;
+    v2(0) = 99;
+    EXPECT_EQ(m(0), 99);
+}
+
+TEST(matrix_view_construct, from_raw_pointer) {
+    std::array<int, 6> buf{1, 2, 3, 4, 5, 6};
+    ysc::matrix_view<int, 2, 3> v{buf.data()};
+    EXPECT_EQ(v(0, 0), 1);
+    EXPECT_EQ(v(1, 2), 6);
+}
+
+// ─── operator() ───────────────────────────────────────────────────────────────
+
+TEST(matrix_view_access, read_within_bounds) {
+    ysc::matrix<int, 2, 2> m{1, 2, 3, 4};
+    const ysc::matrix_view<int, 2, 2> v = m;
+    EXPECT_EQ(v(0, 0), 1);
+    EXPECT_EQ(v(0, 1), 2);
+    EXPECT_EQ(v(1, 0), 3);
+    EXPECT_EQ(v(1, 1), 4);
+}
+
+TEST(matrix_view_access, write_reflects_in_matrix) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    ysc::matrix_view<int, 2, 3> v = m;
+    v(0, 0) = 99;
+    v(1, 2) = 42;
+    EXPECT_EQ(m(0, 0), 99);
+    EXPECT_EQ(m(1, 2), 42);
+}
+
+TEST(matrix_view_access, write_in_matrix_visible_via_view) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    ysc::matrix_view<int, 2, 3> v = m;
+    m(1, 0) = 42;
+    EXPECT_EQ(v(1, 0), 42);
+}
+
+// ─── at() ─────────────────────────────────────────────────────────────────────
+
+TEST(matrix_view_at, nominal_read) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    const ysc::matrix_view<int, 2, 3> v = m;
+    EXPECT_EQ(v.at(1, 2), 6);
+}
+
+TEST(matrix_view_at, nominal_write) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    ysc::matrix_view<int, 2, 3> v = m;
+    v.at(0, 1) = 77;
+    EXPECT_EQ(m(0, 1), 77);
+}
+
+TEST(matrix_view_at, out_of_range_negative) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    const ysc::matrix_view<int, 2, 3> v = m;
+    EXPECT_THROW((void)v.at(-1, 0), std::out_of_range);
+}
+
+TEST(matrix_view_at, out_of_range_too_large) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    const ysc::matrix_view<int, 2, 3> v = m;
+    EXPECT_THROW((void)v.at(2, 0), std::out_of_range);
+}
+
+TEST(matrix_view_at, const_nominal_read) {
+    ysc::matrix<int, 3> m{10, 20, 30};
+    const ysc::matrix_view<int, 3> v = m;
+    EXPECT_EQ(v.at(2), 30);
+}
+
+// ─── iterators ────────────────────────────────────────────────────────────────
+
+TEST(matrix_view_iterators, range_for_read) {
+    ysc::matrix<int, 4> m{1, 2, 3, 4};
+    const ysc::matrix_view<int, 4> v = m;
+    int sum = 0;
+    for (const auto& x : v) {
+        sum += x;
+    }
+    EXPECT_EQ(sum, 10);
+}
+
+TEST(matrix_view_iterators, range_for_write_reflects_in_matrix) {
+    ysc::matrix<int, 3> m{1, 2, 3};
+    ysc::matrix_view<int, 3> v = m;
+    for (auto& x : v) {
+        x *= 2;
+    }
+    EXPECT_EQ(m(0), 2);
+    EXPECT_EQ(m(1), 4);
+    EXPECT_EQ(m(2), 6);
+}
+
+TEST(matrix_view_iterators, begin_equals_data) {
+    ysc::matrix<int, 3> m{1, 2, 3};
+    ysc::matrix_view<int, 3> v = m;
+    EXPECT_EQ(v.begin(), v.data());
+}
+
+TEST(matrix_view_iterators, end_minus_begin_equals_size) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    const ysc::matrix_view<int, 2, 3> v = m;
+    EXPECT_EQ(std::distance(v.begin(), v.end()), static_cast<std::ptrdiff_t>(v.size()));
+}
+
+TEST(matrix_view_iterators, cbegin_cend_accumulate) {
+    ysc::matrix<int, 4> m{10, 20, 30, 40};
+    const ysc::matrix_view<int, 4> v = m;
+    const int total = std::accumulate(v.cbegin(), v.cend(), 0);
+    EXPECT_EQ(total, 100);
+}
+
+TEST(matrix_view_iterators, rbegin_rend) {
+    ysc::matrix<int, 3> m{1, 2, 3};
+    const ysc::matrix_view<int, 3> v = m;
+    std::vector<int> rev(v.rbegin(), v.rend());
+    EXPECT_EQ(rev[0], 3);
+    EXPECT_EQ(rev[2], 1);
+}
+
+TEST(matrix_view_iterators, ranges_sort_through_view) {
+    ysc::matrix<int, 5> m{5, 3, 1, 4, 2};
+    ysc::matrix_view<int, 5> v = m;
+    std::ranges::sort(v);
+    EXPECT_TRUE(std::ranges::is_sorted(m));
+}
+
+// ─── front() / back() ────────────────────────────────────────────────────────
+
+TEST(matrix_view_accessors, front_read) {
+    ysc::matrix<int, 3> m{10, 20, 30};
+    const ysc::matrix_view<int, 3> v = m;
+    EXPECT_EQ(v.front(), 10);
+}
+
+TEST(matrix_view_accessors, front_write_reflects) {
+    ysc::matrix<int, 3> m{10, 20, 30};
+    ysc::matrix_view<int, 3> v = m;
+    v.front() = 99;
+    EXPECT_EQ(m(0), 99);
+}
+
+TEST(matrix_view_accessors, back_read) {
+    ysc::matrix<int, 3> m{10, 20, 30};
+    const ysc::matrix_view<int, 3> v = m;
+    EXPECT_EQ(v.back(), 30);
+}
+
+TEST(matrix_view_accessors, back_write_reflects) {
+    ysc::matrix<int, 3> m{10, 20, 30};
+    ysc::matrix_view<int, 3> v = m;
+    v.back() = 99;
+    EXPECT_EQ(m(2), 99);
+}
+
+// ─── capacity ────────────────────────────────────────────────────────────────
+
+TEST(matrix_view_capacity, size_equals_linear_size) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    const ysc::matrix_view<int, 2, 3> v = m;
+    EXPECT_EQ(v.size(), 6U);
+}
+
+TEST(matrix_view_capacity, data_points_to_matrix_data) {
+    ysc::matrix<int, 3> m{1, 2, 3};
+    ysc::matrix_view<int, 3> v = m;
+    EXPECT_EQ(v.data(), m.data());
+}
+
+TEST(matrix_view_capacity, data_write_through) {
+    ysc::matrix<int, 3> m{1, 2, 3};
+    ysc::matrix_view<int, 3> v = m;
+    v.data()[1] = 42;
+    EXPECT_EQ(m(1), 42);
+}
+
+// ─── fill() ──────────────────────────────────────────────────────────────────
+
+TEST(matrix_view_fill, fill_modifies_matrix) {
+    ysc::matrix<int, 2, 2> m{1, 2, 3, 4};
+    ysc::matrix_view<int, 2, 2> v = m;
+    v.fill(0);
+    EXPECT_EQ(m(0, 0), 0);
+    EXPECT_EQ(m(0, 1), 0);
+    EXPECT_EQ(m(1, 0), 0);
+    EXPECT_EQ(m(1, 1), 0);
+}
+
+// ─── 1D regression ───────────────────────────────────────────────────────────
+
+TEST(matrix_view_1d, single_coord_access) {
+    ysc::matrix<int, 5> m{10, 20, 30, 40, 50};
+    ysc::matrix_view<int, 5> v = m;
+    EXPECT_EQ(v(0), 10);
+    EXPECT_EQ(v(2), 30);
+    EXPECT_EQ(v(4), 50);
+}


### PR DESCRIPTION
## Résumé

Implémente `ysc::matrix_view<T, Dimensions...>`, une vue non-owning sur un `ysc::matrix` ou tout tableau contigu de `T`. La classe stocke un unique pointeur brut `T*`, ce qui garantit `sizeof(matrix_view<T,D...>) == sizeof(T*)`. Elle expose la même interface que `matrix` : `operator()`, `at()`, iterateurs complets (begin/end/rbegin/crend/…), `front()`, `back()`, `fill()`, `data()`, `size()`, `empty()`.

## Critères d'acceptation

- [x] Construction depuis `matrix&` (implicite) : `matrix_view<int,3> v = m;`
- [x] Mutation via la vue reflétée dans la matrice originale
- [x] `static_assert(sizeof(matrix_view<int,3,3>) == sizeof(int*))`
- [x] `at()` lève `std::out_of_range` hors bornes
- [x] Tests dans `test/src/matrix_view.cpp` (30 tests + 6 `static_assert`)

## DoD transverse

- [x] Build et tests verts (`cmake --build build --target check`)
- [x] Aucun avertissement clang-format
- [x] Aucun avertissement clang-tidy
- [x] Toutes les fonctions publiques documentées Doxygen (@brief, @tparam, @param, @return, @throws, @code, @ingroup ysc_view)

## Décisions d'implémentation

- `matrix_view.hpp` inclut `matrix.hpp` pour réutiliser `detail::coordinates_to_index` et le concept `integral_coordinates`. Cette dépendance deviendra circulaire en US-036 (qui ajoutera `m.row()` dans `matrix.hpp`) ; la refactorisation en header partagé est reportée à cette US.
- Le helper privé `end_ptr()` centralise l'unique opération d'arithmétique de pointeur et porte le seul `NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)` de la classe.
- Le constructeur depuis `matrix&` est implicite (NOLINTNEXTLINE justifié), par analogie avec `std::string_view`.