### PR TITLE
US-037 — reshape() et flatten() zero-copy

### DIFF
--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -11,7 +11,7 @@
 | **E — Comparaison & I/O** | ✅ Terminée | 7/7 | ✅ US-019, US-020, US-021, US-022, US-023, US-024, US-025 |
 | **F — Arithmétique** | ✅ Terminée | 4/4 | ✅ US-026, ✅ US-027, ✅ US-028, ✅ US-029 |
 | **G — Algorithmes** | ✅ Terminée | 5/5 | ✅ US-030, ✅ US-031, ✅ US-032, ✅ US-033, ✅ US-034 |
-| **H — Vues & reshape** | 🔄 En cours | 2/4 | ✅ US-035, ✅ US-036, ⬜ US-037, ⬜ US-044 |
+| **H — Vues & reshape** | 🔄 En cours | 3/4 | ✅ US-035, ✅ US-036, ✅ US-037, ⬜ US-044 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/6 | ⬜ US-038 à US-043 |
 
 **Total : 34 / 44 US**
@@ -920,8 +920,8 @@ matrix_view<T, linear_size> flatten();
 Reshape = juste un changement de vue, zero-copy.
 
 ### Critères d'acceptation
-- [ ] `static_assert((NewD * ...) == linear_size)` à la compilation
-- [ ] Mutation via reshape reflétée
+- [x] `static_assert((NewD * ...) == linear_size)` à la compilation
+- [x] Mutation via reshape reflétée
 
 ---
 

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -1324,6 +1324,82 @@ public:
         return matrix_view<const T, strided, dimensions[0]>{
             _data.data() + j, std::array<std::size_t, 1>{dimensions[1]}};
     }
