### PR TITLE
US-055 — CHANGELOG.md versionné

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,3 +102,12 @@ jobs:
             CHANGELOG.md
             matrix.hpp.gz
             ysc-matrix.cmake
+
+      - name: Update CHANGELOG
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git-cliff --config cliff.toml --output CHANGELOG.md
+          git add CHANGELOG.md
+          git commit -m "chore(release): update CHANGELOG for ${{ github.ref_name }}"
+          git push origin HEAD:develop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,113 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.6.0] - 2026-05-14
+
+### Features
+- **US-044:** Constructeur matrix(matrix_view) (owning ← view)
+- **US-037:** reshape() et flatten() zero-copy
+- **US-036:** slice() générique N-D, matrix_view unifié
+
+### Miscellaneous
+- Use eclipse-score/apt-install to cache apt packages in CI
+
+## [0.5.0] - 2026-05-11
+
+### Features
+- **US-035:** matrix_view non-owning read/write view
+- **US-034:** dot() produit scalaire 1D
+- **US-033:** matmul() produit matriciel 2D
+- **US-032:** transpose() pour matrices 2D
+- **US-031:** Réductions : sum, min, max, all, any
+- **US-030:** apply() et map() (algorithmes élément-par-élément)
+
+### Bug Fixes
+- Couverture de code — instantiation explicite + CMakeLists manquants
+- Epic G review — constexpr apply/map, concept += matmul/dot, doc fixes
+
+### Miscellaneous
+- Move some files around
+- Overall .gitignore improvements
+- Fix Codecov comment config
+
+## [0.4.0] - 2026-05-03
+
+### Features
+- **US-028 + US-029:** Arithmétique scalaire et opérateurs unaires
+- **US-026 + US-027:** Opérateurs arithmétiques élément-par-élément
+
+## [0.3.0] - 2026-05-03
+
+### Features
+- **US-020:** Spécialisation std::hash pour ysc::matrix
+- **US-025:** Spécialisation std::formatter pour ysc::matrix
+
+### Miscellaneous
+- Désactiver les commentaires Codecov sur les PRs
+- Exclure test/ du rapport Codecov
+
+## [0.2.4] - 2026-05-03
+
+### Miscellaneous
+- Enrichir les assets de la GitHub Release
+
+## [0.2.3] - 2026-05-03
+
+### Bug Fixes
+- Corriger le chemin d'extraction tar de git-cliff
+
+## [0.2.2] - 2026-05-03
+
+### Features
+- **US-024:** operator<< (ostream) pour ysc::matrix
+
+### Bug Fixes
+- Épingler git-cliff v2.13.1 dans le workflow de release
+
+### Miscellaneous
+- Script release.sh + mise à jour CONTRIBUTING.md
+- Silence Codecov PR comments when coverage is unchanged
+
+## [0.2.1] - 2026-05-03
+
+### Bug Fixes
+- Bump version numbers
+- Épingler git-cliff v2.13.1 dans le workflow de release
+
+## [0.2.0] - 2026-05-03
+
+### Features
+- **US-014:** Renommer namespace _details en detail
+- **US-022:** Constructeur depuis initializer_list imbriquée (2D)
+- **US-023:** Factories zeros, ones, full, identity
+- **US-021:** Refactor du constructeur variadic
+- **US-009:** Remplacer SFINAE par Concepts
+- **US-018:** front(), back(), swap() membre
+- **US-011:** fill() : intégration propre depuis feature-fill
+- **US-019:** operator== et operator<=> (defaulted)
+- **US-017:** size(), empty(), data(), max_size()
+- **US-016:** Itérateurs (begin/end et co.)
+- **US-015:** Typedefs membres STL-compatibles
+- **US-008:** Bump C++ standard from C++17 to C++20
+- **US-001:** Pipeline CI multi-plateforme
+- **US-013:** Fix UB: return *this manquant dans les operator= templatés
+
+### Bug Fixes
+- Guard test subdirectory behind BUILD_TESTING to fix docs CI
+
+### Documentation
+- Improve README and Doxygen landing page
+- Ajouter tableau de bord (vue par épopée + détail Epic A)
+
+### Miscellaneous
+- **US-007:** Release automation (semver + GitHub Releases)
+- **US-006:** Doc Doxygen publiée sur GitHub Pages
+- **US-005:** clang-tidy + vérification CI
+- **US-004:** clang-format + vérification CI
+- **US-003:** Sanitizers (ASan + UBSan)
+- **US-002:** Couverture de code (gcov + lcov + Codecov)
+- Add ysc::matrix::at overload set
+- Add API documentation
+- Matrix constructors, assignment operators and destructor
+- Minimal impl with cmake + gtest + dummy test + headeronly library

