### PR TITLE
US-044 — Constructeur matrix(matrix_view) (owning ← view)

### DIFF
--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -11,10 +11,10 @@
 | **E — Comparaison & I/O** | ✅ Terminée | 7/7 | ✅ US-019, US-020, US-021, US-022, US-023, US-024, US-025 |
 | **F — Arithmétique** | ✅ Terminée | 4/4 | ✅ US-026, ✅ US-027, ✅ US-028, ✅ US-029 |
 | **G — Algorithmes** | ✅ Terminée | 5/5 | ✅ US-030, ✅ US-031, ✅ US-032, ✅ US-033, ✅ US-034 |
-| **H — Vues & reshape** | 🔄 En cours | 3/4 | ✅ US-035, ✅ US-036, ✅ US-037, ⬜ US-044 |
+| **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
 | **I — Finition & release** | ⬜ Non démarrée | 0/6 | ⬜ US-038 à US-043 |
 
-**Total : 34 / 44 US**
+**Total : 35 / 44 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -1099,9 +1099,9 @@ auto m2 = ysc::matrix(v);          // matrix<int, 3>, copie owning
 - Pas d'allocation, pas d'exception (en dehors de celles éventuelles du copy ctor de `T`).
 
 ### Critères d'acceptation
-- [ ] `auto m2 = ysc::matrix(v);` compile pour `v` issu de `slice(...)`, `row(...)`, `col(...)`.
-- [ ] `m2` est indépendant : mutation de `m2` n'affecte pas la matrice source, et vice-versa.
-- [ ] Surcharge `contiguous` testée (copie de `m.slice(i, all, all)`).
-- [ ] Surcharge `strided` testée (copie de `m.col(j)`).
-- [ ] Constructeur Doxygen-documenté (`@brief`, `@tparam`, `@param`, `@code`…`@endcode`, `@ingroup`).
-- [ ] Build et tests verts, pas de warning clang-format ni clang-tidy.
+- [x] `auto m2 = ysc::matrix(v);` compile pour `v` issu de `slice(...)`, `row(...)`, `col(...)`.
+- [x] `m2` est indépendant : mutation de `m2` n'affecte pas la matrice source, et vice-versa.
+- [x] Surcharge `contiguous` testée (copie de `m.slice(i, all, all)`).
+- [x] Surcharge `strided` testée (copie de `m.col(j)`).
+- [x] Constructeur Doxygen-documenté (`@brief`, `@tparam`, `@param`, `@code`…`@endcode`, `@ingroup`).
+- [x] Build et tests verts, pas de warning clang-format ni clang-tidy.

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -21,6 +21,7 @@
 #include <numeric>
 #include <ostream>
 #include <stdexcept>
+#include <tuple>
 #include <type_traits>
 // Clang < 17 cannot compile libstdc++-14's <format> due to unicode.h
 // incompatibility
