### PR TITLE
chore: raffiner la spec US-036 (slice N-D, matrix_view unifié)

### DIFF
--- a/doc/US-036.md
+++ b/doc/US-036.md
@@ -1,0 +1,240 @@
+# US-036 — `slice()` générique N-D
+
+**Priorité :** P2 — **Dépend de :** US-035 — **Bloque :** US-037, US-044
+
+---
+
+## Story
+
+En tant qu'utilisateur de `ysc::matrix`, je veux pouvoir extraire une sous-vue en fixant n'importe quelle combinaison de dimensions, avec des indices déterminés à l'exécution, de manière à obtenir une vue non-owning (les mutations sont reflétées dans la matrice d'origine).
+
+---
+
+## Décisions de design
+
+| Choix | Décision |
+|-------|----------|
+| Sentinelle | `ysc::all` — `struct all_t {}; inline constexpr all_t all{};` dans `<matrix.hpp>` |
+| Tags de storage | `struct ysc::contiguous {};` et `struct ysc::strided {};` (types tag) |
+| API | `m.slice(spec0, spec1, ...)` — chaque argument : `all` (conserver) ou un entier (fixer) |
+| Args manquants | **Padding `all` à droite** — `m.slice(0)` sur 3D ≡ `m.slice(0, all, all)`. `m.slice()` ≡ vue complète |
+| Indices | Valeurs runtime (`std::size_t` ou tout type intégral) — pas de constexpr requis |
+| Hors-bornes | `slice()` **lève** `std::out_of_range` si un index fixé est `< 0` ou `>= Dim[i]` |
+| Retour contigu | `matrix_view<T, contiguous, kept...>` si les dimensions fixées forment un **préfixe** |
+| Retour non-contigu | `matrix_view<T, strided, kept...>` dans tous les autres cas |
+| Conversion vues | Implicite `matrix_view<T, contiguous, D...>` → `matrix_view<T, strided, D...>` |
+| Aliases 2D | `row(i)` ≡ `slice(i)` ≡ `slice(i, all)` ; `col(j)` ≡ `slice(all, j)`, contraints à `order == 2` |
+
+### Définition du préfixe
+
+Le padding `all` à droite est appliqué **avant** l'analyse de préfixe.
+
+```
+Préfixe ⟺ le motif (après padding) est : (entiers)+ puis (all*)
+  slice(i)              → padding → (i, all, all)   → préfixe       → contiguous
+  slice(i, all, all)    → (i, all, all)             → préfixe       → contiguous
+  slice(i, j, all)      → (i, j, all)               → préfixe       → contiguous
+  slice(all, j, all)    → (all, j, all)             → non-préfixe   → strided
+  slice(all, all, k)    → (all, all, k)             → non-préfixe   → strided
+  slice()               → padding → (all, all, all) → préfixe vide  → contiguous (vue complète)
+```
+
+### Calcul du pointeur de base et des strides
+
+Pour `matrix<T, D0, D1, ..., DN>` et `slice(spec0, spec1, ..., specN)` (après padding) :
+
+- **Pointeur de base** : `_data.data() + Σ (index_i × ∏ Dⱼ pour j > i)` pour chaque dim fixée `i`
+- **Stride de la dim conservée `k`** : `∏ Dⱼ pour j > k` (produit sur les dims de la matrice d'**origine**, y compris les dims fixées)
+
+Ces valeurs sont entièrement dérivables des paramètres template (donc constexpr), mais stockées à l'exécution dans la spécialisation `strided`.
+
+---
+
+## Refonte de `matrix_view` en template `<T, Storage, Dims…>`
+
+Fichier : `src/include/matrix_view.hpp`
+
+L'actuel `matrix_view<T, Dims...>` (US-035) devient `matrix_view<T, contiguous, Dims...>`. Une seconde spécialisation `matrix_view<T, strided, Dims...>` est ajoutée. Aucun fichier `strided_matrix_view.hpp` n'est créé.
+
+```cpp
+namespace ysc {
+
+struct contiguous {};
+struct strided    {};
+struct all_t      {};
+inline constexpr all_t all{};
+
+template <class T, class Storage, std::size_t... Dims>
+class matrix_view;  // primaire, non défini
+
+// Spécialisation contiguë : sizeof == sizeof(T*)
+template <class T, std::size_t... Dims>
+class matrix_view<T, contiguous, Dims...> {
+    T* _ptr;
+public:
+    // typedefs STL-compatibles (value_type, reference, iterator, ...)
+    // Construction implicite depuis matrix<T, Dims...>& (US-035, inchangé)
+    // operator(), at(), begin/end/cbegin/cend, rbegin/rend, front/back, data, fill,
+    // empty/size/max_size, order, dimensions
+    // (= API publique actuelle US-035, telle quelle)
+
+    // Conversion implicite vers la vue strided correspondante (strides naturels)
+    operator matrix_view<T, strided, Dims...>() const noexcept;
+};
+
+// Spécialisation strided : sizeof == sizeof(T*) + order * sizeof(std::size_t)
+template <class T, std::size_t... Dims>
+class matrix_view<T, strided, Dims...> {
+    T*                                       _ptr;
+    std::array<std::size_t, sizeof...(Dims)> _strides;
+
+public:
+    using value_type      = T;
+    using size_type       = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using reference       = T&;
+    using const_reference = const T&;
+    using pointer         = T*;
+    using const_pointer   = const T*;
+
+    static constexpr std::size_t order      = sizeof...(Dims);
+    static constexpr std::array  dimensions = {Dims...};
+
+    matrix_view() = delete;
+
+    explicit matrix_view(T* ptr,
+                         std::array<std::size_t, sizeof...(Dims)> strides) noexcept;
+
+    template <class... Coords>
+        requires integral_coordinates<Coords...> && (sizeof...(Coords) == sizeof...(Dims))
+    [[nodiscard]] constexpr T&       operator()(Coords... coords) noexcept;
+    [[nodiscard]] constexpr const T& operator()(Coords... coords) const noexcept;
+
+    template <class... Coords>
+        requires integral_coordinates<Coords...> && (sizeof...(Coords) == sizeof...(Dims))
+    [[nodiscard]] T&       at(Coords... coords);
+    [[nodiscard]] const T& at(Coords... coords) const;
+
+    static constexpr size_type size()  noexcept { return (Dims * ...); }
+    static constexpr bool      empty() noexcept { return size() == 0; }
+    static constexpr size_type max_size() noexcept { return size(); }
+
+    // Pas de begin()/end() (données non-contiguës — itérateurs dans une US future)
+    // Pas de data() (accès brut sans sens sur vue strided)
+    // Pas de fill() (introductible plus tard via apply ou itérateurs)
+};
+
+} // namespace ysc
+```
+
+**Formule d'accès strided :**
+```
+element(c0, c1, ...) = *(_ptr + c0*_strides[0] + c1*_strides[1] + ...)
+```
+
+---
+
+## API `slice()` sur `matrix<T, Dims...>`
+
+```cpp
+template <typename... Specs>
+    requires (sizeof...(Specs) <= sizeof...(Dims))
+          && ((std::same_as<Specs, all_t> || std::integral<Specs>) && ...)
+[[nodiscard]] constexpr auto slice(Specs... specs) &;
+[[nodiscard]] constexpr auto slice(Specs... specs) const&;
+```
+
+- **Padding** : si `sizeof...(Specs) < order`, les positions manquantes sont complétées par `all_t{}` à droite.
+- **Vérification** : pour chaque spec entière à la position `i`, lève `std::out_of_range` si `idx < 0` ou `idx >= Dim[i]`.
+- **Retour** : `matrix_view<T, contiguous, kept...>` si les dims fixées forment un préfixe, sinon `matrix_view<T, strided, kept...>`. Sélection par `if constexpr (detail::is_prefix_slice<Padded...>())`.
+- **Non `noexcept`** (peut lever `std::out_of_range`).
+
+Documentation Doxygen : `@throws std::out_of_range`, exemples couvrant le padding implicite (`m.slice(0)` sur 3D) et le slice complet (`m.slice()`).
+
+---
+
+## Aliases `row()` / `col()` (matrices 2D uniquement)
+
+```cpp
+template <std::size_t D = order> requires (D == 2)
+[[nodiscard]] constexpr auto row(std::size_t i) &
+    -> matrix_view<T, contiguous, dimensions[1]>;
+template <std::size_t D = order> requires (D == 2)
+[[nodiscard]] constexpr auto row(std::size_t i) const&
+    -> matrix_view<const T, contiguous, dimensions[1]>;
+
+template <std::size_t D = order> requires (D == 2)
+[[nodiscard]] constexpr auto col(std::size_t j) &
+    -> matrix_view<T, strided, dimensions[0]>;
+template <std::size_t D = order> requires (D == 2)
+[[nodiscard]] constexpr auto col(std::size_t j) const&
+    -> matrix_view<const T, strided, dimensions[0]>;
+```
+
+Lèvent `std::out_of_range` si `i` ou `j` est hors-bornes (cohérence avec `slice()`).
+
+---
+
+## Métaprogrammation (dans `ysc::detail`)
+
+Helpers à ajouter dans `src/include/matrix.hpp` :
+
+| Helper | Rôle |
+|--------|------|
+| `is_all<S>` | `true` ssi `S == all_t` |
+| `pad_right_with_all<Specs..., N>` | Complète `Specs...` avec `all_t` jusqu'à `N` éléments |
+| `is_prefix_slice<PaddedSpecs...>()` | Retourne `true` si le motif est (intégraux)+(all*) |
+| `kept_dims_seq<PaddedSpecs, DimSeq>` | `std::index_sequence` des dims conservées |
+| `compute_offset(specs..., dims)` | Offset runtime du pointeur de base |
+| `compute_strides<PaddedSpecs>(dims)` | `std::array` des strides pour la vue strided |
+
+---
+
+## Fichiers à créer / modifier
+
+| Fichier | Action |
+|---------|--------|
+| `src/include/matrix_view.hpp` | **Modifier** — passage en template `<T, Storage, Dims…>` à deux spécialisations partielles ; déplacer l'actuel contenu dans la spé `contiguous` ; ajouter la spé `strided` ; ajouter la conversion implicite |
+| `src/include/matrix.hpp` | **Modifier** — ajouter `all_t`/`all`, `contiguous`, `strided`, helpers `detail::`, `slice()`, `row()`, `col()` |
+| `test/src/matrix_view.cpp` | **Modifier** — renommer les types : `matrix_view<T, D…>` → `matrix_view<T, contiguous, D…>` |
+| `test/src/slice.cpp` | **Créer** — tests dédiés (padding, hors-bornes, préfixe/non-préfixe, conversion) |
+| `doc/user-stories.md` | **Modifier** — mettre à jour la spec US-036 |
+
+---
+
+## Critères d'acceptation
+
+- [ ] `m.slice(i, all, all)` retourne `matrix_view<T, contiguous, …>` (vérifiable par `static_assert` sur le type retourné)
+- [ ] `m.slice(all, j, all)` retourne `matrix_view<T, strided, …>`
+- [ ] `m.slice(0)` sur matrice 3D ≡ `m.slice(0, all, all)` (padding `all` à droite)
+- [ ] `m.slice()` retourne une vue complète (équivalente à `matrix_view<T, contiguous, …>` sur toute la matrice)
+- [ ] Mutation via la vue reflétée dans la matrice d'origine (`m.slice(all, j)(i) = v` modifie `m(i, j)`)
+- [ ] `m.slice(...)` sur matrice `const` retourne une vue `const` (mutation refusée à la compilation)
+- [ ] `m.slice(idx_hors_bornes, …)` lève `std::out_of_range`
+- [ ] Conversion implicite `matrix_view<T, contiguous, D…>` → `matrix_view<T, strided, D…>` testée (passage à une API consommatrice de strided)
+- [ ] `m.row(i)` sur matrice 2D — retourne `matrix_view<T, contiguous, …>` correct
+- [ ] `m.col(j)` sur matrice 2D — retourne `matrix_view<T, strided, …>`, mutation reflétée
+- [ ] `m.row(idx_hors_bornes)` / `m.col(idx_hors_bornes)` lèvent `std::out_of_range`
+- [ ] `at()` sur la spé `strided` lève `std::out_of_range` hors bornes
+- [ ] `row()`/`col()` refusés à la compilation pour `order ≠ 2`
+- [ ] Toutes les fonctions publiques documentées Doxygen (`@brief`, `@tparam`, `@param`, `@return`, `@throws`, `@code`…`@endcode`, `@ingroup ysc_view`)
+- [ ] Build et tests verts, pas de warning clang-format, pas de warning clang-tidy
+
+---
+
+## Note sur la taille de la PR
+
+Avec l'unification des deux vues (un seul fichier `matrix_view.hpp` au lieu de deux) et l'extraction du constructeur `matrix(matrix_view)` vers **US-044**, l'US-036 reste susceptible d'avoisiner les 400 lignes (hors tests) mais le risque de dépassement est réduit. Si nécessaire, découper en :
+
+- **US-036a** : refonte de `matrix_view` en spécialisations + tags + `ysc::all` (~300 lignes)
+- **US-036b** : `slice()`, `row()`, `col()` + métaprogrammation (~250 lignes)
+
+---
+
+## Vérification
+
+```bash
+cmake --build build --target check          # build + tests verts
+cmake --build build --target format-check   # pas de warning clang-format
+cmake --build build --target lint           # pas de warning clang-tidy
+```

--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -11,10 +11,10 @@
 | **E — Comparaison & I/O** | ✅ Terminée | 7/7 | ✅ US-019, US-020, US-021, US-022, US-023, US-024, US-025 |
 | **F — Arithmétique** | ✅ Terminée | 4/4 | ✅ US-026, ✅ US-027, ✅ US-028, ✅ US-029 |
 | **G — Algorithmes** | ✅ Terminée | 5/5 | ✅ US-030, ✅ US-031, ✅ US-032, ✅ US-033, ✅ US-034 |
-| **H — Vues & reshape** | 🔄 En cours | 1/3 | ✅ US-035, ⬜ US-036, ⬜ US-037 |
+| **H — Vues & reshape** | 🔄 En cours | 1/4 | ✅ US-035, ⬜ US-036, ⬜ US-037, ⬜ US-044 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/6 | ⬜ US-038 à US-043 |
 
-**Total : 34 / 43 US**
+**Total : 34 / 44 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -878,21 +878,31 @@ constexpr T dot(const matrix<T, N>& a, const matrix<T, N>& b);
 
 ---
 
-## US-036 — Slicing / submatrix
+## US-036 — `slice()` générique N-D
 
-**Priorité :** P2 — **Dépend de :** US-035
+**Priorité :** P2 — **Dépend de :** US-035 — **Bloque :** US-037, US-044
 
 ### Spécification
-- Pour matrices 2D uniquement (extension N-D = autre US)
-- Méthode `m.row(i)` retourne `matrix_view<T, C>`
-- Méthode `m.col(j)` retourne `matrix_view<T, R>` — **mais col n'est pas contiguë** → nécessite stride. Décision : `col()` retourne `strided_matrix_view` (nouvelle classe avec stride). Autre option plus simple : `col()` copie dans `matrix<T, R>` (no view).
-  - **Choix retenu :** `col()` retourne **copie** `matrix<T, R>` (simplicité ; perf acceptable). `row()` retourne `matrix_view` (zero-copy).
+- API `m.slice(spec0, spec1, ...)` — chaque argument : `ysc::all` (conserver) ou un entier (fixer)
+- **Padding `all` à droite** : si `sizeof...(Specs) < order`, complétion implicite par `all` (`m.slice(0)` sur 3D ≡ `m.slice(0, all, all)`)
+- Refonte de `matrix_view` en template `<T, Storage, Dims…>` avec deux **spécialisations partielles** :
+  - `matrix_view<T, contiguous, …>` — anciennement `matrix_view<T, …>` (US-035, breaking change)
+  - `matrix_view<T, strided, …>` — nouvelle, pour les vues non-contiguës
+- `slice()` choisit `contiguous` si les dims fixées forment un préfixe, `strided` sinon
+- Conversion implicite `contiguous` → `strided` (toute vue contiguë s'utilise comme strided)
+- `slice()` **lève** `std::out_of_range` si un index fixé est hors-bornes
+- Aliases ergonomiques `m.row(i)` ≡ `slice(i)` et `m.col(j)` ≡ `slice(all, j)`, contraints à `order == 2`
+
+**Spécification détaillée :** voir `doc/US-036.md`.
 
 ### Critères d'acceptation
-- [ ] `m.row(0)` est un view
-- [ ] `m.col(0)` est une copie
-- [ ] Modif via `m.row(0)(j)` reflétée dans `m`
-- [ ] Documentation explicite sur la différence
+- [ ] `m.slice(i, all, all)` retourne `matrix_view<T, contiguous, …>`
+- [ ] `m.slice(all, j, all)` retourne `matrix_view<T, strided, …>`
+- [ ] `m.slice(0)` sur 3D ≡ `m.slice(0, all, all)` ; `m.slice()` = vue complète
+- [ ] `m.slice(idx_hors_bornes, …)` lève `std::out_of_range`
+- [ ] Conversion implicite contiguous → strided testée
+- [ ] Mutation via vue reflétée dans la matrice d'origine
+- [ ] `row()` / `col()` refusés à la compilation pour `order ≠ 2`
 
 ---
 
@@ -1058,3 +1068,40 @@ En tant qu'utilisateur de la bibliothèque, je veux que chaque fonction publique
 - [ ] La page `@mainpage` liste les 6 groupes ; chaque groupe est accessible en 1 clic depuis la page principale
 - [ ] `cmake --build build --target doc` produit zéro avertissement Doxygen
 - [ ] La CI est rouge si un avertissement Doxygen est introduit (`WARN_AS_ERROR = YES`)
+
+---
+
+## US-044 — Constructeur `matrix(matrix_view)` (owning ← view)
+
+**Priorité :** P2 — **Dépend de :** US-036 — **Épopée :** H
+
+### Story
+En tant qu'utilisateur de `ysc::matrix`, je veux pouvoir reconstruire une matrice owning à partir d'une vue (contiguë ou strided), de manière à matérialiser un résultat de `slice()`, `row()`, `col()` ou `reshape()` en une nouvelle matrice indépendante.
+
+### Spécification
+```cpp
+template <class T, std::size_t... Dims> class matrix {
+    // ...
+    template <class Storage>
+    explicit matrix(const matrix_view<T, Storage, Dims...>& v);
+};
+
+// Usage :
+ysc::matrix<int, 3, 4> m{/*...*/};
+auto v  = m.slice(ysc::all, 0);   // matrix_view<int, strided, 3>
+auto m2 = ysc::matrix(v);          // matrix<int, 3>, copie owning
+```
+
+- Deux surcharges (sélection par `Storage`) :
+  - `contiguous` : copie via `std::copy(v.begin(), v.end(), _data.begin())`.
+  - `strided` : copie élément par élément via `operator()` (pas d'itérateurs sur strided dans US-036).
+- Constructeur **`explicit`** pour éviter les conversions implicites surprises.
+- Pas d'allocation, pas d'exception (en dehors de celles éventuelles du copy ctor de `T`).
+
+### Critères d'acceptation
+- [ ] `auto m2 = ysc::matrix(v);` compile pour `v` issu de `slice(...)`, `row(...)`, `col(...)`.
+- [ ] `m2` est indépendant : mutation de `m2` n'affecte pas la matrice source, et vice-versa.
+- [ ] Surcharge `contiguous` testée (copie de `m.slice(i, all, all)`).
+- [ ] Surcharge `strided` testée (copie de `m.col(j)`).
+- [ ] Constructeur Doxygen-documenté (`@brief`, `@tparam`, `@param`, `@code`…`@endcode`, `@ingroup`).
+- [ ] Build et tests verts, pas de warning clang-format ni clang-tidy.


### PR DESCRIPTION
## Résumé

Raffinement de la spec US-036 avant implémentation, suite à une revue de design :

- **Unification des vues** : `matrix_view` et `strided_matrix_view` (deux classes distinctes dans la spec originale) sont remplacés par deux **spécialisations partielles** d'un même template `matrix_view<T, Storage, Dims…>` avec les tags `ysc::contiguous` et `ysc::strided`. Breaking change sur US-035 : `matrix_view<T, D…>` → `matrix_view<T, contiguous, D…>`.
- **`all` implicite** : `m.slice(0)` sur 3D ≡ `m.slice(0, all, all)` (padding `all` à droite). `m.slice()` = vue complète.
- **Hors-bornes** : `slice()` lève `std::out_of_range` si un index fixé est hors-bornes (pas de `noexcept`, pas de variante `slice_at()`).
- **Conversion implicite** `contiguous` → `strided`.
- **Nouvelle US-044** ajoutée à l'Epic H : constructeur `matrix(matrix_view)` owning ← view (dépend de US-036).

## Changements

- `doc/US-036.md` — réécriture complète de la spec
- `doc/user-stories.md` — Epic H étendu (1/4), section US-036 mise à jour, section US-044 ajoutée

## Checklist

- [x] `doc/US-036.md` reflète toutes les décisions de design arrêtées
- [x] `doc/user-stories.md` : dashboard Epic H à jour (1/4), US-044 documentée
- [x] Exemples de code cohérents avec les nouvelles signatures
- [x] Aucun build/test à exécuter (session purement documentaire)