--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -13,7 +13,7 @@
 | **G — Algorithmes** | ✅ Terminée | 5/5 | ✅ US-030, ✅ US-031, ✅ US-032, ✅ US-033, ✅ US-034 |
 | **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
 | **I — Packaging & préparation v1.0.0** | ⬜ Non démarrée | 0/10 | ⬜ US-038, US-040 à US-043, US-045 à US-049 |
-| **J — Ergonomie & finition** | ⬜ Non démarrée | 0/11 | ⬜ US-039, US-050 à US-059 |
+| **J — Ergonomie & finition** | 🔄 En cours | 1/11 | ✅ US-055, ⬜ US-039, US-050 à US-054, US-056 à US-059 |
 | **K — Extensions post-v1** | ⬜ Non démarrée | 0/9 | ⬜ US-060 à US-068 |
 
 **Total : 38 / 68 US**
@@ -55,7 +55,7 @@
 | US-052 | `matrix_view` : I/O, ctor const, vues composables | P1 | ⬜ À faire |
 | US-053 | Constructeurs additionnels : `std::array`, `std::span`, générateur | P1 | ⬜ À faire |
 | US-054 | `matrix::rows()` / `cols()` + `matmul` vecteur 1D | P1 | ⬜ À faire |
-| US-055 | `CHANGELOG.md` versionné | P1 | ⬜ À faire |
+| US-055 | `CHANGELOG.md` versionné | P1 | ✅ Done |
 | US-056 | Messages d'exception détaillés dans `at()` | P1 | ⬜ À faire |
 | US-057 | Centraliser `NOLINTNEXTLINE` dans `matrix.hpp` | P1 | ⬜ À faire |
 | US-058 | Optimiser `matrix(matrix_view<strided>)` | P1 | ⬜ À faire |
@@ -1495,9 +1495,9 @@ En tant qu'utilisateur arrivant sur le repo GitHub, je veux voir l'historique de
   ```
 
 ### Critères d'acceptation
-- [ ] `CHANGELOG.md` présent à la racine du repo, lisible via GitHub
-- [ ] Contient les releases v0.1.0 à v0.6.0 au minimum
-- [ ] Workflow `release.yml` met à jour et commit `CHANGELOG.md` à chaque nouvelle release
+- [x] `CHANGELOG.md` présent à la racine du repo, lisible via GitHub
+- [x] Contient les releases v0.2.0 à v0.6.0 (premières releases disponibles dans l'historique git)
+- [x] Workflow `release.yml` met à jour et commit `CHANGELOG.md` à chaque nouvelle release
 
 ---
 


### PR DESCRIPTION
## Résumé
Ajout de `CHANGELOG.md` généré manuellement depuis l'historique git, couvrant toutes les releases de v0.2.0 à v0.6.0 (les tags disponibles dans ce dépôt). Le workflow `release.yml` met désormais à jour et commite automatiquement ce fichier sur `develop` à chaque nouvelle release taguée.

## Critères d'acceptation
- [x] `CHANGELOG.md` présent à la racine du repo, lisible via GitHub
- [x] Contient les releases v0.2.0 à v0.6.0 (premières releases disponibles dans l'historique git)
- [x] Workflow `release.yml` met à jour et commit `CHANGELOG.md` à chaque nouvelle release

## Décisions d'implémentation
- `git-cliff` n'étant pas disponible en local, `CHANGELOG.md` a été généré manuellement à partir du `git log`. Le workflow CI utilise déjà `git-cliff` et régénèrera le fichier proprement lors de la prochaine release.
- Le step "Update CHANGELOG" pousse via `HEAD:develop` pour éviter les conflits en cas de detached HEAD lors du checkout du tag.
- La spec mentionnait v0.1.0 mais ce tag n'existe pas dans le dépôt ; le CHANGELOG couvre toutes les versions réellement taguées (v0.2.0 à v0.6.0).