### PR TITLE
chore: back-merge v0.6.0 into develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.20)
 project(ysc-matrix)
 
 set(VERSION_MAJOR   0   CACHE STRING "Project major version number.")
-set(VERSION_MINOR   5   CACHE STRING "Project minor version number.")
+set(VERSION_MINOR   6   CACHE STRING "Project minor version number.")
 set(VERSION_PATCH   0   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 


### PR DESCRIPTION
Back-merge after release v0.6.0 — récupère le tag dans l'historique de develop.