@@ -348,6 +349,51 @@ public:
     // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
     matrix(matrix<U, Dimensions...>&& other) {
         std::move(other._data.cbegin(), other._data.cend(), _data.begin());
+    }
+
+    // constructors from matrix_view
+    /**
+     * @brief Constructs an owning matrix by copying elements from a contiguous view.
+     * @param v Contiguous view to copy from
+     *
+     * Elements are copied with @c std::copy. The resulting matrix is independent of @p v:
+     * mutations to either do not affect the other.
+     *
+     * @code
+     * ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+     * auto row0 = m.row(0);                    // contiguous view of row 0
+     * auto m2   = ysc::matrix<int, 4>(row0);   // owning copy
+     * m2(0) = 99;                              // does not affect m
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    explicit matrix(const matrix_view<T, contiguous, Dimensions...>& v) {
+        std::copy(v.begin(), v.end(), _data.begin());
+    }
+
+    /**
+     * @brief Constructs an owning matrix by copying elements from a strided view.
+     * @param v Strided view to copy from
+     *
+     * Elements are copied one by one via @c operator(). The resulting matrix is independent
+     * of @p v: mutations to either do not affect the other.
+     *
+     * @code
+     * ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+     * auto col1 = m.col(1);                    // strided view of column 1
+     * auto m2   = ysc::matrix<int, 3>(col1);   // owning copy
+     * m2(0) = 99;                              // does not affect m
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    explicit matrix(const matrix_view<T, strided, Dimensions...>& v) {
+        std::size_t k = 0;
+        for (auto& elem : _data) {
+            const auto coords = detail::index_to_coordinates(dimensions, k++);
+            elem = std::apply([&v](auto... cs) -> T { return v(cs...); }, coords);
+        }
     }
 
     // assignment operators (copy)

--- a/src/include/matrix_detail.hpp
+++ b/src/include/matrix_detail.hpp
@@ -81,6 +81,21 @@ constexpr auto coordinates_to_index(TDim const& dimensions, TCoord const& coords
     return index;
 }
 
+// Inverse of coordinates_to_index: converts a flat row-major index to multi-dimensional
+// coordinates. Rightmost coordinate varies fastest (row-major).
+template <std::size_t N>
+constexpr std::array<std::size_t, N> index_to_coordinates(std::array<std::size_t, N> dims,
+                                                          std::size_t k) noexcept {
+    std::array<std::size_t, N> coords{};
+    auto it_c = coords.rbegin();
+    auto it_d = dims.crbegin();
+    for (; it_c != coords.rend(); ++it_c, ++it_d) {
+        *it_c = k % *it_d;
+        k /= *it_d;
+    }
+    return coords;
+}
+
 // ─── slice metaprogramming helpers ───────────────────────────────────────────
 
 /** @brief True iff @c S is @c ysc::all_t. */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(${TARGET_NAME}
     src/iterators.cpp
     src/dot.cpp
     src/matmul.cpp
+    src/matrix_from_view.cpp
     src/matrix_view.cpp
     src/reshape.cpp
     src/slice.cpp

--- a/test/src/matrix_from_view.cpp
+++ b/test/src/matrix_from_view.cpp
@@ -1,6 +1,7 @@
 #include <matrix.hpp>
 #include <matrix_view.hpp>
 
+#include <array>
 #include <gtest/gtest.h>
 #include <type_traits>
 
@@ -14,6 +15,35 @@ static_assert(
 static_assert(
     !std::is_convertible_v<ysc::matrix_view<int, ysc::contiguous, 4>, ysc::matrix<int, 4>>);
 static_assert(!std::is_convertible_v<ysc::matrix_view<int, ysc::strided, 3>, ysc::matrix<int, 3>>);
+
+// ─── detail::index_to_coordinates (compile-time) ─────────────────────────────
+
+static_assert(ysc::detail::index_to_coordinates(std::array<std::size_t, 1>{3}, std::size_t{0}) ==
+              std::array<std::size_t, 1>{0});
+static_assert(ysc::detail::index_to_coordinates(std::array<std::size_t, 2>{3, 4}, std::size_t{5}) ==
+              std::array<std::size_t, 2>{1, 1}); // 5 = 1×4 + 1
+static_assert(ysc::detail::index_to_coordinates(std::array<std::size_t, 2>{3, 4},
+                                                std::size_t{11}) ==
+              std::array<std::size_t, 2>{2, 3});
+
+// ─── detail::index_to_coordinates (runtime) ──────────────────────────────────
+
+TEST(detail_index_to_coordinates, 1d) {
+    EXPECT_EQ((ysc::detail::index_to_coordinates(std::array<std::size_t, 1>{3}, std::size_t{0})),
+              (std::array<std::size_t, 1>{0}));
+    EXPECT_EQ((ysc::detail::index_to_coordinates(std::array<std::size_t, 1>{3}, std::size_t{2})),
+              (std::array<std::size_t, 1>{2}));
+}
+
+TEST(detail_index_to_coordinates, 2d_row_major) {
+    EXPECT_EQ((ysc::detail::index_to_coordinates(std::array<std::size_t, 2>{3, 4}, std::size_t{0})),
+              (std::array<std::size_t, 2>{0, 0}));
+    EXPECT_EQ((ysc::detail::index_to_coordinates(std::array<std::size_t, 2>{3, 4}, std::size_t{5})),
+              (std::array<std::size_t, 2>{1, 1}));
+    EXPECT_EQ(
+        (ysc::detail::index_to_coordinates(std::array<std::size_t, 2>{3, 4}, std::size_t{11})),
+        (std::array<std::size_t, 2>{2, 3}));
+}
 
 // ─── contiguous view (from row) ───────────────────────────────────────────────
 
@@ -54,6 +84,19 @@ TEST(matrix_from_view, contiguous_from_slice) {
     EXPECT_EQ(m2(2, 3), m(1, 2, 3));
 }
 
+TEST(matrix_from_view, contiguous_2d_explicit) {
+    ysc::matrix<int, 2, 3, 4> m{};
+    for (std::size_t i = 0; i < 2; ++i)
+        for (std::size_t j = 0; j < 3; ++j)
+            for (std::size_t k = 0; k < 4; ++k)
+                m(i, j, k) = static_cast<int>(i * 12 + j * 4 + k + 1);
+    auto v = m.slice(0); // contiguous view of m[0]: matrix_view<int, contiguous, 3, 4>
+    ysc::matrix<int, 3, 4> m2(v);
+    for (std::size_t j = 0; j < 3; ++j)
+        for (std::size_t k = 0; k < 4; ++k)
+            EXPECT_EQ(m2(j, k), m(0, j, k));
+}
+
 // ─── strided view (from col) ──────────────────────────────────────────────────
 
 TEST(matrix_from_view, strided_from_col_copies_values) {
@@ -86,6 +129,21 @@ TEST(matrix_from_view, strided_from_slice_all_fixed) {
     EXPECT_EQ(m2(0), m(0, 1));
     EXPECT_EQ(m2(1), m(1, 1));
     EXPECT_EQ(m2(2), m(2, 1));
+}
+
+TEST(matrix_from_view, strided_2d_from_3d_slice) {
+    ysc::matrix<int, 2, 3, 4> m{};
+    for (std::size_t i = 0; i < 2; ++i)
+        for (std::size_t j = 0; j < 3; ++j)
+            for (std::size_t k = 0; k < 4; ++k)
+                m(i, j, k) = static_cast<int>(i * 12 + j * 4 + k + 1);
+    // slice(ysc::all, 1) → spec (all_t, 1, all_t): keeps dims 0 and 2, fixes dim 1 at 1
+    // result: matrix_view<int, strided, 2, 4>
+    auto v = m.slice(ysc::all, 1);
+    ysc::matrix<int, 2, 4> m2(v);
+    for (std::size_t i = 0; i < 2; ++i)
+        for (std::size_t k = 0; k < 4; ++k)
+            EXPECT_EQ(m2(i, k), m(i, 1, k));
 }
 
 // ─── CTAD ─────────────────────────────────────────────────────────────────────

--- a/test/src/matrix_from_view.cpp
+++ b/test/src/matrix_from_view.cpp
@@ -94,7 +94,7 @@ TEST(matrix_from_view, contiguous_2d_explicit) {
     ysc::matrix<int, 3, 4> m2(v);
     for (std::size_t j = 0; j < 3; ++j)
         for (std::size_t k = 0; k < 4; ++k)
-            EXPECT_EQ(m2(j, k), m(0, j, k));
+            EXPECT_EQ(m2(j, k), m(std::size_t{0}, j, k));
 }
 
 // ─── strided view (from col) ──────────────────────────────────────────────────
@@ -143,7 +143,7 @@ TEST(matrix_from_view, strided_2d_from_3d_slice) {
     ysc::matrix<int, 2, 4> m2(v);
     for (std::size_t i = 0; i < 2; ++i)
         for (std::size_t k = 0; k < 4; ++k)
-            EXPECT_EQ(m2(i, k), m(i, 1, k));
+            EXPECT_EQ(m2(i, k), m(i, std::size_t{1}, k));
 }
 
 // ─── CTAD ─────────────────────────────────────────────────────────────────────

--- a/test/src/matrix_from_view.cpp
+++ b/test/src/matrix_from_view.cpp
@@ -1,0 +1,109 @@
+#include <matrix.hpp>
+#include <matrix_view.hpp>
+
+#include <gtest/gtest.h>
+#include <type_traits>
+
+// ─── compile-time assertions ──────────────────────────────────────────────────
+
+static_assert(
+    std::is_constructible_v<ysc::matrix<int, 4>, const ysc::matrix_view<int, ysc::contiguous, 4>&>);
+static_assert(
+    std::is_constructible_v<ysc::matrix<int, 3>, const ysc::matrix_view<int, ysc::strided, 3>&>);
+// Constructors are explicit: no implicit conversion
+static_assert(
+    !std::is_convertible_v<ysc::matrix_view<int, ysc::contiguous, 4>, ysc::matrix<int, 4>>);
+static_assert(!std::is_convertible_v<ysc::matrix_view<int, ysc::strided, 3>, ysc::matrix<int, 3>>);
+
+// ─── contiguous view (from row) ───────────────────────────────────────────────
+
+TEST(matrix_from_view, contiguous_from_row_copies_values) {
+    ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    auto row1 = m.row(1);
+    auto m2 = ysc::matrix<int, 4>(row1);
+    EXPECT_EQ(m2(0), 5);
+    EXPECT_EQ(m2(1), 6);
+    EXPECT_EQ(m2(2), 7);
+    EXPECT_EQ(m2(3), 8);
+}
+
+TEST(matrix_from_view, contiguous_mutation_of_copy_does_not_affect_source) {
+    ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    auto m2 = ysc::matrix<int, 4>(m.row(1));
+    m2(0) = 99;
+    EXPECT_EQ(m(1, 0), 5);
+}
+
+TEST(matrix_from_view, contiguous_mutation_of_source_does_not_affect_copy) {
+    ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    auto m2 = ysc::matrix<int, 4>(m.row(1));
+    m(1, 0) = 99;
+    EXPECT_EQ(m2(0), 5);
+}
+
+TEST(matrix_from_view, contiguous_from_slice) {
+    ysc::matrix<int, 2, 3, 4> m{};
+    for (std::size_t i = 0; i < 2; ++i)
+        for (std::size_t j = 0; j < 3; ++j)
+            for (std::size_t k = 0; k < 4; ++k)
+                m(i, j, k) = static_cast<int>(i * 12 + j * 4 + k + 1);
+    auto v = m.slice(1); // contiguous view of m[1]: a 3×4 slice
+    auto m2 = ysc::matrix<int, 3, 4>(v);
+    EXPECT_EQ(m2(0, 0), m(1, 0, 0));
+    EXPECT_EQ(m2(1, 2), m(1, 1, 2));
+    EXPECT_EQ(m2(2, 3), m(1, 2, 3));
+}
+
+// ─── strided view (from col) ──────────────────────────────────────────────────
+
+TEST(matrix_from_view, strided_from_col_copies_values) {
+    ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    auto col2 = m.col(2);
+    auto m2 = ysc::matrix<int, 3>(col2);
+    EXPECT_EQ(m2(0), m(0, 2));
+    EXPECT_EQ(m2(1), m(1, 2));
+    EXPECT_EQ(m2(2), m(2, 2));
+}
+
+TEST(matrix_from_view, strided_mutation_of_copy_does_not_affect_source) {
+    ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    auto m2 = ysc::matrix<int, 3>(m.col(2));
+    m2(0) = 99;
+    EXPECT_EQ(m(0, 2), 3);
+}
+
+TEST(matrix_from_view, strided_mutation_of_source_does_not_affect_copy) {
+    ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    auto m2 = ysc::matrix<int, 3>(m.col(2));
+    m(0, 2) = 99;
+    EXPECT_EQ(m2(0), 3);
+}
+
+TEST(matrix_from_view, strided_from_slice_all_fixed) {
+    ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    auto v = m.slice(ysc::all, 1); // strided view of column 1
+    auto m2 = ysc::matrix<int, 3>(v);
+    EXPECT_EQ(m2(0), m(0, 1));
+    EXPECT_EQ(m2(1), m(1, 1));
+    EXPECT_EQ(m2(2), m(2, 1));
+}
+
+// ─── CTAD ─────────────────────────────────────────────────────────────────────
+
+TEST(matrix_from_view, ctad_contiguous) {
+    ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    auto row0 = m.row(0);
+    auto m2 = ysc::matrix(row0);
+    static_assert(std::is_same_v<decltype(m2), ysc::matrix<int, 4>>);
+    EXPECT_EQ(m2(0), 1);
+    EXPECT_EQ(m2(3), 4);
+}
+
+TEST(matrix_from_view, ctad_strided) {
+    ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    auto col0 = m.col(0);
+    auto m2 = ysc::matrix(col0);
+    static_assert(std::is_same_v<decltype(m2), ysc::matrix<int, 3>>);
+    EXPECT_EQ(m2(0), 1);
+    EXPECT_EQ(m2(2), 9);
+}

--- a/test/src/matrix_from_view.cpp
+++ b/test/src/matrix_from_view.cpp
@@ -73,10 +73,13 @@ TEST(matrix_from_view, contiguous_mutation_of_source_does_not_affect_copy) {
 
 TEST(matrix_from_view, contiguous_from_slice) {
     ysc::matrix<int, 2, 3, 4> m{};
-    for (std::size_t i = 0; i < 2; ++i)
-        for (std::size_t j = 0; j < 3; ++j)
-            for (std::size_t k = 0; k < 4; ++k)
+    for (std::size_t i = 0; i < 2; ++i) {
+        for (std::size_t j = 0; j < 3; ++j) {
+            for (std::size_t k = 0; k < 4; ++k) {
                 m(i, j, k) = static_cast<int>(i * 12 + j * 4 + k + 1);
+            }
+        }
+    }
     auto v = m.slice(1); // contiguous view of m[1]: a 3×4 slice
     auto m2 = ysc::matrix<int, 3, 4>(v);
     EXPECT_EQ(m2(0, 0), m(1, 0, 0));
@@ -86,15 +89,20 @@ TEST(matrix_from_view, contiguous_from_slice) {
 
 TEST(matrix_from_view, contiguous_2d_explicit) {
     ysc::matrix<int, 2, 3, 4> m{};
-    for (std::size_t i = 0; i < 2; ++i)
-        for (std::size_t j = 0; j < 3; ++j)
-            for (std::size_t k = 0; k < 4; ++k)
+    for (std::size_t i = 0; i < 2; ++i) {
+        for (std::size_t j = 0; j < 3; ++j) {
+            for (std::size_t k = 0; k < 4; ++k) {
                 m(i, j, k) = static_cast<int>(i * 12 + j * 4 + k + 1);
+            }
+        }
+    }
     auto v = m.slice(0); // contiguous view of m[0]: matrix_view<int, contiguous, 3, 4>
     ysc::matrix<int, 3, 4> m2(v);
-    for (std::size_t j = 0; j < 3; ++j)
-        for (std::size_t k = 0; k < 4; ++k)
+    for (std::size_t j = 0; j < 3; ++j) {
+        for (std::size_t k = 0; k < 4; ++k) {
             EXPECT_EQ(m2(j, k), m(std::size_t{0}, j, k));
+        }
+    }
 }
 
 // ─── strided view (from col) ──────────────────────────────────────────────────
@@ -133,17 +141,22 @@ TEST(matrix_from_view, strided_from_slice_all_fixed) {
 
 TEST(matrix_from_view, strided_2d_from_3d_slice) {
     ysc::matrix<int, 2, 3, 4> m{};
-    for (std::size_t i = 0; i < 2; ++i)
-        for (std::size_t j = 0; j < 3; ++j)
-            for (std::size_t k = 0; k < 4; ++k)
+    for (std::size_t i = 0; i < 2; ++i) {
+        for (std::size_t j = 0; j < 3; ++j) {
+            for (std::size_t k = 0; k < 4; ++k) {
                 m(i, j, k) = static_cast<int>(i * 12 + j * 4 + k + 1);
+            }
+        }
+    }
     // slice(ysc::all, 1) → spec (all_t, 1, all_t): keeps dims 0 and 2, fixes dim 1 at 1
     // result: matrix_view<int, strided, 2, 4>
     auto v = m.slice(ysc::all, 1);
     ysc::matrix<int, 2, 4> m2(v);
-    for (std::size_t i = 0; i < 2; ++i)
-        for (std::size_t k = 0; k < 4; ++k)
+    for (std::size_t i = 0; i < 2; ++i) {
+        for (std::size_t k = 0; k < 4; ++k) {
             EXPECT_EQ(m2(i, k), m(i, std::size_t{1}, k));
+        }
+    }
 }
 
 // ─── CTAD ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Résumé

Ajout de deux constructeurs explicites dans `ysc::matrix` permettant de matérialiser une vue (`matrix_view`) en matrice owning indépendante : une surcharge `contiguous` (copie via `std::copy`) et une surcharge `strided` (copie élément par élément via `operator()` + `detail::index_to_coordinates`). CTAD fonctionne : `auto m2 = ysc::matrix(v)` déduit correctement `matrix<int, N>` à partir du type de la vue.

## Critères d'acceptation

- [x] `auto m2 = ysc::matrix(v);` compile pour `v` issu de `slice(...)`, `row(...)`, `col(...)`
- [x] `m2` est indépendant : mutation de `m2` n'affecte pas la matrice source, et vice-versa
- [x] Surcharge `contiguous` testée (copie de `m.row(0)`, `m.slice(1)`)
- [x] Surcharge `strided` testée (copie de `m.col(2)`, `m.slice(ysc::all, 1)`)
- [x] Constructeurs Doxygen-documentés (`@brief`, `@param`, `@code`…`@endcode`, `@ingroup ysc_view`)
- [x] Build et tests verts, pas de warning clang-format ni clang-tidy

## Décisions d'implémentation

- `detail::index_to_coordinates` ajouté dans `matrix_detail.hpp` : inverse de `coordinates_to_index`, convertit un index flat row-major en coordonnées multidimensionnelles. Utilise des itérateurs reverse pour rester propre vis-à-vis de clang-tidy.
- Surcharge `strided` : range-for sur `_data` avec compteur `k` + `std::apply` pour expanser les coordonnées en appel variadic à `v(cs...)`.
- `#include <tuple>` ajouté pour `std::apply`.