### PR TITLE
US-036 — slice() générique N-D, matrix_view unifié

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
 
   format-check:
     name: Format Check (clang-format)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -242,7 +242,7 @@ jobs:
 
   lint:
     name: Lint (clang-tidy)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
 
   format-check:
     name: Format Check (clang-format)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -242,7 +242,7 @@ jobs:
 
   lint:
     name: Lint (clang-tidy)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/cmake/ClangFormat.cmake
+++ b/cmake/ClangFormat.cmake
@@ -1,17 +1,38 @@
-find_program(CLANG_FORMAT_EXECUTABLE NAMES clang-format)
+find_program(DOCKER_EXECUTABLE NAMES docker)
 
-if(CLANG_FORMAT_EXECUTABLE)
+if(DOCKER_EXECUTABLE)
     file(GLOB_RECURSE ALL_SOURCES
         ${CMAKE_SOURCE_DIR}/src/*.hpp
         ${CMAKE_SOURCE_DIR}/test/include/*.hpp
         ${CMAKE_SOURCE_DIR}/test/src/*.cpp
     )
+
+    set(CONTAINER_SOURCES "")
+    foreach(ABS_PATH IN LISTS ALL_SOURCES)
+        file(RELATIVE_PATH REL_PATH ${CMAKE_SOURCE_DIR} ${ABS_PATH})
+        list(APPEND CONTAINER_SOURCES "/mnt/${REL_PATH}")
+    endforeach()
+
+    set(CLANG_FORMAT_DOCKERFILE ${CMAKE_SOURCE_DIR}/utils/clang-format/Dockerfile)
+    set(CLANG_FORMAT_IMAGE ysc-matrix-clang-format)
+
+    execute_process(COMMAND id -u OUTPUT_VARIABLE _docker_uid OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(COMMAND id -g OUTPUT_VARIABLE _docker_gid OUTPUT_STRIP_TRAILING_WHITESPACE)
+
     add_custom_target(format
-        COMMAND ${CLANG_FORMAT_EXECUTABLE} -i ${ALL_SOURCES}
-        COMMENT "Formatting source files with clang-format"
+        COMMAND ${DOCKER_EXECUTABLE} build
+            -t ${CLANG_FORMAT_IMAGE}
+            -f ${CLANG_FORMAT_DOCKERFILE}
+            ${CMAKE_SOURCE_DIR}/utils/clang-format
+        COMMAND ${DOCKER_EXECUTABLE} run --rm
+            --user ${_docker_uid}:${_docker_gid}
+            -v ${CMAKE_SOURCE_DIR}:/mnt
+            ${CLANG_FORMAT_IMAGE}
+            -i ${CONTAINER_SOURCES}
+        COMMENT "Formatting source files with clang-format (Docker)"
         VERBATIM
     )
-    message(STATUS "clang-format found: ${CLANG_FORMAT_EXECUTABLE} -- target 'format' available")
+    message(STATUS "docker found: ${DOCKER_EXECUTABLE} -- target 'format' available (via Docker clang-format 18.1.8)")
 else()
-    message(STATUS "clang-format not found -- target 'format' unavailable")
+    message(STATUS "docker not found -- target 'format' unavailable")
 endif()

--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -11,7 +11,7 @@
 | **E — Comparaison & I/O** | ✅ Terminée | 7/7 | ✅ US-019, US-020, US-021, US-022, US-023, US-024, US-025 |
 | **F — Arithmétique** | ✅ Terminée | 4/4 | ✅ US-026, ✅ US-027, ✅ US-028, ✅ US-029 |
 | **G — Algorithmes** | ✅ Terminée | 5/5 | ✅ US-030, ✅ US-031, ✅ US-032, ✅ US-033, ✅ US-034 |
-| **H — Vues & reshape** | 🔄 En cours | 1/4 | ✅ US-035, ⬜ US-036, ⬜ US-037, ⬜ US-044 |
+| **H — Vues & reshape** | 🔄 En cours | 2/4 | ✅ US-035, ✅ US-036, ⬜ US-037, ⬜ US-044 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/6 | ⬜ US-038 à US-043 |
 
 **Total : 34 / 44 US**
@@ -896,13 +896,13 @@ constexpr T dot(const matrix<T, N>& a, const matrix<T, N>& b);
 **Spécification détaillée :** voir `doc/US-036.md`.
 
 ### Critères d'acceptation
-- [ ] `m.slice(i, all, all)` retourne `matrix_view<T, contiguous, …>`
-- [ ] `m.slice(all, j, all)` retourne `matrix_view<T, strided, …>`
-- [ ] `m.slice(0)` sur 3D ≡ `m.slice(0, all, all)` ; `m.slice()` = vue complète
-- [ ] `m.slice(idx_hors_bornes, …)` lève `std::out_of_range`
-- [ ] Conversion implicite contiguous → strided testée
-- [ ] Mutation via vue reflétée dans la matrice d'origine
-- [ ] `row()` / `col()` refusés à la compilation pour `order ≠ 2`
+- [x] `m.slice(i, all, all)` retourne `matrix_view<T, contiguous, …>`
+- [x] `m.slice(all, j, all)` retourne `matrix_view<T, strided, …>`
+- [x] `m.slice(0)` sur 3D ≡ `m.slice(0, all, all)` ; `m.slice()` = vue complète
+- [x] `m.slice(idx_hors_bornes, …)` lève `std::out_of_range`
+- [x] Conversion implicite contiguous → strided testée
+- [x] Mutation via vue reflétée dans la matrice d'origine
+- [x] `row()` / `col()` refusés à la compilation pour `order ≠ 2`
 
 ---
 

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -3,11 +3,11 @@
  * @author Yankel Scialom (YSC) <yankel-pro@scialom.org>
  * @date 2019
  *
- * @copyright This project is released under GNU Lesser General Public License; see
- *            COPYING and COPYING.LESSER files attached.
+ * @copyright This project is released under GNU Lesser General Public License;
+ * see COPYING and COPYING.LESSER files attached.
  *
- * The matrix library is a header-only template library defining a general-purpose
- * multi-dimension container of static dimensions.
+ * The matrix library is a header-only template library defining a
+ * general-purpose multi-dimension container of static dimensions.
  */
 #ifndef YSC_MATRIX_HPP
 #define YSC_MATRIX_HPP
@@ -22,7 +22,8 @@
 #include <ostream>
 #include <stdexcept>
 #include <type_traits>
-// Clang < 17 cannot compile libstdc++-14's <format> due to unicode.h incompatibility
+// Clang < 17 cannot compile libstdc++-14's <format> due to unicode.h
+// incompatibility
 #if __has_include(<format>) && (!defined(__clang__) || __clang_major__ >= 17)
 #include <format>
 #include <sstream>
@@ -37,8 +38,8 @@ namespace detail {
 template <class T>
 concept ostream_streamable = requires(std::ostream& os, const T& v) { os << v; };
 
-// Print a hyperslice of a matrix starting at `it`, covering dimension `dim_idx` onward.
-// Returns an iterator past the last element printed.
+// Print a hyperslice of a matrix starting at `it`, covering dimension `dim_idx`
+// onward. Returns an iterator past the last element printed.
 // NOLINTNEXTLINE(misc-no-recursion)
 template <class It, class Dims>
 It print_recursive(std::ostream& os, It it, const Dims& dims, std::size_t dim_idx) {
@@ -82,36 +83,39 @@ constexpr struct matrix_zero_t {
  * @tparam T          Element type
  * @tparam Dimentions Dimensions of the matrix
  *
- * `matrix<T, 2, 5, 9>` is an order 3  matrix of @c T elements; its dimensions are
- * 2 by 5 by 9 (90 @c T elements in total).
+ * `matrix<T, 2, 5, 9>` is an order 3  matrix of @c T elements; its dimensions
+ * are 2 by 5 by 9 (90 @c T elements in total).
  *
  * This container is a class type with the semantics of an aggregate similar to
  * a struct holding a C-style array `T[Dimensions][...]` as its only non-static
  * data member. Unlike a C-style array, it doesn't decay to `T*` automatically.
- * As an aggregate impersonator, it can be initialized with aggregate-initialization
- * given exactly @c linear_size initializers that are convertible to @c T:
- * `ysc::matrix<int, 3, 2> m = {1,2,3,4,5,6};`.
+ * As an aggregate impersonator, it can be initialized with
+ * aggregate-initialization given exactly @c linear_size initializers that are
+ * convertible to @c T: `ysc::matrix<int, 3, 2> m = {1,2,3,4,5,6};`.
  *
  * The struct combines the performance and accessibility of a C-style array with
- * the benefits of a standard container, such as knowing its own size, supporting
- * assignment, random access iterators, etc.
+ * the benefits of a standard container, such as knowing its own size,
+ * supporting assignment, random access iterators, etc.
  *
  * @todo Requirements (Container, etc.)
  *
  * @todo Special case when one dimension is 0.
  *
  * ### Iterator invalidation
- * As a rule, iterators to aa matrix are never invalidated throughout the lifetime of
- * the matrix. One should take note, however, that during swap, the iterator will continue
- * to point to the same matrix element, and will thus change its value.
+ * As a rule, iterators to aa matrix are never invalidated throughout the
+ * lifetime of the matrix. One should take note, however, that during swap, the
+ * iterator will continue to point to the same matrix element, and will thus
+ * change its value.
  */
 template <class T, std::size_t... Dimensions> class matrix {
     template <class, std::size_t...> friend class matrix;
 
 public:
-    /** @brief Order of the matrix (2D matrix have order 2, 3D order 3, etc.). */
+    /** @brief Order of the matrix (2D matrix have order 2, 3D order 3, etc.).
+     */
     static constexpr std::size_t order = sizeof...(Dimensions);
-    /** @brief Dimensions of the matrix. An order-`N` matrix has `N` dimensions. */
+    /** @brief Dimensions of the matrix. An order-`N` matrix has `N` dimensions.
+     */
     static constexpr std::array dimensions = {Dimensions...};
 
 private:
@@ -162,9 +166,11 @@ public:
 
     // capacity
     /**
-     * @brief Returns the number of elements in the matrix (product of all dimensions).
+     * @brief Returns the number of elements in the matrix (product of all
+     * dimensions).
      *
-     * @note This function is @c static because the size is a compile-time constant.
+     * @note This function is @c static because the size is a compile-time
+     * constant.
      */
     static constexpr size_type size() noexcept { return linear_size; }
 
@@ -173,28 +179,32 @@ public:
      *
      * Always equal to @c size() for this fixed-size container.
      *
-     * @note This function is @c static because the value is a compile-time constant.
+     * @note This function is @c static because the value is a compile-time
+     * constant.
      */
     static constexpr size_type max_size() noexcept { return linear_size; }
 
     /**
      * @brief Returns whether the matrix has no elements.
      *
-     * @note This function is @c static because the value is a compile-time constant.
+     * @note This function is @c static because the value is a compile-time
+     * constant.
      */
     static constexpr bool empty() noexcept { return linear_size == 0; }
 
     /**
      * @brief Returns a pointer to the underlying element storage.
      *
-     * Elements are stored in row-major order (rightmost dimension is contiguous).
+     * Elements are stored in row-major order (rightmost dimension is
+     * contiguous).
      */
     constexpr pointer data() noexcept { return _data.data(); }
 
     /**
      * @brief Returns a pointer to the underlying element storage.
      *
-     * Elements are stored in row-major order (rightmost dimension is contiguous).
+     * Elements are stored in row-major order (rightmost dimension is
+     * contiguous).
      */
     [[nodiscard]] constexpr const_pointer data() const noexcept { return _data.data(); }
 
@@ -206,7 +216,8 @@ public:
      * Swaps the elements of @a lhs and @a rhs as if:
      * @code
      using std::swap;
-     for (auto lhs_it = lhs.begin(), auto rhs_it = rhs.begin() ; lhs_it != lhs.end() ; ++lhs_it,
+     for (auto lhs_it = lhs.begin(), auto rhs_it = rhs.begin() ; lhs_it !=
+     lhs.end() ; ++lhs_it,
      ++rhs_it) { swap(*lhs_it, *rhs_it);
      }
      @endcode
@@ -220,31 +231,35 @@ public:
     /**
      * @brief Initializes the matrix.
      *
-     * @note If `T` is a trivial type, initialization may result in indeterminate values.
+     * @note If `T` is a trivial type, initialization may result in
+     * indeterminate values.
      */
-    // Intentional: _data is deliberately left uninitialized for trivial T to avoid the cost of
-    // zero-initialization on the hot path. Use matrix(matrix_zero_t) for zero-initialization.
+    // Intentional: _data is deliberately left uninitialized for trivial T to
+    // avoid the cost of zero-initialization on the hot path. Use
+    // matrix(matrix_zero_t) for zero-initialization.
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
     matrix() = default;
 
     /**
-     * @brief Initializes the matrix following the rules of default initialization.
+     * @brief Initializes the matrix following the rules of default
+     * initialization.
      *
-     * @note If `T` is a trivial type, the matrix is zero-initialized; otherwise the default
-     * constructors of its elements are called.
+     * @note If `T` is a trivial type, the matrix is zero-initialized; otherwise
+     * the default constructors of its elements are called.
      */
     constexpr matrix(matrix_zero_t /*zero*/) : _data({}) {}
 
     // aggregate constructors
     /**
-     * @brief Initializes the matrix following the rules of aggregate initialization.
+     * @brief Initializes the matrix following the rules of aggregate
+     * initialization.
      * @tparam Args... Source types (must all be convertible to @c T)
      * @param args...  Source values (must be exactly @c linear_size values)
      *
-     * `matrix<long, 2, 2> m{true, '\x02', 3, 4L}` initializes an order-2 matrix from the values
-     * `true`, `'\x02'`, `3` and `4L` converted to `long`.
-     * Partial initialization (fewer than `linear_size` values) is not supported; use
-     * `matrix(matrix_zero_t)` to zero-initialize.
+     * `matrix<long, 2, 2> m{true, '\x02', 3, 4L}` initializes an order-2 matrix
+     * from the values `true`, `'\x02'`, `3` and `4L` converted to `long`.
+     * Partial initialization (fewer than `linear_size` values) is not
+     * supported; use `matrix(matrix_zero_t)` to zero-initialize.
      */
     template <class... Args>
         requires(sizeof...(Args) == linear_size) && (std::convertible_to<Args, T> && ...) &&
@@ -256,11 +271,13 @@ public:
     // nested initializer_list constructor (2D only)
     /**
      * @brief Initializes a 2D matrix from a nested initializer list.
-     * @tparam D1 Deduced from @c order; constrained to 2 (do not specify explicitly).
-     * @param init Row-major nested initializer list; must have exactly @c dimensions[0] rows,
-     *             each of exactly @c dimensions[1] elements.
+     * @tparam D1 Deduced from @c order; constrained to 2 (do not specify
+     * explicitly).
+     * @param init Row-major nested initializer list; must have exactly @c
+     * dimensions[0] rows, each of exactly @c dimensions[1] elements.
      *
-     * @throws std::length_error if the number of rows or the size of any row does not match.
+     * @throws std::length_error if the number of rows or the size of any row
+     * does not match.
      *
      * @code
      * ysc::matrix<int, 2, 3> m{{1, 2, 3}, {4, 5, 6}};
@@ -296,7 +313,8 @@ public:
      * @tparam U     Element type of the source matrix
      * @param  other Source matrix
      *
-     * Elements of the matrix are copy-initialized from the elements of the source matrix.
+     * Elements of the matrix are copy-initialized from the elements of the
+     * source matrix.
      */
     template <class U>
         requires matrix_convertible_from<T, U>
@@ -309,8 +327,8 @@ public:
      * @brief Initializes the matrix with the content of another.
      * @param other Source matrix
      *
-     * Elements of the matrix are move-initialized from the elements of the source matrix.
-     * `other` is left in a valid but unspecified state.
+     * Elements of the matrix are move-initialized from the elements of the
+     * source matrix. `other` is left in a valid but unspecified state.
      */
     matrix(matrix&& other) = default;
 
@@ -319,13 +337,14 @@ public:
      * @tparam U     Element type of the source matrix
      * @param  other Source matrix
      *
-     * Elements of the matrix are move-initialized from the elements of the source matrix.
-     * `other` is left in a valid but unspecified state.
+     * Elements of the matrix are move-initialized from the elements of the
+     * source matrix. `other` is left in a valid but unspecified state.
      */
     template <class U>
         requires matrix_convertible_from<T, U>
-    // std::move is used as a range algorithm (element-wise move), not as a cast.
-    // Direct std::move(other) is impossible because T != U; per-element conversion is required.
+    // std::move is used as a range algorithm (element-wise move), not as a
+    // cast. Direct std::move(other) is impossible because T != U; per-element
+    // conversion is required.
     // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
     matrix(matrix<U, Dimensions...>&& other) {
         std::move(other._data.cbegin(), other._data.cend(), _data.begin());
@@ -364,8 +383,8 @@ public:
      */
     template <class U>
         requires matrix_convertible_from<T, U>
-    // Same rationale as the converting move constructor: element-wise move via algorithm,
-    // T != U prevents direct std::move(other).
+    // Same rationale as the converting move constructor: element-wise move via
+    // algorithm, T != U prevents direct std::move(other).
     // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
     matrix& operator=(matrix<U, Dimensions...>&& other) {
         std::move(other._data.cbegin(), other._data.cend(), _data.begin());
@@ -376,9 +395,13 @@ public:
     ~matrix() = default;
 
     // comparison operators
-    /** @brief Equality comparison — lexicographic on the flat row-major storage. */
+    /** @brief Equality comparison — lexicographic on the flat row-major
+     * storage.
+     */
     friend bool operator==(const matrix& lhs, const matrix& rhs) = default;
-    /** @brief Three-way comparison — lexicographic on the flat row-major storage. */
+    /** @brief Three-way comparison — lexicographic on the flat row-major
+     * storage.
+     */
     friend auto operator<=>(const matrix& lhs, const matrix& rhs) = default;
 
     // arithmetic operators
@@ -408,7 +431,8 @@ public:
     }
 
     /**
-     * @brief Subtracts @a other from this matrix element-wise and assigns the result.
+     * @brief Subtracts @a other from this matrix element-wise and assigns the
+     * result.
      * @param other Matrix to subtract
      * @return @c *this
      *
@@ -466,12 +490,13 @@ public:
     }
 
     /**
-     * @brief Multiplies this matrix by @a other element-wise (Hadamard product) and assigns.
+     * @brief Multiplies this matrix by @a other element-wise (Hadamard product)
+     * and assigns.
      * @param other Matrix to multiply by
      * @return @c *this
      *
-     * @note This is the Hadamard (element-wise) product, not the matrix product.
-     *       The matrix product will be available as @c ysc::matmul.
+     * @note This is the Hadamard (element-wise) product, not the matrix
+     * product. The matrix product will be available as @c ysc::matmul.
      *
      * @code
      * ysc::matrix<int, 2> a{2, 3}, b{4, 5};
@@ -489,7 +514,8 @@ public:
     }
 
     /**
-     * @brief Divides this matrix by @a other element-wise and assigns the result.
+     * @brief Divides this matrix by @a other element-wise and assigns the
+     * result.
      * @param other Divisor matrix
      * @return @c *this
      *
@@ -514,8 +540,8 @@ public:
      * @param rhs Right-hand matrix
      * @return New matrix containing element-wise products
      *
-     * @note This is the Hadamard (element-wise) product, not the matrix product.
-     *       The matrix product will be available as @c ysc::matmul.
+     * @note This is the Hadamard (element-wise) product, not the matrix
+     * product. The matrix product will be available as @c ysc::matmul.
      *
      * @code
      * ysc::matrix<int, 2> a{2, 3}, b{4, 5};
@@ -551,8 +577,10 @@ public:
 
     // scalar arithmetic operators
     /**
-     * @brief Multiplies every element of this matrix by scalar @a s and assigns the result.
-     * @tparam Scalar Scalar type — must support compound assignment: `T a; a *= Scalar`
+     * @brief Multiplies every element of this matrix by scalar @a s and assigns
+     * the result.
+     * @tparam Scalar Scalar type — must support compound assignment: `T a; a *=
+     * Scalar`
      * @param  s      Scalar multiplier
      * @return @c *this
      *
@@ -573,8 +601,10 @@ public:
     }
 
     /**
-     * @brief Divides every element of this matrix by scalar @a s and assigns the result.
-     * @tparam Scalar Scalar type — must support compound assignment: `T a; a /= Scalar`
+     * @brief Divides every element of this matrix by scalar @a s and assigns
+     * the result.
+     * @tparam Scalar Scalar type — must support compound assignment: `T a; a /=
+     * Scalar`
      * @param  s      Scalar divisor
      * @return @c *this
      *
@@ -595,8 +625,10 @@ public:
     }
 
     /**
-     * @brief Adds scalar @a s to every element of this matrix and assigns the result.
-     * @tparam Scalar Scalar type — must support compound assignment: `T a; a += Scalar`
+     * @brief Adds scalar @a s to every element of this matrix and assigns the
+     * result.
+     * @tparam Scalar Scalar type — must support compound assignment: `T a; a +=
+     * Scalar`
      * @param  s      Scalar addend
      * @return @c *this
      *
@@ -617,8 +649,10 @@ public:
     }
 
     /**
-     * @brief Subtracts scalar @a s from every element of this matrix and assigns the result.
-     * @tparam Scalar Scalar type — must support compound assignment: `T a; a -= Scalar`
+     * @brief Subtracts scalar @a s from every element of this matrix and
+     * assigns the result.
+     * @tparam Scalar Scalar type — must support compound assignment: `T a; a -=
+     * Scalar`
      * @param  s      Scalar subtrahend
      * @return @c *this
      *
@@ -640,7 +674,8 @@ public:
 
     /**
      * @brief Returns the element-wise product of a matrix and a scalar.
-     * @tparam Scalar Scalar type — must support compound assignment: `T a; a *= Scalar`
+     * @tparam Scalar Scalar type — must support compound assignment: `T a; a *=
+     * Scalar`
      * @param  lhs    Matrix operand
      * @param  s      Scalar multiplier
      * @return New matrix with each element multiplied by @a s
@@ -660,8 +695,10 @@ public:
     }
 
     /**
-     * @brief Returns the element-wise product of a scalar and a matrix (commutative).
-     * @tparam Scalar Scalar type — must support compound assignment: `T a; a *= Scalar`
+     * @brief Returns the element-wise product of a scalar and a matrix
+     * (commutative).
+     * @tparam Scalar Scalar type — must support compound assignment: `T a; a *=
+     * Scalar`
      * @param  s      Scalar multiplier
      * @param  rhs    Matrix operand
      * @return New matrix with each element multiplied by @a s
@@ -682,7 +719,8 @@ public:
 
     /**
      * @brief Returns a new matrix with every element divided by scalar @a s.
-     * @tparam Scalar Scalar type — must support compound assignment: `T a; a /= Scalar`
+     * @tparam Scalar Scalar type — must support compound assignment: `T a; a /=
+     * Scalar`
      * @param  lhs    Matrix operand
      * @param  s      Scalar divisor
      * @return New matrix with each element divided by @a s
@@ -703,7 +741,8 @@ public:
 
     /**
      * @brief Returns a new matrix with scalar @a s added to every element.
-     * @tparam Scalar Scalar type — must support compound assignment: `T a; a += Scalar`
+     * @tparam Scalar Scalar type — must support compound assignment: `T a; a +=
+     * Scalar`
      * @param  lhs    Matrix operand
      * @param  s      Scalar addend
      * @return New matrix with @a s added to each element
@@ -723,8 +762,10 @@ public:
     }
 
     /**
-     * @brief Returns a new matrix with scalar @a s subtracted from every element.
-     * @tparam Scalar Scalar type — must support compound assignment: `T a; a -= Scalar`
+     * @brief Returns a new matrix with scalar @a s subtracted from every
+     * element.
+     * @tparam Scalar Scalar type — must support compound assignment: `T a; a -=
+     * Scalar`
      * @param  lhs    Matrix operand
      * @param  s      Scalar subtrahend
      * @return New matrix with @a s subtracted from each element
@@ -787,7 +828,8 @@ public:
      * @tparam F Callable type — must satisfy `std::invocable<F, T&>`
      * @param  f Function to apply to each element
      *
-     * Visits every element in row-major order and calls @a f with a reference to the element.
+     * Visits every element in row-major order and calls @a f with a reference
+     * to the element.
      * @a f may modify the element; the matrix is mutated in place.
      *
      * @code
@@ -807,11 +849,12 @@ public:
     }
 
     /**
-     * @brief Returns a new matrix obtained by applying a function to every element.
+     * @brief Returns a new matrix obtained by applying a function to every
+     * element.
      * @tparam F  Callable type — must satisfy `std::invocable<F, const T&>`
      * @param  f  Function to apply to each element
-     * @return A new matrix whose element type is `std::invoke_result_t<F, const T&>`
-     *         and whose dimensions are identical to @c *this.
+     * @return A new matrix whose element type is `std::invoke_result_t<F, const
+     * T&>` and whose dimensions are identical to @c *this.
      *
      * Does not modify the original matrix.
      *
@@ -825,8 +868,8 @@ public:
      */
     template <class F>
         requires std::invocable<F, const T&>
-    [[nodiscard]] constexpr auto
-    map(F f) const -> matrix<std::invoke_result_t<F, const T&>, Dimensions...> {
+    [[nodiscard]] constexpr auto map(F f) const
+        -> matrix<std::invoke_result_t<F, const T&>, Dimensions...> {
         matrix<std::invoke_result_t<F, const T&>, Dimensions...> result(zero);
         std::transform(_data.cbegin(), _data.cend(), result.begin(),
                        [&f](const T& v) { return std::invoke(f, v); });
@@ -949,28 +992,32 @@ public:
 
     // element access
     /**
-     * @brief Returns a reference to the first element in the matrix (row-major order).
+     * @brief Returns a reference to the first element in the matrix (row-major
+     * order).
      *
      * Calling @c front() on an empty matrix is undefined behavior.
      */
     constexpr reference front() noexcept { return _data.front(); }
 
     /**
-     * @brief Returns a const reference to the first element in the matrix (row-major order).
+     * @brief Returns a const reference to the first element in the matrix
+     * (row-major order).
      *
      * Calling @c front() on an empty matrix is undefined behavior.
      */
     [[nodiscard]] constexpr const_reference front() const noexcept { return _data.front(); }
 
     /**
-     * @brief Returns a reference to the last element in the matrix (row-major order).
+     * @brief Returns a reference to the last element in the matrix (row-major
+     * order).
      *
      * Calling @c back() on an empty matrix is undefined behavior.
      */
     constexpr reference back() noexcept { return _data.back(); }
 
     /**
-     * @brief Returns a const reference to the last element in the matrix (row-major order).
+     * @brief Returns a const reference to the last element in the matrix
+     * (row-major order).
      *
      * Calling @c back() on an empty matrix is undefined behavior.
      */
@@ -986,7 +1033,8 @@ public:
     template <class... Coords>
         requires integral_coordinates<Coords...>
     constexpr T const& operator()(Coords... coordinates) const {
-        // Intentional: unchecked access on the performance path. Use at() for bounds checking.
+        // Intentional: unchecked access on the performance path. Use at() for
+        // bounds checking.
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
         return _data[detail::coordinates_to_index(dimensions, std::array{coordinates...})];
     }
@@ -1001,7 +1049,8 @@ public:
     template <class... Coords>
         requires integral_coordinates<Coords...>
     constexpr T& operator()(Coords... coordinates) {
-        // Intentional: unchecked access on the performance path. Use at() for bounds checking.
+        // Intentional: unchecked access on the performance path. Use at() for
+        // bounds checking.
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
         return _data[detail::coordinates_to_index(dimensions, std::array{coordinates...})];
     }
@@ -1010,7 +1059,8 @@ public:
      * @brief Returns a reference to the element at coordinates.
      * @param coordinates Coordinates of the element to return
      *
-     * If @a coordinates is not within the range of the container, an exception of type
+     * If @a coordinates is not within the range of the container, an exception
+     * of type
      * @c std::out_of_range is thrown.
      */
     template <class... Coords>
@@ -1028,7 +1078,8 @@ public:
      * @brief Returns a reference to the element at coordinates.
      * @param coordinates Coordinates of the element to return
      *
-     * If @a coordinates is not within the range of the container, an exception of type
+     * If @a coordinates is not within the range of the container, an exception
+     * of type
      * @c std::out_of_range is thrown.
      */
     template <class... Coords>
@@ -1046,17 +1097,22 @@ public:
 
     /**
      * @brief Returns a non-owning view over a hyperslice of the matrix.
-     * @tparam Specs Spec types: @c ysc::all_t to keep a dimension, any integral to fix it.
-     * @param  specs Per-dimension specs.  Missing trailing specs are implicitly @c ysc::all.
-     * @return @c matrix_view<T,contiguous,KeptDims...> if fixed dims form a prefix;
+     * @tparam Specs Spec types: @c ysc::all_t to keep a dimension, any integral
+     * to fix it.
+     * @param  specs Per-dimension specs.  Missing trailing specs are implicitly
+     * @c ysc::all.
+     * @return @c matrix_view<T,contiguous,KeptDims...> if fixed dims form a
+     * prefix;
      *         @c matrix_view<T,strided,KeptDims...> otherwise.
-     * @throws std::out_of_range if any fixed index is out of bounds for its dimension.
+     * @throws std::out_of_range if any fixed index is out of bounds for its
+     * dimension.
      *
      * @code
      * ysc::matrix<int, 3, 4, 5> m{};
-     * auto v0 = m.slice(1);            // contiguous: row 1 across all 4×5 columns
-     * auto v1 = m.slice(ysc::all, 2);  // strided: column 2 across all 3×5 rows
-     * auto v2 = m.slice();             // contiguous: view over the whole matrix
+     * auto v0 = m.slice(1);            // contiguous: row 1 across all 4×5
+     * columns auto v1 = m.slice(ysc::all, 2);  // strided: column 2 across all
+     * 3×5 rows auto v2 = m.slice();             // contiguous: view over the
+     * whole matrix
      * @endcode
      *
      * @ingroup ysc_view
@@ -1103,11 +1159,14 @@ public:
 
     /**
      * @brief Returns a non-owning const view over a hyperslice of the matrix.
-     * @tparam Specs Spec types: @c ysc::all_t to keep a dimension, any integral to fix it.
-     * @param  specs Per-dimension specs.  Missing trailing specs are implicitly @c ysc::all.
+     * @tparam Specs Spec types: @c ysc::all_t to keep a dimension, any integral
+     * to fix it.
+     * @param  specs Per-dimension specs.  Missing trailing specs are implicitly
+     * @c ysc::all.
      * @return @c matrix_view<const T,contiguous,KeptDims...> or
      *         @c matrix_view<const T,strided,KeptDims...>.
-     * @throws std::out_of_range if any fixed index is out of bounds for its dimension.
+     * @throws std::out_of_range if any fixed index is out of bounds for its
+     * dimension.
      *
      * @code
      * const ysc::matrix<int, 3, 4> m{};
@@ -1159,7 +1218,8 @@ public:
 
     /**
      * @brief Returns a contiguous view over row @a i (2D matrices only).
-     * @tparam D Deduced from @c order; constrained to 2 — do not specify explicitly.
+     * @tparam D Deduced from @c order; constrained to 2 — do not specify
+     * explicitly.
      * @param i  Row index (0-based).
      * @return @c matrix_view<T,contiguous,C> where @c C = @c dimensions[1]
      * @throws std::out_of_range if @a i >= @c dimensions[0].
@@ -1184,9 +1244,11 @@ public:
 
     /**
      * @brief Returns a const contiguous view over row @a i (2D matrices only).
-     * @tparam D Deduced from @c order; constrained to 2 — do not specify explicitly.
+     * @tparam D Deduced from @c order; constrained to 2 — do not specify
+     * explicitly.
      * @param i  Row index (0-based).
-     * @return @c matrix_view<const T,contiguous,C> where @c C = @c dimensions[1]
+     * @return @c matrix_view<const T,contiguous,C> where @c C = @c
+     * dimensions[1]
      * @throws std::out_of_range if @a i >= @c dimensions[0].
      *
      * @code
@@ -1209,9 +1271,12 @@ public:
 
     /**
      * @brief Returns a strided view over column @a j (2D matrices only).
-     * @tparam D Deduced from @c order; constrained to 2 — do not specify explicitly.
+     * @tparam D Deduced from @c order; constrained to 2 — do not specify
+     * explicitly.
      * @param j  Column index (0-based).
-     * @return @c matrix_view<T,strided,R> where @c R = @c dimensions[0], stride = @c dimensions[1]
+     * @return @c matrix_view<T,strided,R> where @c R = @c dimensions[0], stride
+     * =
+     * @c dimensions[1]
      * @throws std::out_of_range if @a j >= @c dimensions[1].
      *
      * @code
@@ -1235,7 +1300,8 @@ public:
 
     /**
      * @brief Returns a const strided view over column @a j (2D matrices only).
-     * @tparam D Deduced from @c order; constrained to 2 — do not specify explicitly.
+     * @tparam D Deduced from @c order; constrained to 2 — do not specify
+     * explicitly.
      * @param j  Column index (0-based).
      * @return @c matrix_view<const T,strided,R> where @c R = @c dimensions[0]
      * @throws std::out_of_range if @a j >= @c dimensions[1].
@@ -1318,7 +1384,8 @@ constexpr matrix<T, N, N> identity() {
  * @tparam R  Number of rows of the input matrix
  * @tparam C  Number of columns of the input matrix
  * @param  m  Matrix to transpose
- * @return New @c matrix<T,C,R> where `result(j, i) == m(i, j)` for all valid @a i, @a j
+ * @return New @c matrix<T,C,R> where `result(j, i) == m(i, j)` for all valid @a
+ * i, @a j
  *
  * @code
  * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
@@ -1348,8 +1415,8 @@ template <class T, std::size_t R, std::size_t C>
  * @tparam P  Number of columns of @a b and the result
  * @param  a  Left-hand matrix of size M×N
  * @param  b  Right-hand matrix of size N×P
- * @return New @c matrix<Tc,M,P> where `Tc = decltype(Ta{} * Tb{})`, equal to the matrix product `a
- * × b`
+ * @return New @c matrix<Tc,M,P> where `Tc = decltype(Ta{} * Tb{})`, equal to
+ * the matrix product `a × b`
  *
  * @code
  * ysc::matrix<int, 2, 3>    a{1, 2, 3, 4, 5, 6};
@@ -1361,8 +1428,8 @@ template <class T, std::size_t R, std::size_t C>
  */
 template <class Ta, class Tb, std::size_t M, std::size_t N, std::size_t P>
     requires std::invocable<std::multiplies<>, const Ta&, const Tb&> &&
-                 requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc,
-                          const Ta& a, const Tb& b) { tc += a * b; }
+             requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc, const Ta& a,
+                      const Tb& b) { tc += a * b; }
 [[nodiscard]] constexpr auto matmul(const matrix<Ta, M, N>& a, const matrix<Tb, N, P>& b)
     -> matrix<std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>, M, P> {
     using Tc = std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>;
@@ -1378,14 +1445,15 @@ template <class Ta, class Tb, std::size_t M, std::size_t N, std::size_t P>
 }
 
 /**
- * @brief Returns the dot product of two 1D matrices (vectors) of the same length.
+ * @brief Returns the dot product of two 1D matrices (vectors) of the same
+ * length.
  * @tparam Ta Element type of @a a — must be multipliable with @a Tb
  * @tparam Tb Element type of @a b — must be multipliable with @a Ta
  * @tparam N  Number of elements
  * @param  a  First vector
  * @param  b  Second vector
- * @return Scalar value `Tc` where `Tc = decltype(Ta{} * Tb{})`, equal to `sum(a[i] * b[i])` for `i`
- * in `[0, N)`
+ * @return Scalar value `Tc` where `Tc = decltype(Ta{} * Tb{})`, equal to
+ * `sum(a[i] * b[i])` for `i` in `[0, N)`
  *
  * @code
  * ysc::matrix<int, 3>    a{1, 2, 3};
@@ -1397,8 +1465,8 @@ template <class Ta, class Tb, std::size_t M, std::size_t N, std::size_t P>
  */
 template <class Ta, class Tb, std::size_t N>
     requires std::invocable<std::multiplies<>, const Ta&, const Tb&> &&
-                 requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc,
-                          const Ta& a, const Tb& b) { tc += a * b; }
+             requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc, const Ta& a,
+                      const Tb& b) { tc += a * b; }
 [[nodiscard]] constexpr auto dot(const matrix<Ta, N>& a, const matrix<Tb, N>& b)
     -> std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> {
     using Tc = std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>;
@@ -1416,7 +1484,8 @@ template <class Ta, class Tb, std::size_t N>
 
 /**
  * @brief Writes a matrix to an output stream.
- * @tparam T    Element type — must be writable to `std::ostream` via `operator<<`
+ * @tparam T    Element type — must be writable to `std::ostream` via
+ * `operator<<`
  * @tparam Dims Dimensions of the matrix
  * @param  os   Destination stream
  * @param  m    Matrix to print
@@ -1425,8 +1494,8 @@ template <class Ta, class Tb, std::size_t N>
  * Produces nested bracket notation: `[e0, e1, ...]` for 1D,
  * `[[e00, e01], [e10, e11]]` for 2D, and so on recursively.
  *
- * This overload only participates in overload resolution when `T` is streamable,
- * so it never causes a hard error for non-streamable element types.
+ * This overload only participates in overload resolution when `T` is
+ * streamable, so it never causes a hard error for non-streamable element types.
  *
  * @code
  * ysc::matrix<int, 2, 2> m{1, 2, 3, 4};
@@ -1481,12 +1550,14 @@ template <class T, std::size_t... D> struct std::hash<ysc::matrix<T, D...>> {
 
 /**
  * @brief Specialization of @c std::formatter for @c ysc::matrix.
- * @tparam T     Element type — must be streamable via @c operator<<(std::ostream&, const T&)
+ * @tparam T     Element type — must be streamable via @c
+ * operator<<(std::ostream&, const T&)
  * @tparam D     Dimensions of the matrix
  * @tparam CharT Character type for the format context
  *
  * Enables `std::format("{}", m)` and produces the same nested-bracket output as
- * `operator<<`: `[e0, e1, …]` for 1D, `[[e00, e01], [e10, e11]]` for 2D, and so on.
+ * `operator<<`: `[e0, e1, …]` for 1D, `[[e00, e01], [e10, e11]]` for 2D, and so
+ * on.
  *
  * Only available when the @c <format> library feature is present
  * (@c __cpp_lib_format ≥ 201907L).

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -825,8 +825,8 @@ public:
      */
     template <class F>
         requires std::invocable<F, const T&>
-    [[nodiscard]] constexpr auto map(F f) const
-        -> matrix<std::invoke_result_t<F, const T&>, Dimensions...> {
+    [[nodiscard]] constexpr auto
+    map(F f) const -> matrix<std::invoke_result_t<F, const T&>, Dimensions...> {
         matrix<std::invoke_result_t<F, const T&>, Dimensions...> result(zero);
         std::transform(_data.cbegin(), _data.cend(), result.begin(),
                        [&f](const T& v) { return std::invoke(f, v); });
@@ -1361,8 +1361,8 @@ template <class T, std::size_t R, std::size_t C>
  */
 template <class Ta, class Tb, std::size_t M, std::size_t N, std::size_t P>
     requires std::invocable<std::multiplies<>, const Ta&, const Tb&> &&
-             requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc, const Ta& a,
-                      const Tb& b) { tc += a * b; }
+                 requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc,
+                          const Ta& a, const Tb& b) { tc += a * b; }
 [[nodiscard]] constexpr auto matmul(const matrix<Ta, M, N>& a, const matrix<Tb, N, P>& b)
     -> matrix<std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>, M, P> {
     using Tc = std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>;
@@ -1397,8 +1397,8 @@ template <class Ta, class Tb, std::size_t M, std::size_t N, std::size_t P>
  */
 template <class Ta, class Tb, std::size_t N>
     requires std::invocable<std::multiplies<>, const Ta&, const Tb&> &&
-             requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc, const Ta& a,
-                      const Tb& b) { tc += a * b; }
+                 requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc,
+                          const Ta& a, const Tb& b) { tc += a * b; }
 [[nodiscard]] constexpr auto dot(const matrix<Ta, N>& a, const matrix<Tb, N>& b)
     -> std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> {
     using Tc = std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>;

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -868,8 +868,8 @@ public:
      */
     template <class F>
         requires std::invocable<F, const T&>
-    [[nodiscard]] constexpr auto map(F f) const
-        -> matrix<std::invoke_result_t<F, const T&>, Dimensions...> {
+    [[nodiscard]] constexpr auto
+    map(F f) const -> matrix<std::invoke_result_t<F, const T&>, Dimensions...> {
         matrix<std::invoke_result_t<F, const T&>, Dimensions...> result(zero);
         std::transform(_data.cbegin(), _data.cend(), result.begin(),
                        [&f](const T& v) { return std::invoke(f, v); });
@@ -1428,8 +1428,8 @@ template <class T, std::size_t R, std::size_t C>
  */
 template <class Ta, class Tb, std::size_t M, std::size_t N, std::size_t P>
     requires std::invocable<std::multiplies<>, const Ta&, const Tb&> &&
-             requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc, const Ta& a,
-                      const Tb& b) { tc += a * b; }
+                 requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc,
+                          const Ta& a, const Tb& b) { tc += a * b; }
 [[nodiscard]] constexpr auto matmul(const matrix<Ta, M, N>& a, const matrix<Tb, N, P>& b)
     -> matrix<std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>, M, P> {
     using Tc = std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>;
@@ -1465,8 +1465,8 @@ template <class Ta, class Tb, std::size_t M, std::size_t N, std::size_t P>
  */
 template <class Ta, class Tb, std::size_t N>
     requires std::invocable<std::multiplies<>, const Ta&, const Tb&> &&
-             requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc, const Ta& a,
-                      const Tb& b) { tc += a * b; }
+                 requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc,
+                          const Ta& a, const Tb& b) { tc += a * b; }
 [[nodiscard]] constexpr auto dot(const matrix<Ta, N>& a, const matrix<Tb, N>& b)
     -> std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> {
     using Tc = std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>;

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -28,6 +28,9 @@
 #include <sstream>
 #endif
 
+#include <matrix_detail.hpp>
+#include <matrix_view.hpp>
+
 namespace ysc {
 namespace detail {
 
@@ -58,21 +61,6 @@ It print_recursive(std::ostream& os, It it, const Dims& dims, std::size_t dim_id
     return it;
 }
 
-// cache-friendly: neighbor objects within the right-most coordinate are neighbors in memory
-template <class TDim, class TCoord>
-constexpr auto coordinates_to_index(TDim const& dimensions, TCoord const& coords) {
-    // Row-major index: index = c[0]*D[1]*…*D[N-1] + c[1]*D[2]*…*D[N-1] + … + c[N-1]
-    // Evaluated right-to-left; `stride` is the product of all dimensions already visited.
-    std::size_t index = 0;
-    std::size_t stride = 1;
-    auto dim = dimensions.crbegin();
-    auto coord = coords.crbegin();
-    for (; dim != dimensions.crend(); ++dim, ++coord) {
-        index += static_cast<std::size_t>(*coord) * stride;
-        stride *= *dim;
-    }
-    return index;
-}
 } // namespace detail
 
 /**
@@ -81,14 +69,6 @@ constexpr auto coordinates_to_index(TDim const& dimensions, TCoord const& coords
  */
 template <class T, class U>
 concept matrix_convertible_from = std::convertible_to<U, T>;
-
-/**
- * @brief Satisfied when all types in `Coords` are integral (ignoring cv-ref qualifiers).
- * Used to constrain `operator()` and `at()` so that floating-point or other
- * non-integral coordinate types yield a readable diagnostic.
- */
-template <class... Coords>
-concept integral_coordinates = (std::integral<std::remove_cvref_t<Coords>> && ...);
 
 /**
  * @brief Tag a @c matrix object to be zero-initialized.
@@ -845,8 +825,8 @@ public:
      */
     template <class F>
         requires std::invocable<F, const T&>
-    [[nodiscard]] constexpr auto
-    map(F f) const -> matrix<std::invoke_result_t<F, const T&>, Dimensions...> {
+    [[nodiscard]] constexpr auto map(F f) const
+        -> matrix<std::invoke_result_t<F, const T&>, Dimensions...> {
         matrix<std::invoke_result_t<F, const T&>, Dimensions...> result(zero);
         std::transform(_data.cbegin(), _data.cend(), result.begin(),
                        [&f](const T& v) { return std::invoke(f, v); });
@@ -1061,6 +1041,223 @@ public:
         }
         return (*this)(coordinates...);
     }
+
+    // ─── views (slice / row / col) ───────────────────────────────────────────
+
+    /**
+     * @brief Returns a non-owning view over a hyperslice of the matrix.
+     * @tparam Specs Spec types: @c ysc::all_t to keep a dimension, any integral to fix it.
+     * @param  specs Per-dimension specs.  Missing trailing specs are implicitly @c ysc::all.
+     * @return @c matrix_view<T,contiguous,KeptDims...> if fixed dims form a prefix;
+     *         @c matrix_view<T,strided,KeptDims...> otherwise.
+     * @throws std::out_of_range if any fixed index is out of bounds for its dimension.
+     *
+     * @code
+     * ysc::matrix<int, 3, 4, 5> m{};
+     * auto v0 = m.slice(1);            // contiguous: row 1 across all 4×5 columns
+     * auto v1 = m.slice(ysc::all, 2);  // strided: column 2 across all 3×5 rows
+     * auto v2 = m.slice();             // contiguous: view over the whole matrix
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    template <typename... Specs>
+        requires(sizeof...(Specs) <= order) &&
+                ((std::same_as<Specs, all_t> || std::integral<Specs>) && ...) &&
+                (sizeof...(Specs) < order || (std::same_as<Specs, all_t> || ...))
+    [[nodiscard]] constexpr auto slice(Specs... specs) & {
+        using PaddedT = detail::pad_right_with_all_t<order, Specs...>;
+        using KeptDims = typename detail::filter_kept_dims<PaddedT, Dimensions...>::type;
+        constexpr bool is_prefix = detail::is_prefix_slice_v<PaddedT>;
+        using Storage = std::conditional_t<is_prefix, contiguous, strided>;
+        using ViewT = detail::make_matrix_view_t<T, Storage, KeptDims>;
+
+        std::array<std::size_t, order> spec_vals{};
+        {
+            std::size_t i = 0;
+            (
+                [&](auto s) {
+                    using S = std::remove_cvref_t<decltype(s)>;
+                    if constexpr (!detail::is_all_v<S>) {
+                        auto idx = static_cast<std::size_t>(s);
+                        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                        if (idx >= dimensions[i]) {
+                            throw std::out_of_range("slice: index out of range");
+                        }
+                        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                        spec_vals[i] = idx;
+                    }
+                    ++i;
+                }(specs),
+                ...);
+        }
+
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        auto* base = _data.data() + detail::slice_helper<PaddedT>::offset(dimensions, spec_vals);
+        if constexpr (is_prefix) {
+            return ViewT{base};
+        } else {
+            return ViewT{base, detail::slice_helper<PaddedT>::strides(dimensions)};
+        }
+    }
+
+    /**
+     * @brief Returns a non-owning const view over a hyperslice of the matrix.
+     * @tparam Specs Spec types: @c ysc::all_t to keep a dimension, any integral to fix it.
+     * @param  specs Per-dimension specs.  Missing trailing specs are implicitly @c ysc::all.
+     * @return @c matrix_view<const T,contiguous,KeptDims...> or
+     *         @c matrix_view<const T,strided,KeptDims...>.
+     * @throws std::out_of_range if any fixed index is out of bounds for its dimension.
+     *
+     * @code
+     * const ysc::matrix<int, 3, 4> m{};
+     * auto v = m.slice(1);  // const view of row 1
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    template <typename... Specs>
+        requires(sizeof...(Specs) <= order) &&
+                ((std::same_as<Specs, all_t> || std::integral<Specs>) && ...) &&
+                (sizeof...(Specs) < order || (std::same_as<Specs, all_t> || ...))
+    [[nodiscard]] constexpr auto slice(Specs... specs) const& {
+        using PaddedT = detail::pad_right_with_all_t<order, Specs...>;
+        using KeptDims = typename detail::filter_kept_dims<PaddedT, Dimensions...>::type;
+        constexpr bool is_prefix = detail::is_prefix_slice_v<PaddedT>;
+        using Storage = std::conditional_t<is_prefix, contiguous, strided>;
+        using ViewT = detail::make_matrix_view_t<const T, Storage, KeptDims>;
+
+        std::array<std::size_t, order> spec_vals{};
+        {
+            std::size_t i = 0;
+            (
+                [&](auto s) {
+                    using S = std::remove_cvref_t<decltype(s)>;
+                    if constexpr (!detail::is_all_v<S>) {
+                        auto idx = static_cast<std::size_t>(s);
+                        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                        if (idx >= dimensions[i]) {
+                            throw std::out_of_range("slice: index out of range");
+                        }
+                        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                        spec_vals[i] = idx;
+                    }
+                    ++i;
+                }(specs),
+                ...);
+        }
+
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        const auto* base =
+            _data.data() + detail::slice_helper<PaddedT>::offset(dimensions, spec_vals);
+        if constexpr (is_prefix) {
+            return ViewT{base};
+        } else {
+            return ViewT{base, detail::slice_helper<PaddedT>::strides(dimensions)};
+        }
+    }
+
+    /**
+     * @brief Returns a contiguous view over row @a i (2D matrices only).
+     * @tparam D Deduced from @c order; constrained to 2 — do not specify explicitly.
+     * @param i  Row index (0-based).
+     * @return @c matrix_view<T,contiguous,C> where @c C = @c dimensions[1]
+     * @throws std::out_of_range if @a i >= @c dimensions[0].
+     *
+     * @code
+     * ysc::matrix<int, 3, 4> m{};
+     * auto r = m.row(1);  // contiguous view of row 1 — 4 elements
+     * r(2) = 99;          // writes m(1, 2)
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    template <std::size_t D = order>
+        requires(D == 2)
+    [[nodiscard]] constexpr auto row(std::size_t i) & {
+        if (i >= dimensions[0]) {
+            throw std::out_of_range("row: index out of range");
+        }
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        return matrix_view<T, contiguous, dimensions[1]>{_data.data() + (i * dimensions[1])};
+    }
+
+    /**
+     * @brief Returns a const contiguous view over row @a i (2D matrices only).
+     * @tparam D Deduced from @c order; constrained to 2 — do not specify explicitly.
+     * @param i  Row index (0-based).
+     * @return @c matrix_view<const T,contiguous,C> where @c C = @c dimensions[1]
+     * @throws std::out_of_range if @a i >= @c dimensions[0].
+     *
+     * @code
+     * const ysc::matrix<int, 3, 4> m{};
+     * auto r = m.row(1);
+     * assert(r(0) == m(1, 0));
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    template <std::size_t D = order>
+        requires(D == 2)
+    [[nodiscard]] constexpr auto row(std::size_t i) const& {
+        if (i >= dimensions[0]) {
+            throw std::out_of_range("row: index out of range");
+        }
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        return matrix_view<const T, contiguous, dimensions[1]>{_data.data() + (i * dimensions[1])};
+    }
+
+    /**
+     * @brief Returns a strided view over column @a j (2D matrices only).
+     * @tparam D Deduced from @c order; constrained to 2 — do not specify explicitly.
+     * @param j  Column index (0-based).
+     * @return @c matrix_view<T,strided,R> where @c R = @c dimensions[0], stride = @c dimensions[1]
+     * @throws std::out_of_range if @a j >= @c dimensions[1].
+     *
+     * @code
+     * ysc::matrix<int, 3, 4> m{};
+     * auto c = m.col(2);  // strided view of column 2 — 3 elements, stride 4
+     * c(1) = 99;          // writes m(1, 2)
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    template <std::size_t D = order>
+        requires(D == 2)
+    [[nodiscard]] constexpr auto col(std::size_t j) & {
+        if (j >= dimensions[1]) {
+            throw std::out_of_range("col: index out of range");
+        }
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        return matrix_view<T, strided, dimensions[0]>{_data.data() + j,
+                                                      std::array<std::size_t, 1>{dimensions[1]}};
+    }
+
+    /**
+     * @brief Returns a const strided view over column @a j (2D matrices only).
+     * @tparam D Deduced from @c order; constrained to 2 — do not specify explicitly.
+     * @param j  Column index (0-based).
+     * @return @c matrix_view<const T,strided,R> where @c R = @c dimensions[0]
+     * @throws std::out_of_range if @a j >= @c dimensions[1].
+     *
+     * @code
+     * const ysc::matrix<int, 3, 4> m{};
+     * auto c = m.col(2);
+     * assert(c(1) == m(1, 2));
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    template <std::size_t D = order>
+        requires(D == 2)
+    [[nodiscard]] constexpr auto col(std::size_t j) const& {
+        if (j >= dimensions[1]) {
+            throw std::out_of_range("col: index out of range");
+        }
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        return matrix_view<const T, strided, dimensions[0]>{
+            _data.data() + j, std::array<std::size_t, 1>{dimensions[1]}};
+    }
 };
 
 /**
@@ -1164,8 +1361,8 @@ template <class T, std::size_t R, std::size_t C>
  */
 template <class Ta, class Tb, std::size_t M, std::size_t N, std::size_t P>
     requires std::invocable<std::multiplies<>, const Ta&, const Tb&> &&
-                 requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc,
-                          const Ta& a, const Tb& b) { tc += a * b; }
+             requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc, const Ta& a,
+                      const Tb& b) { tc += a * b; }
 [[nodiscard]] constexpr auto matmul(const matrix<Ta, M, N>& a, const matrix<Tb, N, P>& b)
     -> matrix<std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>, M, P> {
     using Tc = std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>;
@@ -1200,8 +1397,8 @@ template <class Ta, class Tb, std::size_t M, std::size_t N, std::size_t P>
  */
 template <class Ta, class Tb, std::size_t N>
     requires std::invocable<std::multiplies<>, const Ta&, const Tb&> &&
-                 requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc,
-                          const Ta& a, const Tb& b) { tc += a * b; }
+             requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc, const Ta& a,
+                      const Tb& b) { tc += a * b; }
 [[nodiscard]] constexpr auto dot(const matrix<Ta, N>& a, const matrix<Tb, N>& b)
     -> std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> {
     using Tc = std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>;

--- a/src/include/matrix_detail.hpp
+++ b/src/include/matrix_detail.hpp
@@ -1,0 +1,218 @@
+/**
+ * @file matrix_detail.hpp
+ * @author Yankel Scialom (YSC) <yankel-pro@scialom.org>
+ * @date 2026
+ *
+ * @copyright This project is released under GNU Lesser General Public License; see
+ *            COPYING and COPYING.LESSER files attached.
+ *
+ * Shared types and helpers used by both matrix.hpp and matrix_view.hpp.
+ * Users should not include this header directly; include matrix.hpp instead.
+ */
+#ifndef YSC_MATRIX_DETAIL_HPP
+#define YSC_MATRIX_DETAIL_HPP
+
+#include <array>
+#include <concepts>
+#include <cstddef>
+#include <type_traits>
+
+namespace ysc {
+
+// ─── storage tags ────────────────────────────────────────────────────────────
+
+/** @brief Storage tag: view elements are contiguous in memory. @ingroup ysc_view */
+struct contiguous {};
+/** @brief Storage tag: view elements are non-contiguous (strided) in memory. @ingroup ysc_view */
+struct strided {};
+
+// ─── slice sentinel ──────────────────────────────────────────────────────────
+
+/**
+ * @brief Sentinel type used in slice() to indicate "keep this dimension".
+ * @ingroup ysc_view
+ */
+struct all_t {};
+
+/**
+ * @brief Sentinel value: pass ysc::all to slice() to keep a dimension unchanged.
+ *
+ * @code
+ * ysc::matrix<int, 3, 4, 5> m{};
+ * auto v = m.slice(ysc::all, 2);  // keeps dims 0 and 2, fixes dim 1 at index 2
+ * @endcode
+ *
+ * @ingroup ysc_view
+ */
+inline constexpr all_t all{};
+
+// ─── forward declarations ─────────────────────────────────────────────────────
+
+template <class T, std::size_t... Dims> class matrix;
+
+template <class T, class Storage, std::size_t... Dims> class matrix_view;
+
+// ─── concepts ─────────────────────────────────────────────────────────────────
+
+/**
+ * @brief Satisfied when all types in @c Coords are integral (ignoring cv-ref).
+ * Used to constrain @c operator() and @c at() on matrix and matrix_view.
+ */
+template <class... Coords>
+concept integral_coordinates = (std::integral<std::remove_cvref_t<Coords>> && ...);
+
+// ─── detail namespace ─────────────────────────────────────────────────────────
+
+namespace detail {
+
+// cache-friendly: neighbor objects within the right-most coordinate are neighbors in memory
+template <class TDim, class TCoord>
+constexpr auto coordinates_to_index(TDim const& dimensions, TCoord const& coords) {
+    // Row-major index: index = c[0]*D[1]*…*D[N-1] + c[1]*D[2]*…*D[N-1] + … + c[N-1]
+    // Evaluated right-to-left; `stride` is the product of all dimensions already visited.
+    std::size_t index = 0;
+    std::size_t stride = 1;
+    auto dim = dimensions.crbegin();
+    auto coord = coords.crbegin();
+    for (; dim != dimensions.crend(); ++dim, ++coord) {
+        index += static_cast<std::size_t>(*coord) * stride;
+        stride *= *dim;
+    }
+    return index;
+}
+
+// ─── slice metaprogramming helpers ───────────────────────────────────────────
+
+/** @brief True iff @c S is @c ysc::all_t. */
+template <class S> inline constexpr bool is_all_v = std::same_as<S, all_t>;
+
+/** @brief Number of @c all_t values in @c Specs... */
+template <class... Specs>
+inline constexpr std::size_t n_kept_v = (std::size_t{0} + ... + (is_all_v<Specs> ? 1 : 0));
+
+/** @brief Non-type parameter pack container for @c std::size_t values. */
+template <std::size_t... Vals> struct size_seq {};
+
+/** @brief Prepend value @c V to a @c size_seq. */
+template <std::size_t V, class Seq> struct prepend_val;
+template <std::size_t V, std::size_t... Vals> struct prepend_val<V, size_seq<Vals...>> {
+    using type = size_seq<V, Vals...>;
+};
+
+/** @brief Pad @c Specs... with @c all_t on the right until @c N elements total.
+ *  Returns a @c std::tuple of the padded types. */
+template <std::size_t ToAdd, class... Specs> struct pad_right_with_all {
+    using type = typename pad_right_with_all<ToAdd - 1, Specs..., all_t>::type;
+};
+template <class... Specs> struct pad_right_with_all<0, Specs...> {
+    using type = std::tuple<Specs...>;
+};
+template <std::size_t N, class... Specs>
+    requires(sizeof...(Specs) <= N)
+using pad_right_with_all_t = typename pad_right_with_all<N - sizeof...(Specs), Specs...>::type;
+
+/** @brief True iff the padded spec pattern is @c (integrals)*(all*). */
+template <class PaddedTuple> struct is_prefix_slice_helper;
+template <class... PaddedSpecs> struct is_prefix_slice_helper<std::tuple<PaddedSpecs...>> {
+    static constexpr bool value = [] {
+        bool seen_all = false;
+        bool ok = true;
+        ((seen_all = seen_all || is_all_v<PaddedSpecs>,
+          ok = ok && (!seen_all || is_all_v<PaddedSpecs>)),
+         ...);
+        return ok;
+    }();
+};
+template <class PaddedTuple>
+inline constexpr bool is_prefix_slice_v = is_prefix_slice_helper<PaddedTuple>::value;
+
+/** @brief Produces a @c size_seq of dims at positions where the spec is @c all_t. */
+template <class PaddedTuple, std::size_t... AllDims> struct filter_kept_dims;
+template <> struct filter_kept_dims<std::tuple<>> {
+    using type = size_seq<>;
+};
+template <class Spec, class... RestSpecs, std::size_t Dim, std::size_t... RestDims>
+struct filter_kept_dims<std::tuple<Spec, RestSpecs...>, Dim, RestDims...> {
+    using rest_type = typename filter_kept_dims<std::tuple<RestSpecs...>, RestDims...>::type;
+    using type =
+        std::conditional_t<is_all_v<Spec>, typename prepend_val<Dim, rest_type>::type, rest_type>;
+};
+
+/** @brief Builds @c matrix_view<T,Storage,KeptDims...> from a @c size_seq. */
+template <class T, class Storage, class KeptSizeSeq> struct make_matrix_view;
+template <class T, class Storage, std::size_t... KeptDims>
+struct make_matrix_view<T, Storage, size_seq<KeptDims...>> {
+    using type = matrix_view<T, Storage, KeptDims...>;
+};
+template <class T, class Storage, class KeptSizeSeq>
+using make_matrix_view_t = typename make_matrix_view<T, Storage, KeptSizeSeq>::type;
+
+/**
+ * @brief Centralises runtime offset and stride computations for @c slice().
+ * @tparam PaddedTuple @c std::tuple of padded spec types (all_t or integral)
+ */
+template <class PaddedTuple> struct slice_helper;
+template <class... PaddedSpecs> struct slice_helper<std::tuple<PaddedSpecs...>> {
+    static constexpr std::size_t n_specs = sizeof...(PaddedSpecs);
+    static constexpr std::size_t n_kept = n_kept_v<PaddedSpecs...>;
+    static constexpr std::array<bool, n_specs> is_kept = {is_all_v<PaddedSpecs>...};
+    static constexpr std::array<bool, n_specs> is_fixed = {!is_all_v<PaddedSpecs>...};
+
+    /**
+     * @brief Computes the flat-array offset of the slice's base pointer.
+     * @param dims      Original matrix dimensions
+     * @param spec_vals Index values for fixed specs (0 for all_t positions)
+     * @return Flat offset from the matrix's data() pointer
+     */
+    [[nodiscard]] static constexpr std::size_t
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+    offset(std::array<std::size_t, n_specs> dims,
+           std::array<std::size_t, n_specs> spec_vals) noexcept {
+        std::size_t result = 0;
+        for (std::size_t i = 0; i < n_specs; ++i) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+            if (is_fixed[i]) {
+                std::size_t stride = 1;
+                for (std::size_t j = i + 1; j < n_specs; ++j) {
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                    stride *= dims[j];
+                }
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                result += spec_vals[i] * stride;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * @brief Computes the strides array for a strided view.
+     *
+     * Stride at position k (for a kept dim) = product of original dims after position k.
+     *
+     * @param dims Original matrix dimensions
+     * @return Array of strides, one per kept dimension
+     */
+    [[nodiscard]] static constexpr std::array<std::size_t, n_kept>
+    strides(std::array<std::size_t, n_specs> dims) noexcept {
+        std::array<std::size_t, n_kept> result{};
+        std::size_t k = 0;
+        for (std::size_t i = 0; i < n_specs; ++i) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+            if (is_kept[i]) {
+                std::size_t stride = 1;
+                for (std::size_t j = i + 1; j < n_specs; ++j) {
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                    stride *= dims[j];
+                }
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                result[k++] = stride;
+            }
+        }
+        return result;
+    }
+};
+
+} // namespace detail
+} // namespace ysc
+
+#endif // YSC_MATRIX_DETAIL_HPP

--- a/src/include/matrix_view.hpp
+++ b/src/include/matrix_view.hpp
@@ -6,7 +6,9 @@
  * @copyright This project is released under GNU Lesser General Public License; see
  *            COPYING and COPYING.LESSER files attached.
  *
- * Non-owning view over a ysc::matrix storage.
+ * Non-owning views over a ysc::matrix storage:
+ *   - matrix_view<T, contiguous, Dims...> — elements are contiguous in memory
+ *   - matrix_view<T, strided,    Dims...> — elements are non-contiguous (strided)
  */
 #ifndef YSC_MATRIX_VIEW_HPP
 #define YSC_MATRIX_VIEW_HPP
@@ -16,7 +18,7 @@
 #include <iterator>
 #include <stdexcept>
 
-#include <matrix.hpp>
+#include <matrix_detail.hpp>
 
 namespace ysc {
 
@@ -25,32 +27,52 @@ namespace ysc {
  * @brief Non-owning read/write views over @c ysc::matrix storage.
  */
 
+// ─── primary template (not defined — use a specialization) ───────────────────
+
 /**
- * @brief Non-owning read/write view over a contiguous sequence of @c T elements.
+ * @brief Non-owning view over a @c ysc::matrix storage.
+ *
+ * Two specializations exist:
+ *   - @c matrix_view<T, contiguous, Dims...> — elements contiguous in memory
+ *   - @c matrix_view<T, strided,    Dims...> — elements non-contiguous (strided)
+ *
+ * @tparam T       Element type
+ * @tparam Storage Storage tag: @c ysc::contiguous or @c ysc::strided
+ * @tparam Dims    Dimensions of the view
+ *
+ * @ingroup ysc_view
+ */
+template <class T, class Storage, std::size_t... Dims> class matrix_view;
+
+// ─── contiguous specialization ────────────────────────────────────────────────
+
+/**
+ * @brief Non-owning read/write view over a **contiguous** sequence of @c T elements.
  *
  * @tparam T          Element type
  * @tparam Dimensions Dimensions of the view (same as the underlying @c matrix)
  *
- * A @c matrix_view holds a raw pointer and the dimension metadata as template
- * parameters.  It does **not** own the memory: the lifetime of the underlying
- * @c matrix (or raw array) must exceed the lifetime of the view.
+ * A @c matrix_view<T,contiguous,Dims...> holds a single raw pointer and the
+ * dimension metadata as template parameters.  It does **not** own the memory:
+ * the lifetime of the underlying @c matrix (or raw array) must exceed that of
+ * the view.
  *
- * @warning Destroying the underlying @c matrix while a @c matrix_view still
- *          refers to it is undefined behavior.
+ * @warning Destroying the underlying @c matrix while a view still refers to it
+ *          is undefined behavior.
  *
- * Because dimensions are part of the type, @c sizeof(matrix_view<T,D...>) equals
- * @c sizeof(T*) on every platform (single pointer, no extra bookkeeping).
+ * Because dimensions are part of the type,
+ * @c sizeof(matrix_view<T,contiguous,D...>) equals @c sizeof(T*) on every platform.
  *
  * @code
  * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
- * ysc::matrix_view<int, 2, 3> v = m;
+ * ysc::matrix_view<int, ysc::contiguous, 2, 3> v = m;
  * v(0, 0) = 99;           // mutation is reflected in m
  * assert(m(0, 0) == 99);
  * @endcode
  *
  * @ingroup ysc_view
  */
-template <class T, std::size_t... Dimensions> class matrix_view {
+template <class T, std::size_t... Dimensions> class matrix_view<T, contiguous, Dimensions...> {
 public:
     /** @brief Order of the view (number of dimensions). */
     static constexpr std::size_t order = sizeof...(Dimensions);
@@ -99,12 +121,12 @@ public:
      * @brief Constructs a view over an existing @c matrix.
      * @param m Matrix to view
      *
-     * Implicit conversion is intentional: `matrix_view<T,D...> v = m;` should work
-     * as naturally as `std::string_view sv = str;`.
+     * Implicit conversion is intentional: `matrix_view<T,contiguous,D...> v = m;`
+     * should work as naturally as `std::string_view sv = str;`.
      *
      * @code
      * ysc::matrix<int, 3> m{1, 2, 3};
-     * ysc::matrix_view<int, 3> v = m;
+     * ysc::matrix_view<int, ysc::contiguous, 3> v = m;
      * @endcode
      *
      * @ingroup ysc_view
@@ -121,7 +143,7 @@ public:
      *
      * @code
      * int buf[6]{};
-     * ysc::matrix_view<int, 2, 3> v{buf};
+     * ysc::matrix_view<int, ysc::contiguous, 2, 3> v{buf};
      * @endcode
      *
      * @ingroup ysc_view
@@ -138,6 +160,24 @@ public:
     constexpr matrix_view& operator=(matrix_view&&) noexcept = default;
     /** @brief Destructor (does not free the underlying storage). */
     ~matrix_view() = default;
+
+    /**
+     * @brief Implicit conversion to the corresponding strided view.
+     *
+     * Every contiguous view is also a valid strided view (with natural strides).
+     * This conversion allows passing a contiguous view to any API that accepts a
+     * strided view.
+     *
+     * @code
+     * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+     * ysc::matrix_view<int, ysc::contiguous, 2, 3> cv = m;
+     * ysc::matrix_view<int, ysc::strided,    2, 3> sv = cv;  // implicit conversion
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
+    operator matrix_view<T, strided, Dimensions...>() const noexcept;
 
     // ─── iterators ───────────────────────────────────────────────────────────
 
@@ -242,7 +282,7 @@ public:
      * @note This function is @c static because the size is a compile-time constant.
      *
      * @code
-     * static_assert(ysc::matrix_view<int, 2, 3>::size() == 6);
+     * static_assert(ysc::matrix_view<int, ysc::contiguous, 2, 3>::size() == 6);
      * @endcode
      *
      * @ingroup ysc_view
@@ -335,12 +375,11 @@ public:
      * @param coords  Coordinates of the element
      * @return Reference to the element
      *
-     * No bounds checking is performed; if @p coords are outside the view dimensions,
-     * the behavior is undefined.  Use @c at() for bounds-checked access.
+     * No bounds checking is performed; use @c at() for bounds-checked access.
      *
      * @code
      * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
-     * ysc::matrix_view<int, 2, 3> v = m;
+     * ysc::matrix_view<int, ysc::contiguous, 2, 3> v = m;
      * assert(v(1, 2) == 6);
      * @endcode
      *
@@ -355,17 +394,16 @@ public:
     }
 
     /**
-     * @brief Returns a reference to the element at the given coordinates.
+     * @brief Returns a mutable reference to the element at the given coordinates.
      * @tparam Coords Integral coordinate types
      * @param coords  Coordinates of the element
-     * @return Reference to the element
+     * @return Mutable reference to the element
      *
-     * No bounds checking is performed; if @p coords are outside the view dimensions,
-     * the behavior is undefined.  Use @c at() for bounds-checked access.
+     * No bounds checking is performed; use @c at() for bounds-checked access.
      *
      * @code
      * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
-     * ysc::matrix_view<int, 2, 3> v = m;
+     * ysc::matrix_view<int, ysc::contiguous, 2, 3> v = m;
      * v(0, 0) = 99;
      * assert(m(0, 0) == 99);
      * @endcode
@@ -381,15 +419,16 @@ public:
     }
 
     /**
-     * @brief Returns a reference to the element at the given coordinates, with bounds checking.
+     * @brief Returns a const reference to the element at the given coordinates, with bounds
+     *        checking.
      * @tparam Coords Integral coordinate types
      * @param coords  Coordinates of the element
-     * @return Reference to the element
+     * @return Const reference to the element
      * @throws std::out_of_range if any coordinate is negative or out of bounds
      *
      * @code
      * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
-     * ysc::matrix_view<int, 2, 3> v = m;
+     * ysc::matrix_view<int, ysc::contiguous, 2, 3> v = m;
      * assert(v.at(1, 2) == 6);
      * @endcode
      *
@@ -407,15 +446,16 @@ public:
     }
 
     /**
-     * @brief Returns a reference to the element at the given coordinates, with bounds checking.
+     * @brief Returns a mutable reference to the element at the given coordinates, with bounds
+     *        checking.
      * @tparam Coords Integral coordinate types
      * @param coords  Coordinates of the element
-     * @return Reference to the element
+     * @return Mutable reference to the element
      * @throws std::out_of_range if any coordinate is negative or out of bounds
      *
      * @code
      * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
-     * ysc::matrix_view<int, 2, 3> v = m;
+     * ysc::matrix_view<int, ysc::contiguous, 2, 3> v = m;
      * v.at(0, 0) = 99;
      * assert(m(0, 0) == 99);
      * @endcode
@@ -443,7 +483,7 @@ public:
      *
      * @code
      * ysc::matrix<int, 3> m{1, 2, 3};
-     * ysc::matrix_view<int, 3> v = m;
+     * ysc::matrix_view<int, ysc::contiguous, 3> v = m;
      * v.fill(0);
      * assert(m(0) == 0 && m(2) == 0);
      * @endcode
@@ -454,6 +494,278 @@ public:
         std::fill(begin(), end(), value);
     }
 };
+
+// ─── strided specialization ───────────────────────────────────────────────────
+
+/**
+ * @brief Non-owning read/write view over a **non-contiguous** (strided) sequence of elements.
+ *
+ * @tparam T          Element type
+ * @tparam Dimensions Dimensions of the view (kept dimensions only)
+ *
+ * A @c matrix_view<T,strided,Dims...> holds a raw pointer and a strides array.
+ * Elements are accessed as:
+ * @code
+ * element(c0, c1, ...) == *(_ptr + c0*strides[0] + c1*strides[1] + ...)
+ * @endcode
+ *
+ * @note Iterators and @c data() are not available (non-contiguous layout).
+ *       Use @c operator() or @c at() for element access.
+ *
+ * @warning Destroying the underlying @c matrix while a view still refers to it
+ *          is undefined behavior.
+ *
+ * @code
+ * ysc::matrix<int, 3, 4> m{};
+ * // Column 2: elements m(0,2), m(1,2), m(2,2) — stride 4
+ * auto col2 = m.col(2);   // matrix_view<int, strided, 3>
+ * col2(1) = 99;           // writes m(1, 2)
+ * assert(m(1, 2) == 99);
+ * @endcode
+ *
+ * @ingroup ysc_view
+ */
+template <class T, std::size_t... Dimensions> class matrix_view<T, strided, Dimensions...> {
+public:
+    /** @brief Order of the view (number of dimensions). */
+    static constexpr std::size_t order = sizeof...(Dimensions);
+    /** @brief Dimensions of the view (kept dimensions only). */
+    static constexpr std::array dimensions = {Dimensions...};
+
+private:
+    static constexpr std::size_t linear_size = (Dimensions * ...);
+    T* _ptr;
+    std::array<std::size_t, sizeof...(Dimensions)> _strides;
+
+public:
+    // ─── typedefs ────────────────────────────────────────────────────────────
+
+    /** @brief Element type. */
+    using value_type = T;
+    /** @brief Unsigned integer type for sizes and counts. */
+    using size_type = std::size_t;
+    /** @brief Signed integer type for differences between iterators. */
+    using difference_type = std::ptrdiff_t;
+    /** @brief Reference to element type. */
+    using reference = T&;
+    /** @brief Const reference to element type. */
+    using const_reference = const T&;
+    /** @brief Pointer to element type. */
+    using pointer = T*;
+    /** @brief Const pointer to element type. */
+    using const_pointer = const T*;
+
+    // ─── construction ────────────────────────────────────────────────────────
+
+    matrix_view() = delete;
+
+    /**
+     * @brief Constructs a strided view from a raw pointer and a strides array.
+     * @param ptr     Pointer to the first element of the view
+     * @param strides Stride for each dimension (in elements, not bytes)
+     *
+     * @code
+     * // View every other element of a 1D array as a 1D strided view of size 3
+     * int buf[6]{1, 2, 3, 4, 5, 6};
+     * ysc::matrix_view<int, ysc::strided, 3> v{buf, {2}};
+     * assert(v(0) == 1 && v(1) == 3 && v(2) == 5);
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    constexpr explicit matrix_view(T* ptr,
+                                   std::array<std::size_t, sizeof...(Dimensions)> strides) noexcept
+        : _ptr{ptr}, _strides{strides} {}
+
+    /** @brief Copies the view (shallow: copies the pointer and strides, not the data). */
+    constexpr matrix_view(const matrix_view&) noexcept = default;
+    /** @brief Copy-assigns the view (shallow). */
+    constexpr matrix_view& operator=(const matrix_view&) noexcept = default;
+    /** @brief Move-constructs the view. */
+    constexpr matrix_view(matrix_view&&) noexcept = default;
+    /** @brief Move-assigns the view. */
+    constexpr matrix_view& operator=(matrix_view&&) noexcept = default;
+    /** @brief Destructor (does not free the underlying storage). */
+    ~matrix_view() = default;
+
+    // ─── capacity ────────────────────────────────────────────────────────────
+
+    /**
+     * @brief Returns the number of elements in the view (product of all kept dimensions).
+     * @return Number of elements
+     *
+     * @note This function is @c static because the size is a compile-time constant.
+     *
+     * @code
+     * static_assert(ysc::matrix_view<int, ysc::strided, 3, 4>::size() == 12);
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] static constexpr size_type size() noexcept { return linear_size; }
+
+    /**
+     * @brief Returns the maximum number of elements the view can address.
+     * @return Maximum number of elements (always equal to @c size())
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] static constexpr size_type max_size() noexcept { return linear_size; }
+
+    /**
+     * @brief Returns whether the view has no elements.
+     * @return @c true if @c linear_size == 0
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] static constexpr bool empty() noexcept { return linear_size == 0; }
+
+    // ─── element access ──────────────────────────────────────────────────────
+
+    /**
+     * @brief Returns a const reference to the element at the given coordinates.
+     * @tparam Coords Integral coordinate types
+     * @param coords  Coordinates of the element
+     * @return Const reference to the element
+     *
+     * No bounds checking is performed; use @c at() for bounds-checked access.
+     * The element is located at: @code _ptr + c0*strides[0] + c1*strides[1] + ... @endcode
+     *
+     * @code
+     * ysc::matrix<int, 3, 4> m{};
+     * auto col = m.col(2);   // strided view of column 2
+     * assert(col(1) == m(1, 2));
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    template <class... Coords>
+        requires integral_coordinates<Coords...> && (sizeof...(Coords) == sizeof...(Dimensions))
+    [[nodiscard]] constexpr const T& operator()(Coords... coords) const noexcept {
+        const std::array<std::size_t, sizeof...(Dimensions)> c = {
+            static_cast<std::size_t>(coords)...};
+        std::size_t off = 0;
+        for (std::size_t i = 0; i < sizeof...(Dimensions); ++i) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+            off += c[i] * _strides[i];
+        }
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        return *(_ptr + off);
+    }
+
+    /**
+     * @brief Returns a mutable reference to the element at the given coordinates.
+     * @tparam Coords Integral coordinate types
+     * @param coords  Coordinates of the element
+     * @return Mutable reference to the element
+     *
+     * No bounds checking is performed; use @c at() for bounds-checked access.
+     * The element is located at: @code _ptr + c0*strides[0] + c1*strides[1] + ... @endcode
+     *
+     * @code
+     * ysc::matrix<int, 3, 4> m{};
+     * auto col = m.col(2);   // strided view of column 2
+     * col(1) = 99;           // writes m(1, 2)
+     * assert(m(1, 2) == 99);
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    template <class... Coords>
+        requires integral_coordinates<Coords...> && (sizeof...(Coords) == sizeof...(Dimensions))
+    [[nodiscard]] constexpr T& operator()(Coords... coords) noexcept {
+        const std::array<std::size_t, sizeof...(Dimensions)> c = {
+            static_cast<std::size_t>(coords)...};
+        std::size_t off = 0;
+        for (std::size_t i = 0; i < sizeof...(Dimensions); ++i) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+            off += c[i] * _strides[i];
+        }
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        return *(_ptr + off);
+    }
+
+    /**
+     * @brief Returns a const reference to the element at the given coordinates, with bounds
+     *        checking.
+     * @tparam Coords Integral coordinate types
+     * @param coords  Coordinates of the element
+     * @return Const reference to the element
+     * @throws std::out_of_range if any coordinate is negative or out of bounds
+     *
+     * @code
+     * ysc::matrix<int, 3, 4> m{};
+     * const auto col = m.col(2);
+     * assert(col.at(0) == m(0, 2));
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    template <class... Coords>
+        requires integral_coordinates<Coords...> && (sizeof...(Coords) == sizeof...(Dimensions))
+    [[nodiscard]] const T& at(Coords... coords) const {
+        const bool any_of_coords_is_negative = ((coords < 0) || ...);
+        const bool any_of_coords_is_out_of_bound =
+            ((static_cast<std::size_t>(coords) >= Dimensions) || ...);
+        if (any_of_coords_is_negative || any_of_coords_is_out_of_bound) {
+            throw std::out_of_range{"matrix_view::at"};
+        }
+        return (*this)(coords...);
+    }
+
+    /**
+     * @brief Returns a mutable reference to the element at the given coordinates, with bounds
+     *        checking.
+     * @tparam Coords Integral coordinate types
+     * @param coords  Coordinates of the element
+     * @return Mutable reference to the element
+     * @throws std::out_of_range if any coordinate is negative or out of bounds
+     *
+     * @code
+     * ysc::matrix<int, 3, 4> m{};
+     * auto col = m.col(2);
+     * col.at(1) = 99;
+     * assert(m(1, 2) == 99);
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    template <class... Coords>
+        requires integral_coordinates<Coords...> && (sizeof...(Coords) == sizeof...(Dimensions))
+    [[nodiscard]] T& at(Coords... coords) {
+        const bool any_of_coords_is_negative = ((coords < 0) || ...);
+        const bool any_of_coords_is_out_of_bound =
+            ((static_cast<std::size_t>(coords) >= Dimensions) || ...);
+        if (any_of_coords_is_negative || any_of_coords_is_out_of_bound) {
+            throw std::out_of_range{"matrix_view::at"};
+        }
+        return (*this)(coords...);
+    }
+};
+
+// ─── contiguous → strided conversion (defined here, after strided is complete) ─
+
+/**
+ * @brief Converts a contiguous view to the equivalent strided view.
+ *
+ * The natural strides of a row-major contiguous view are computed at compile time.
+ * Stride at dimension @c i = product of all dimensions after @c i.
+ *
+ * @ingroup ysc_view
+ */
+template <class T, std::size_t... Dimensions>
+matrix_view<T, contiguous, Dimensions...>::operator matrix_view<T, strided, Dimensions...>()
+    const noexcept {
+    constexpr std::array<std::size_t, sizeof...(Dimensions)> dims_arr = {Dimensions...};
+    std::array<std::size_t, sizeof...(Dimensions)> strides{};
+    for (std::size_t i = 0; i < sizeof...(Dimensions); ++i) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+        strides[i] = 1;
+        for (std::size_t j = i + 1; j < sizeof...(Dimensions); ++j) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+            strides[i] *= dims_arr[j];
+        }
+    }
+    return matrix_view<T, strided, Dimensions...>{_ptr, strides};
+}
 
 } // namespace ysc
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(${TARGET_NAME}
     src/dot.cpp
     src/matmul.cpp
     src/matrix_view.cpp
+    src/slice.cpp
     src/ostream.cpp
     src/reductions.cpp
     src/transpose.cpp

--- a/test/src/matrix_view.cpp
+++ b/test/src/matrix_view.cpp
@@ -10,26 +10,28 @@
 
 // ─── compile-time assertions ──────────────────────────────────────────────────
 
-static_assert(sizeof(ysc::matrix_view<int, 3, 3>) == sizeof(int*));
-static_assert(sizeof(ysc::matrix_view<double, 5>) == sizeof(double*));
+static_assert(sizeof(ysc::matrix_view<int, ysc::contiguous, 3, 3>) == sizeof(int*));
+static_assert(sizeof(ysc::matrix_view<double, ysc::contiguous, 5>) == sizeof(double*));
 
-static_assert(std::contiguous_iterator<ysc::matrix_view<int, 3>::iterator>);
-static_assert(std::contiguous_iterator<ysc::matrix_view<int, 3>::const_iterator>);
+static_assert(std::contiguous_iterator<ysc::matrix_view<int, ysc::contiguous, 3>::iterator>);
+static_assert(std::contiguous_iterator<ysc::matrix_view<int, ysc::contiguous, 3>::const_iterator>);
 
-static_assert(ysc::matrix_view<int, 2, 3>::order == 2);
-static_assert(ysc::matrix_view<int, 2, 3>::size() == 6);
-static_assert(!ysc::matrix_view<int, 2, 3>::empty());
+static_assert(ysc::matrix_view<int, ysc::contiguous, 2, 3>::order == 2);
+static_assert(ysc::matrix_view<int, ysc::contiguous, 2, 3>::size() == 6);
+static_assert(!ysc::matrix_view<int, ysc::contiguous, 2, 3>::empty());
 
-static_assert(!std::is_default_constructible_v<ysc::matrix_view<int, 3>>);
-static_assert(std::is_constructible_v<ysc::matrix_view<int, 3>, ysc::matrix<int, 3>&>);
+static_assert(!std::is_default_constructible_v<ysc::matrix_view<int, ysc::contiguous, 3>>);
+static_assert(
+    std::is_constructible_v<ysc::matrix_view<int, ysc::contiguous, 3>, ysc::matrix<int, 3>&>);
 // Non-const matrix_view cannot be constructed from a const matrix
-static_assert(!std::is_constructible_v<ysc::matrix_view<int, 3>, const ysc::matrix<int, 3>&>);
+static_assert(!std::is_constructible_v<ysc::matrix_view<int, ysc::contiguous, 3>,
+                                       const ysc::matrix<int, 3>&>);
 
 // ─── construction ─────────────────────────────────────────────────────────────
 
 TEST(matrix_view_construct, from_matrix_implicit) {
     ysc::matrix<int, 3> m{1, 2, 3};
-    ysc::matrix_view<int, 3> v = m;
+    ysc::matrix_view<int, ysc::contiguous, 3> v = m;
     EXPECT_EQ(v(0), m(0));
     EXPECT_EQ(v(1), m(1));
     EXPECT_EQ(v(2), m(2));
@@ -37,16 +39,16 @@ TEST(matrix_view_construct, from_matrix_implicit) {
 
 TEST(matrix_view_construct, copy_shares_pointer) {
     ysc::matrix<int, 3> m{10, 20, 30};
-    ysc::matrix_view<int, 3> v1 = m;
+    ysc::matrix_view<int, ysc::contiguous, 3> v1 = m;
     // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
-    ysc::matrix_view<int, 3> v2 = v1;
+    ysc::matrix_view<int, ysc::contiguous, 3> v2 = v1;
     v2(0) = 99;
     EXPECT_EQ(m(0), 99);
 }
 
 TEST(matrix_view_construct, from_raw_pointer) {
     std::array<int, 6> buf{1, 2, 3, 4, 5, 6};
-    ysc::matrix_view<int, 2, 3> v{buf.data()};
+    ysc::matrix_view<int, ysc::contiguous, 2, 3> v{buf.data()};
     EXPECT_EQ(v(0, 0), 1);
     EXPECT_EQ(v(1, 2), 6);
 }
@@ -55,7 +57,7 @@ TEST(matrix_view_construct, from_raw_pointer) {
 
 TEST(matrix_view_access, read_within_bounds) {
     ysc::matrix<int, 2, 2> m{1, 2, 3, 4};
-    const ysc::matrix_view<int, 2, 2> v = m;
+    const ysc::matrix_view<int, ysc::contiguous, 2, 2> v = m;
     EXPECT_EQ(v(0, 0), 1);
     EXPECT_EQ(v(0, 1), 2);
     EXPECT_EQ(v(1, 0), 3);
@@ -64,7 +66,7 @@ TEST(matrix_view_access, read_within_bounds) {
 
 TEST(matrix_view_access, write_reflects_in_matrix) {
     ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
-    ysc::matrix_view<int, 2, 3> v = m;
+    ysc::matrix_view<int, ysc::contiguous, 2, 3> v = m;
     v(0, 0) = 99;
     v(1, 2) = 42;
     EXPECT_EQ(m(0, 0), 99);
@@ -73,7 +75,7 @@ TEST(matrix_view_access, write_reflects_in_matrix) {
 
 TEST(matrix_view_access, write_in_matrix_visible_via_view) {
     ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
-    ysc::matrix_view<int, 2, 3> v = m;
+    ysc::matrix_view<int, ysc::contiguous, 2, 3> v = m;
     m(1, 0) = 42;
     EXPECT_EQ(v(1, 0), 42);
 }
@@ -82,44 +84,44 @@ TEST(matrix_view_access, write_in_matrix_visible_via_view) {
 
 TEST(matrix_view_at, nominal_read) {
     ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
-    const ysc::matrix_view<int, 2, 3> v = m;
+    const ysc::matrix_view<int, ysc::contiguous, 2, 3> v = m;
     EXPECT_EQ(v.at(1, 2), 6);
 }
 
 TEST(matrix_view_at, nominal_write) {
     ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
-    ysc::matrix_view<int, 2, 3> v = m;
+    ysc::matrix_view<int, ysc::contiguous, 2, 3> v = m;
     v.at(0, 1) = 77;
     EXPECT_EQ(m(0, 1), 77);
 }
 
 TEST(matrix_view_at, out_of_range_negative) {
     ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
-    const ysc::matrix_view<int, 2, 3> v = m;
+    const ysc::matrix_view<int, ysc::contiguous, 2, 3> v = m;
     EXPECT_THROW((void)v.at(-1, 0), std::out_of_range);
 }
 
 TEST(matrix_view_at, out_of_range_too_large) {
     ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
-    const ysc::matrix_view<int, 2, 3> v = m;
+    const ysc::matrix_view<int, ysc::contiguous, 2, 3> v = m;
     EXPECT_THROW((void)v.at(2, 0), std::out_of_range);
 }
 
 TEST(matrix_view_at, out_of_range_negative_mutable) {
     ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
-    ysc::matrix_view<int, 2, 3> v = m;
+    ysc::matrix_view<int, ysc::contiguous, 2, 3> v = m;
     EXPECT_THROW((void)v.at(-1, 0), std::out_of_range);
 }
 
 TEST(matrix_view_at, out_of_range_too_large_mutable) {
     ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
-    ysc::matrix_view<int, 2, 3> v = m;
+    ysc::matrix_view<int, ysc::contiguous, 2, 3> v = m;
     EXPECT_THROW((void)v.at(2, 0), std::out_of_range);
 }
 
 TEST(matrix_view_at, const_nominal_read) {
     ysc::matrix<int, 3> m{10, 20, 30};
-    const ysc::matrix_view<int, 3> v = m;
+    const ysc::matrix_view<int, ysc::contiguous, 3> v = m;
     EXPECT_EQ(v.at(2), 30);
 }
 
@@ -127,7 +129,7 @@ TEST(matrix_view_at, const_nominal_read) {
 
 TEST(matrix_view_iterators, range_for_read) {
     ysc::matrix<int, 4> m{1, 2, 3, 4};
-    const ysc::matrix_view<int, 4> v = m;
+    const ysc::matrix_view<int, ysc::contiguous, 4> v = m;
     int sum = 0;
     for (const auto& x : v) {
         sum += x;
@@ -137,7 +139,7 @@ TEST(matrix_view_iterators, range_for_read) {
 
 TEST(matrix_view_iterators, range_for_write_reflects_in_matrix) {
     ysc::matrix<int, 3> m{1, 2, 3};
-    ysc::matrix_view<int, 3> v = m;
+    ysc::matrix_view<int, ysc::contiguous, 3> v = m;
     for (auto& x : v) {
         x *= 2;
     }
@@ -148,26 +150,26 @@ TEST(matrix_view_iterators, range_for_write_reflects_in_matrix) {
 
 TEST(matrix_view_iterators, begin_equals_data) {
     ysc::matrix<int, 3> m{1, 2, 3};
-    ysc::matrix_view<int, 3> v = m;
+    ysc::matrix_view<int, ysc::contiguous, 3> v = m;
     EXPECT_EQ(v.begin(), v.data());
 }
 
 TEST(matrix_view_iterators, end_minus_begin_equals_size) {
     ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
-    const ysc::matrix_view<int, 2, 3> v = m;
+    const ysc::matrix_view<int, ysc::contiguous, 2, 3> v = m;
     EXPECT_EQ(std::distance(v.begin(), v.end()), static_cast<std::ptrdiff_t>(v.size()));
 }
 
 TEST(matrix_view_iterators, cbegin_cend_accumulate) {
     ysc::matrix<int, 4> m{10, 20, 30, 40};
-    const ysc::matrix_view<int, 4> v = m;
+    const ysc::matrix_view<int, ysc::contiguous, 4> v = m;
     const int total = std::accumulate(v.cbegin(), v.cend(), 0);
     EXPECT_EQ(total, 100);
 }
 
 TEST(matrix_view_iterators, rbegin_rend) {
     ysc::matrix<int, 3> m{1, 2, 3};
-    const ysc::matrix_view<int, 3> v = m;
+    const ysc::matrix_view<int, ysc::contiguous, 3> v = m;
     std::vector<int> rev(v.rbegin(), v.rend());
     EXPECT_EQ(rev[0], 3);
     EXPECT_EQ(rev[2], 1);
@@ -175,7 +177,7 @@ TEST(matrix_view_iterators, rbegin_rend) {
 
 TEST(matrix_view_iterators, ranges_sort_through_view) {
     ysc::matrix<int, 5> m{5, 3, 1, 4, 2};
-    ysc::matrix_view<int, 5> v = m;
+    ysc::matrix_view<int, ysc::contiguous, 5> v = m;
     std::ranges::sort(v);
     EXPECT_TRUE(std::ranges::is_sorted(m));
 }
@@ -184,26 +186,26 @@ TEST(matrix_view_iterators, ranges_sort_through_view) {
 
 TEST(matrix_view_accessors, front_read) {
     ysc::matrix<int, 3> m{10, 20, 30};
-    const ysc::matrix_view<int, 3> v = m;
+    const ysc::matrix_view<int, ysc::contiguous, 3> v = m;
     EXPECT_EQ(v.front(), 10);
 }
 
 TEST(matrix_view_accessors, front_write_reflects) {
     ysc::matrix<int, 3> m{10, 20, 30};
-    ysc::matrix_view<int, 3> v = m;
+    ysc::matrix_view<int, ysc::contiguous, 3> v = m;
     v.front() = 99;
     EXPECT_EQ(m(0), 99);
 }
 
 TEST(matrix_view_accessors, back_read) {
     ysc::matrix<int, 3> m{10, 20, 30};
-    const ysc::matrix_view<int, 3> v = m;
+    const ysc::matrix_view<int, ysc::contiguous, 3> v = m;
     EXPECT_EQ(v.back(), 30);
 }
 
 TEST(matrix_view_accessors, back_write_reflects) {
     ysc::matrix<int, 3> m{10, 20, 30};
-    ysc::matrix_view<int, 3> v = m;
+    ysc::matrix_view<int, ysc::contiguous, 3> v = m;
     v.back() = 99;
     EXPECT_EQ(m(2), 99);
 }
@@ -212,19 +214,19 @@ TEST(matrix_view_accessors, back_write_reflects) {
 
 TEST(matrix_view_capacity, size_equals_linear_size) {
     ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
-    const ysc::matrix_view<int, 2, 3> v = m;
+    const ysc::matrix_view<int, ysc::contiguous, 2, 3> v = m;
     EXPECT_EQ(v.size(), 6U);
 }
 
 TEST(matrix_view_capacity, data_points_to_matrix_data) {
     ysc::matrix<int, 3> m{1, 2, 3};
-    ysc::matrix_view<int, 3> v = m;
+    ysc::matrix_view<int, ysc::contiguous, 3> v = m;
     EXPECT_EQ(v.data(), m.data());
 }
 
 TEST(matrix_view_capacity, data_write_through) {
     ysc::matrix<int, 3> m{1, 2, 3};
-    ysc::matrix_view<int, 3> v = m;
+    ysc::matrix_view<int, ysc::contiguous, 3> v = m;
     v.data()[1] = 42;
     EXPECT_EQ(m(1), 42);
 }
@@ -233,7 +235,7 @@ TEST(matrix_view_capacity, data_write_through) {
 
 TEST(matrix_view_fill, fill_modifies_matrix) {
     ysc::matrix<int, 2, 2> m{1, 2, 3, 4};
-    ysc::matrix_view<int, 2, 2> v = m;
+    ysc::matrix_view<int, ysc::contiguous, 2, 2> v = m;
     v.fill(0);
     EXPECT_EQ(m(0, 0), 0);
     EXPECT_EQ(m(0, 1), 0);
@@ -245,7 +247,7 @@ TEST(matrix_view_fill, fill_modifies_matrix) {
 
 TEST(matrix_view_1d, single_coord_access) {
     ysc::matrix<int, 5> m{10, 20, 30, 40, 50};
-    ysc::matrix_view<int, 5> v = m;
+    ysc::matrix_view<int, ysc::contiguous, 5> v = m;
     EXPECT_EQ(v(0), 10);
     EXPECT_EQ(v(2), 30);
     EXPECT_EQ(v(4), 50);

--- a/test/src/slice.cpp
+++ b/test/src/slice.cpp
@@ -1,0 +1,280 @@
+#include <matrix.hpp>
+#include <matrix_view.hpp>
+
+#include <concepts>
+#include <gtest/gtest.h>
+#include <type_traits>
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+// Accept any strided view of size N (used to test implicit conversion)
+template <class T, std::size_t N> T sum_strided(ysc::matrix_view<T, ysc::strided, N> v) {
+    T result{};
+    for (std::size_t i = 0; i < N; ++i) {
+        result += v(i);
+    }
+    return result;
+}
+
+// ─── static assertions: return types ─────────────────────────────────────────
+
+// 3D matrix: slice(i, all, all) → contiguous (prefix of fixed dims)
+static_assert(
+    std::same_as<decltype(std::declval<ysc::matrix<int, 3, 4, 5>&>().slice(0, ysc::all, ysc::all)),
+                 ysc::matrix_view<int, ysc::contiguous, 4, 5>>);
+
+// 3D matrix: slice(i) → padding → (i, all, all) → contiguous
+static_assert(std::same_as<decltype(std::declval<ysc::matrix<int, 3, 4, 5>&>().slice(0)),
+                           ysc::matrix_view<int, ysc::contiguous, 4, 5>>);
+
+// 3D matrix: slice() → padding → (all, all, all) → contiguous (full view)
+static_assert(std::same_as<decltype(std::declval<ysc::matrix<int, 3, 4, 5>&>().slice()),
+                           ysc::matrix_view<int, ysc::contiguous, 3, 4, 5>>);
+
+// 3D matrix: slice(all, j, all) → strided (non-prefix)
+static_assert(
+    std::same_as<decltype(std::declval<ysc::matrix<int, 3, 4, 5>&>().slice(ysc::all, 0, ysc::all)),
+                 ysc::matrix_view<int, ysc::strided, 3, 5>>);
+
+// 3D matrix: slice(all, all, k) → strided (non-prefix)
+static_assert(
+    std::same_as<decltype(std::declval<ysc::matrix<int, 3, 4, 5>&>().slice(ysc::all, ysc::all, 0)),
+                 ysc::matrix_view<int, ysc::strided, 3, 4>>);
+
+// 2D matrix: row() → contiguous, col() → strided
+static_assert(std::same_as<decltype(std::declval<ysc::matrix<int, 3, 4>&>().row(0)),
+                           ysc::matrix_view<int, ysc::contiguous, 4>>);
+static_assert(std::same_as<decltype(std::declval<ysc::matrix<int, 3, 4>&>().col(0)),
+                           ysc::matrix_view<int, ysc::strided, 3>>);
+
+// const matrix → const T in view
+static_assert(std::same_as<decltype(std::declval<const ysc::matrix<int, 3, 4>&>().slice(0)),
+                           ysc::matrix_view<const int, ysc::contiguous, 4>>);
+static_assert(std::same_as<decltype(std::declval<const ysc::matrix<int, 3, 4>&>().col(0)),
+                           ysc::matrix_view<const int, ysc::strided, 3>>);
+
+// sizeof(strided view) == sizeof(T*) + order * sizeof(size_t)
+static_assert(sizeof(ysc::matrix_view<int, ysc::strided, 3>) ==
+              sizeof(int*) + 1 * sizeof(std::size_t));
+static_assert(sizeof(ysc::matrix_view<int, ysc::strided, 3, 4>) ==
+              sizeof(int*) + 2 * sizeof(std::size_t));
+
+// ─── slice — prefix (contiguous) ─────────────────────────────────────────────
+
+TEST(slice_contiguous, row_via_slice_reads_correctly) {
+    // matrix<int, 3, 4>: rows are [0..3],[4..7],[8..11]
+    ysc::matrix<int, 3, 4> m{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+    auto v = m.slice(1); // row 1: {4,5,6,7}
+    EXPECT_EQ(v(0), 4);
+    EXPECT_EQ(v(1), 5);
+    EXPECT_EQ(v(2), 6);
+    EXPECT_EQ(v(3), 7);
+}
+
+TEST(slice_contiguous, mutation_reflected_in_matrix) {
+    ysc::matrix<int, 3, 4> m{};
+    auto v = m.slice(1);
+    v(2) = 99;
+    EXPECT_EQ(m(1, 2), 99);
+}
+
+TEST(slice_contiguous, full_view_via_slice_no_args) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    auto v = m.slice(); // full view
+    EXPECT_EQ(v(0, 0), 1);
+    EXPECT_EQ(v(1, 2), 6);
+    v(0, 1) = 77;
+    EXPECT_EQ(m(0, 1), 77);
+}
+
+TEST(slice_contiguous, prefix_explicit_all) {
+    ysc::matrix<int, 3, 4, 5> m{};
+    m(2, 3, 4) = 42;
+    auto v = m.slice(2, ysc::all, ysc::all); // contiguous subslice: layer 2
+    EXPECT_EQ(v(3, 4), 42);
+}
+
+TEST(slice_contiguous, two_fixed_dims_prefix) {
+    ysc::matrix<int, 3, 4, 5> m{};
+    m(1, 2, 3) = 55;
+    auto v = m.slice(1, 2); // padding: (1, 2, all) → contiguous row at [1][2]
+    EXPECT_EQ(v(3), 55);
+}
+
+// ─── slice — non-prefix (strided) ────────────────────────────────────────────
+
+TEST(slice_strided, middle_dim_fixed) {
+    // matrix<int, 3, 4, 5>: slice(all, 2, all) → strided view of "plane" at dim1=2
+    ysc::matrix<int, 3, 4, 5> m{};
+    m(0, 2, 0) = 1;
+    m(1, 2, 3) = 2;
+    m(2, 2, 4) = 3;
+    auto v = m.slice(ysc::all, 2, ysc::all); // matrix_view<int, strided, 3, 5>
+    EXPECT_EQ(v(0, 0), 1);
+    EXPECT_EQ(v(1, 3), 2);
+    EXPECT_EQ(v(2, 4), 3);
+}
+
+TEST(slice_strided, last_dim_fixed) {
+    ysc::matrix<int, 3, 4, 5> m{};
+    m(1, 2, 3) = 77;
+    auto v = m.slice(ysc::all, ysc::all, 3); // strided, 3×4
+    EXPECT_EQ(v(1, 2), 77);
+}
+
+TEST(slice_strided, mutation_reflected_in_matrix) {
+    ysc::matrix<int, 3, 4> m{};
+    auto v = m.slice(ysc::all, 2); // strided column 2
+    v(1) = 99;
+    EXPECT_EQ(m(1, 2), 99);
+}
+
+TEST(slice_strided, at_out_of_range) {
+    ysc::matrix<int, 3, 4, 5> m{};
+    auto v = m.slice(ysc::all, 2, ysc::all);
+    EXPECT_THROW((void)v.at(99, 0), std::out_of_range);
+    EXPECT_THROW((void)v.at(0, 99), std::out_of_range);
+    EXPECT_EQ(v.at(0, 0), 0); // in-bounds: no throw
+}
+
+// ─── padding (implicit all) ───────────────────────────────────────────────────
+
+TEST(slice_padding, slice_one_arg_3d_equals_slice_i_all_all) {
+    ysc::matrix<int, 3, 4, 5> m{};
+    m(2, 0, 0) = 7;
+    m(2, 3, 4) = 8;
+    auto v1 = m.slice(2);
+    auto v2 = m.slice(2, ysc::all, ysc::all);
+    EXPECT_EQ(v1(0, 0), v2(0, 0));
+    EXPECT_EQ(v1(3, 4), v2(3, 4));
+}
+
+// ─── bounds checking ─────────────────────────────────────────────────────────
+
+TEST(slice_bounds, out_of_range_throws) {
+    ysc::matrix<int, 3, 4> m{};
+    EXPECT_THROW((void)m.slice(99), std::out_of_range);
+    EXPECT_THROW((void)m.slice(ysc::all, 99), std::out_of_range);
+    EXPECT_NO_THROW((void)m.slice(2));
+}
+
+TEST(slice_bounds, const_matrix_out_of_range) {
+    const ysc::matrix<int, 3, 4> m{};
+    EXPECT_THROW((void)m.slice(99), std::out_of_range);
+    EXPECT_NO_THROW((void)m.slice(2));
+}
+
+// ─── const-correctness ────────────────────────────────────────────────────────
+
+TEST(slice_const, const_matrix_returns_const_view) {
+    ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    const auto& cm = m;
+    auto v = cm.slice(1);
+    // v is matrix_view<const int, contiguous, 4> — mutation must fail to compile:
+    // v(0) = 99;   // would be a compile error
+    EXPECT_EQ(v(0), 5); // read works
+    static_assert(std::is_const_v<std::remove_reference_t<decltype(v(0))>>);
+}
+
+TEST(slice_const, const_strided_view_read) {
+    ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    const auto& cm = m;
+    auto v = cm.slice(ysc::all, 1); // strided column 1 — const view
+    EXPECT_EQ(v(0), 2);             // m(0,1)
+    EXPECT_EQ(v(1), 6);             // m(1,1)
+    EXPECT_EQ(v(2), 10);            // m(2,1)
+}
+
+// ─── implicit conversion contiguous → strided ─────────────────────────────────
+
+TEST(slice_conversion, contiguous_to_strided_implicit) {
+    ysc::matrix<int, 5> m{10, 20, 30, 40, 50};
+    auto cv = m.slice(); // contiguous view
+    // Pass to function that accepts strided view — implicit conversion
+    // Assign to local first: template args confuse the EXPECT_EQ macro's comma parsing
+    int const total = sum_strided<int, 5>(cv);
+    EXPECT_EQ(total, 150);
+}
+
+TEST(slice_conversion, strided_view_mutation_via_converted_view) {
+    ysc::matrix<int, 3> m{1, 2, 3};
+    ysc::matrix_view<int, ysc::strided, 3> sv = m.slice();
+    sv(0) = 77;
+    EXPECT_EQ(m(0), 77);
+}
+
+// ─── row() / col() ────────────────────────────────────────────────────────────
+
+TEST(slice_row, row_reads_correctly) {
+    ysc::matrix<int, 3, 4> m{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+    auto r = m.row(2);
+    EXPECT_EQ(r(0), 8);
+    EXPECT_EQ(r(1), 9);
+    EXPECT_EQ(r(2), 10);
+    EXPECT_EQ(r(3), 11);
+}
+
+TEST(slice_row, row_mutation_reflected) {
+    ysc::matrix<int, 3, 4> m{};
+    m.row(1)(2) = 42;
+    EXPECT_EQ(m(1, 2), 42);
+}
+
+TEST(slice_row, row_out_of_range) {
+    ysc::matrix<int, 3, 4> m{};
+    EXPECT_THROW((void)m.row(3), std::out_of_range);
+    EXPECT_NO_THROW((void)m.row(2));
+}
+
+TEST(slice_row, const_row_read) {
+    const ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    auto r = m.row(0);
+    EXPECT_EQ(r(0), 1);
+    EXPECT_EQ(r(3), 4);
+}
+
+TEST(slice_col, col_reads_correctly) {
+    ysc::matrix<int, 3, 4> m{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+    auto c = m.col(1); // column 1: m(0,1)=1, m(1,1)=5, m(2,1)=9
+    EXPECT_EQ(c(0), 1);
+    EXPECT_EQ(c(1), 5);
+    EXPECT_EQ(c(2), 9);
+}
+
+TEST(slice_col, col_mutation_reflected) {
+    ysc::matrix<int, 3, 4> m{};
+    m.col(2)(1) = 99;
+    EXPECT_EQ(m(1, 2), 99);
+}
+
+TEST(slice_col, col_out_of_range) {
+    ysc::matrix<int, 3, 4> m{};
+    EXPECT_THROW((void)m.col(4), std::out_of_range);
+    EXPECT_NO_THROW((void)m.col(3));
+}
+
+TEST(slice_col, const_col_read) {
+    const ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    auto c = m.col(0); // column 0: 1, 5, 9
+    EXPECT_EQ(c(0), 1);
+    EXPECT_EQ(c(1), 5);
+    EXPECT_EQ(c(2), 9);
+}
+
+// row/col restricted to order==2 — verified at compile time.
+// Uses void_t SFINAE instead of !requires{} to work around a GCC 15 bug where constraint
+// failures inside requires-expressions produce hard errors for constrained function templates.
+namespace {
+template <class M, class = void> struct has_row_m : std::false_type {};
+template <class M>
+struct has_row_m<M, std::void_t<decltype(std::declval<M&>().row(std::size_t{}))>> : std::true_type {
+};
+
+template <class M, class = void> struct has_col_m : std::false_type {};
+template <class M>
+struct has_col_m<M, std::void_t<decltype(std::declval<M&>().col(std::size_t{}))>> : std::true_type {
+};
+} // namespace
+
+static_assert(!has_row_m<ysc::matrix<int, 3, 4, 5>>::value);
+static_assert(!has_col_m<ysc::matrix<int, 5>>::value);

--- a/test/src/slice.cpp
+++ b/test/src/slice.cpp
@@ -203,6 +203,15 @@ TEST(slice_conversion, strided_view_mutation_via_converted_view) {
     EXPECT_EQ(m(0), 77);
 }
 
+TEST(slice_conversion, contiguous_2d_to_strided_implicit) {
+    ysc::matrix<int, 3, 4> m{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+    auto cv = m.slice(); // matrix_view<int, contiguous, 3, 4>
+    ysc::matrix_view<int, ysc::strided, 3, 4> sv = cv;
+    EXPECT_EQ(sv(0, 0), 0);
+    EXPECT_EQ(sv(1, 2), 6);
+    EXPECT_EQ(sv(2, 3), 11);
+}
+
 // ─── row() / col() ────────────────────────────────────────────────────────────
 
 TEST(slice_row, row_reads_correctly) {
@@ -233,6 +242,12 @@ TEST(slice_row, const_row_read) {
     EXPECT_EQ(r(3), 4);
 }
 
+TEST(slice_row, const_row_out_of_range) {
+    const ysc::matrix<int, 3, 4> m{};
+    EXPECT_THROW((void)m.row(3), std::out_of_range);
+    EXPECT_NO_THROW((void)m.row(2));
+}
+
 TEST(slice_col, col_reads_correctly) {
     ysc::matrix<int, 3, 4> m{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
     auto c = m.col(1); // column 1: m(0,1)=1, m(1,1)=5, m(2,1)=9
@@ -259,6 +274,12 @@ TEST(slice_col, const_col_read) {
     EXPECT_EQ(c(0), 1);
     EXPECT_EQ(c(1), 5);
     EXPECT_EQ(c(2), 9);
+}
+
+TEST(slice_col, const_col_out_of_range) {
+    const ysc::matrix<int, 3, 4> m{};
+    EXPECT_THROW((void)m.col(4), std::out_of_range);
+    EXPECT_NO_THROW((void)m.col(3));
 }
 
 // row/col restricted to order==2 — verified at compile time.

--- a/utils/clang-format/Dockerfile
+++ b/utils/clang-format/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.21
+
+RUN apk update && apk add clang18-extra-tools=18.1.8-r2
+
+WORKDIR /mnt
+ENTRYPOINT ["/usr/lib/llvm18/bin/clang-format"]


### PR DESCRIPTION
## Résumé

Refonte de `matrix_view<T, Dims...>` (US-035) en `matrix_view<T, Storage, Dims...>` avec deux spécialisations partielles : `contiguous` (ancienne API, breaking change) et `strided` (nouvelle, pour les vues non-contiguës). La dépendance circulaire entre `matrix.hpp` et `matrix_view.hpp` est résolue par extraction du code partagé dans un nouveau header `matrix_detail.hpp`. La méthode `slice()` est ajoutée à `matrix<T, Dims...>` et retourne la bonne spécialisation selon que les dimensions fixées forment un préfixe (`contiguous`) ou non (`strided`). Les aliases `row(i)` et `col(j)` sont ajoutés pour les matrices 2D.

**Note d'implémentation :** le pattern `!requires { m.row(0); }` produit un hard error avec GCC 15 pour les templates contraints avec paramètre par défaut. Contourné via `void_t` SFINAE dans le test.

## Critères d'acceptation

- [x] `m.slice(i, all, all)` retourne `matrix_view<T, contiguous, …>` (vérifié `static_assert`)
- [x] `m.slice(all, j, all)` retourne `matrix_view<T, strided, …>` (vérifié `static_assert`)
- [x] `m.slice(0)` sur 3D ≡ `m.slice(0, all, all)` — padding implicite
- [x] `m.slice()` = vue complète contiguë sur toute la matrice
- [x] Mutation via vue reflétée dans la matrice d'origine
- [x] `m.slice(...)` sur `const matrix` retourne une vue `const T`
- [x] `m.slice(idx_hors_bornes, …)` lève `std::out_of_range`
- [x] Conversion implicite `matrix_view<T, contiguous, D…>` → `matrix_view<T, strided, D…>` testée
- [x] `m.row(i)` sur matrice 2D — retourne `matrix_view<T, contiguous, …>` correct
- [x] `m.col(j)` sur matrice 2D — retourne `matrix_view<T, strided, …>`, mutation reflétée
- [x] `m.row(idx_hors_bornes)` / `m.col(idx_hors_bornes)` lèvent `std::out_of_range`
- [x] `at()` sur la spé `strided` lève `std::out_of_range` hors bornes
- [x] `row()`/`col()` refusés à la compilation pour `order ≠ 2`
- [x] Toutes les fonctions publiques documentées Doxygen
- [x] Build et tests verts, clang-format propre, clang-tidy propre