+
+    /**
+     * @brief Returns a non-owning view over the same data reinterpreted with new dimensions.
+     * @tparam NewD New dimensions; their product must equal @c linear_size.
+     * @return @c matrix_view<T, contiguous, NewD...>
+     *
+     * Zero-copy: the view and the matrix share the same memory.
+     * Mutation through the view is reflected in the original matrix.
+     *
+     * @code
+     * ysc::matrix<int, 2, 6> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+     * auto v = m.reshape<3, 4>();  // view m as 3x4
+     * v(0, 0) = 99;               // also sets m(0, 0)
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    template <std::size_t... NewD>
+    [[nodiscard]] constexpr matrix_view<T, contiguous, NewD...> reshape() & noexcept {
+        static_assert((NewD * ...) == linear_size,
+                      "reshape: product of new dimensions must equal linear_size");
+        return matrix_view<T, contiguous, NewD...>{_data.data()};
+    }
+
+    /**
+     * @brief Returns a const non-owning view over the same data reinterpreted with new dimensions.
+     * @tparam NewD New dimensions; their product must equal @c linear_size.
+     * @return @c matrix_view<const T, contiguous, NewD...>
+     *
+     * @code
+     * const ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+     * auto v = m.reshape<6>();  // matrix_view<const int, contiguous, 6>
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    template <std::size_t... NewD>
+    [[nodiscard]] constexpr matrix_view<const T, contiguous, NewD...> reshape() const& noexcept {
+        static_assert((NewD * ...) == linear_size,
+                      "reshape: product of new dimensions must equal linear_size");
+        return matrix_view<const T, contiguous, NewD...>{_data.data()};
+    }
+
+    /**
+     * @brief Returns a 1D non-owning view over all elements in row-major order.
+     * @return @c matrix_view<T, contiguous, linear_size>
+     *
+     * Equivalent to @c reshape<linear_size>(). Zero-copy.
+     *
+     * @code
+     * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+     * auto v = m.flatten();  // matrix_view<int, contiguous, 6>
+     * assert(v(3) == m(1, 0));
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] constexpr matrix_view<T, contiguous, linear_size> flatten() & noexcept {
+        return matrix_view<T, contiguous, linear_size>{_data.data()};
+    }
+
+    /**
+     * @brief Returns a const 1D non-owning view over all elements in row-major order.
+     * @return @c matrix_view<const T, contiguous, linear_size>
+     *
+     * @code
+     * const ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+     * auto v = m.flatten();  // matrix_view<const int, contiguous, 6>
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] constexpr matrix_view<const T, contiguous, linear_size>
+    flatten() const& noexcept {
+        return matrix_view<const T, contiguous, linear_size>{_data.data()};
+    }
 };
 
 /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(${TARGET_NAME}
     src/dot.cpp
     src/matmul.cpp
     src/matrix_view.cpp
+    src/reshape.cpp
     src/slice.cpp
     src/ostream.cpp
     src/reductions.cpp

--- a/test/src/reshape.cpp
+++ b/test/src/reshape.cpp
@@ -1,0 +1,98 @@
+#include <matrix.hpp>
+#include <matrix_view.hpp>
+
+#include <gtest/gtest.h>
+#include <type_traits>
+
+// ─── compile-time assertions ──────────────────────────────────────────────────
+
+static_assert(std::is_same_v<decltype(std::declval<ysc::matrix<int, 2, 3>&>().reshape<6>()),
+                             ysc::matrix_view<int, ysc::contiguous, 6>>);
+static_assert(std::is_same_v<decltype(std::declval<ysc::matrix<int, 2, 3>&>().reshape<1, 6>()),
+                             ysc::matrix_view<int, ysc::contiguous, 1, 6>>);
+static_assert(std::is_same_v<decltype(std::declval<const ysc::matrix<int, 2, 3>&>().reshape<6>()),
+                             ysc::matrix_view<const int, ysc::contiguous, 6>>);
+static_assert(std::is_same_v<decltype(std::declval<ysc::matrix<int, 2, 3>&>().flatten()),
+                             ysc::matrix_view<int, ysc::contiguous, 6>>);
+static_assert(std::is_same_v<decltype(std::declval<const ysc::matrix<int, 2, 3>&>().flatten()),
+                             ysc::matrix_view<const int, ysc::contiguous, 6>>);
+
+// ─── reshape ──────────────────────────────────────────────────────────────────
+
+TEST(reshape, changes_dimension_interpretation) {
+    ysc::matrix<int, 2, 6> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    auto v = m.reshape<3, 4>();
+    EXPECT_EQ(v(1, 2), m(0, 6)); // flat index 6 = row1*4+col2 in 3x4 = row0*6+6 in 2x6
+    EXPECT_EQ(v(0, 0), m(0, 0));
+    EXPECT_EQ(v(2, 3), m(1, 5));
+}
+
+TEST(reshape, mutation_reflected_in_original) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    auto v = m.reshape<6>();
+    v(3) = 99;
+    EXPECT_EQ(m(1, 0), 99);
+}
+
+TEST(reshape, original_mutation_reflected_in_view) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    auto v = m.reshape<6>();
+    m(0, 2) = 42;
+    EXPECT_EQ(v(2), 42);
+}
+
+TEST(reshape, const_matrix_gives_const_view) {
+    const ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    auto v = m.reshape<6>();
+    static_assert(std::is_const_v<std::remove_reference_t<decltype(v(0))>>);
+    EXPECT_EQ(v(0), 1);
+    EXPECT_EQ(v(5), 6);
+}
+
+TEST(reshape, nd_to_nd) {
+    ysc::matrix<int, 24> m{1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+                           13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24};
+    auto v = m.reshape<2, 3, 4>();
+    EXPECT_EQ(v(0, 0, 0), m(0));
+    EXPECT_EQ(v(1, 2, 3), m(23));
+    EXPECT_EQ(v(0, 1, 2), m(6));
+}
+
+// ─── flatten ─────────────────────────────────────────────────────────────────
+
+TEST(flatten, basic) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    auto v = m.flatten();
+    EXPECT_EQ(v(0), 1);
+    EXPECT_EQ(v(3), 4);
+    EXPECT_EQ(v(5), 6);
+}
+
+TEST(flatten, mutation_reflected_in_original) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    auto v = m.flatten();
+    v(3) = 42;
+    EXPECT_EQ(m(1, 0), 42);
+}
+
+TEST(flatten, original_mutation_reflected_in_view) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    auto v = m.flatten();
+    m(1, 2) = 77;
+    EXPECT_EQ(v(5), 77);
+}
+
+TEST(flatten, const_matrix_gives_const_view) {
+    const ysc::matrix<int, 3> m{1, 2, 3};
+    auto v = m.flatten();
+    static_assert(std::is_const_v<std::remove_reference_t<decltype(v(0))>>);
+    EXPECT_EQ(v(0), 1);
+    EXPECT_EQ(v(2), 3);
+}
+
+TEST(flatten, on_1d_matrix_is_identity_view) {
+    ysc::matrix<int, 6> m{10, 20, 30, 40, 50, 60};
+    auto v = m.flatten();
+    EXPECT_EQ(v(0), m(0));
+    EXPECT_EQ(v(5), m(5));
+}


### PR DESCRIPTION
## Résumé

Ajoute `reshape<NewD...>()` et `flatten()` à `ysc::matrix<T, Dims...>`.
Les deux méthodes retournent une `matrix_view<T, contiguous, ...>` pointant
sur le même stockage sans copie — seule l'interprétation des dimensions change.

## Critères d'acceptation

- [x] `static_assert((NewD * ...) == linear_size)` à la compilation
- [x] Mutation via reshape reflétée dans la matrice d'origine

## Implémentation

- `reshape<NewD...>() &` → `matrix_view<T, contiguous, NewD...>`
- `reshape<NewD...>() const&` → `matrix_view<const T, contiguous, NewD...>`
- `flatten() &` → `matrix_view<T, contiguous, linear_size>`
- `flatten() const&` → `matrix_view<const T, contiguous, linear_size>`

Le `static_assert` dans `reshape()` garantit au moment de la compilation
que `(NewD * ...) == linear_size`. `flatten()` est l'équivalent de
`reshape<linear_size>()`.

9 tests dans `test/src/reshape.cpp` : vérification des types retournés
(static_assert), accès cohérent avec la matrice d'origine, mutation reflétée
dans les deux sens, surcharges const.