### PR TITLE
US-056 — Messages d'exception détaillés dans at()

### DIFF
--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -13,10 +13,10 @@
 | **G — Algorithmes** | ✅ Terminée | 5/5 | ✅ US-030, ✅ US-031, ✅ US-032, ✅ US-033, ✅ US-034 |
 | **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
 | **I — Packaging & préparation v1.0.0** | ⬜ Non démarrée | 0/10 | ⬜ US-038, US-040 à US-043, US-045 à US-049 |
-| **J — Ergonomie & finition** | ⬜ Non démarrée | 0/11 | ⬜ US-039, US-050 à US-059 |
+| **J — Ergonomie & finition** | 🔄 En cours | 1/11 | ✅ US-056, ⬜ US-039, US-050 à US-055, US-057 à US-059 |
 | **K — Extensions post-v1** | ⬜ Non démarrée | 0/9 | ⬜ US-060 à US-068 |
 
-**Total : 38 / 68 US**
+**Total : 39 / 68 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -56,7 +56,7 @@
 | US-053 | Constructeurs additionnels : `std::array`, `std::span`, générateur | P1 | ⬜ À faire |
 | US-054 | `matrix::rows()` / `cols()` + `matmul` vecteur 1D | P1 | ⬜ À faire |
 | US-055 | `CHANGELOG.md` versionné | P1 | ⬜ À faire |
-| US-056 | Messages d'exception détaillés dans `at()` | P1 | ⬜ À faire |
+| US-056 | Messages d'exception détaillés dans `at()` | P1 | ✅ Done |
 | US-057 | Centraliser `NOLINTNEXTLINE` dans `matrix.hpp` | P1 | ⬜ À faire |
 | US-058 | Optimiser `matrix(matrix_view<strided>)` | P1 | ⬜ À faire |
 | US-059 | `operator-()` `constexpr` + hash combine 64-bit | P1 | ⬜ À faire |

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -21,6 +21,7 @@
 #include <numeric>
 #include <ostream>
 #include <stdexcept>
+#include <string>
 #include <tuple>
 #include <type_traits>
 // Clang < 17 cannot compile libstdc++-14's <format> due to unicode.h
@@ -1106,16 +1107,31 @@ public:
      * @param coordinates Coordinates of the element to return
      *
      * If @a coordinates is not within the range of the container, an exception
-     * of type
-     * @c std::out_of_range is thrown.
+     * of type @c std::out_of_range is thrown with a message of the form:
+     * @code
+     * "matrix::at: coordinate <c> is out of bounds for dimension <i> (size=<s>)"
+     * @endcode
+     * where @c c is the offending coordinate value, @c i is the dimension index,
+     * and @c s is the size of that dimension.
+     *
+     * @throws std::out_of_range if any coordinate is negative or exceeds the
+     * dimension size
      */
     template <class... Coords>
         requires integral_coordinates<Coords...>
     [[nodiscard]] const T& at(Coords... coordinates) const {
-        const bool any_of_coords_is_negative = ((coordinates < 0) || ...);
-        const bool any_of_coords_is_out_of_bound = ((coordinates >= Dimensions) || ...);
-        if (any_of_coords_is_negative || any_of_coords_is_out_of_bound) {
-            throw std::out_of_range{"matrix::at"};
+        const std::array<std::ptrdiff_t, sizeof...(Coords)> coords_arr = {
+            static_cast<std::ptrdiff_t>(coordinates)...};
+        for (std::size_t i = 0; i < sizeof...(Coords); ++i) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+            if (coords_arr[i] < 0 || static_cast<std::size_t>(coords_arr[i]) >= dimensions[i]) {
+                throw std::out_of_range(
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                    "matrix::at: coordinate " + std::to_string(coords_arr[i]) +
+                    " is out of bounds for dimension " + std::to_string(i) +
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                    " (size=" + std::to_string(dimensions[i]) + ")");
+            }
         }
         return (*this)(coordinates...);
     }
@@ -1125,16 +1141,31 @@ public:
      * @param coordinates Coordinates of the element to return
      *
      * If @a coordinates is not within the range of the container, an exception
-     * of type
-     * @c std::out_of_range is thrown.
+     * of type @c std::out_of_range is thrown with a message of the form:
+     * @code
+     * "matrix::at: coordinate <c> is out of bounds for dimension <i> (size=<s>)"
+     * @endcode
+     * where @c c is the offending coordinate value, @c i is the dimension index,
+     * and @c s is the size of that dimension.
+     *
+     * @throws std::out_of_range if any coordinate is negative or exceeds the
+     * dimension size
      */
     template <class... Coords>
         requires integral_coordinates<Coords...>
     T& at(Coords... coordinates) {
-        const bool any_of_coords_is_negative = ((coordinates < 0) || ...);
-        const bool any_of_coords_is_out_of_bound = ((coordinates >= Dimensions) || ...);
-        if (any_of_coords_is_negative || any_of_coords_is_out_of_bound) {
-            throw std::out_of_range{"matrix::at"};
+        const std::array<std::ptrdiff_t, sizeof...(Coords)> coords_arr = {
+            static_cast<std::ptrdiff_t>(coordinates)...};
+        for (std::size_t i = 0; i < sizeof...(Coords); ++i) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+            if (coords_arr[i] < 0 || static_cast<std::size_t>(coords_arr[i]) >= dimensions[i]) {
+                throw std::out_of_range(
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                    "matrix::at: coordinate " + std::to_string(coords_arr[i]) +
+                    " is out of bounds for dimension " + std::to_string(i) +
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                    " (size=" + std::to_string(dimensions[i]) + ")");
+            }
         }
         return (*this)(coordinates...);
     }

--- a/src/include/matrix_view.hpp
+++ b/src/include/matrix_view.hpp
@@ -17,6 +17,7 @@
 #include <array>
 #include <iterator>
 #include <stdexcept>
+#include <string>
 
 #include <matrix_detail.hpp>
 
@@ -424,7 +425,11 @@ public:
      * @tparam Coords Integral coordinate types
      * @param coords  Coordinates of the element
      * @return Const reference to the element
-     * @throws std::out_of_range if any coordinate is negative or out of bounds
+     * @throws std::out_of_range if any coordinate is negative or out of bounds, with a message
+     *         of the form:
+     *         @code
+     *         "matrix_view::at: coordinate <c> is out of bounds for dimension <i> (size=<s>)"
+     *         @endcode
      *
      * @code
      * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
@@ -437,10 +442,18 @@ public:
     template <class... Coords>
         requires integral_coordinates<Coords...>
     [[nodiscard]] const T& at(Coords... coords) const {
-        const bool any_of_coords_is_negative = ((coords < 0) || ...);
-        const bool any_of_coords_is_out_of_bound = ((coords >= Dimensions) || ...);
-        if (any_of_coords_is_negative || any_of_coords_is_out_of_bound) {
-            throw std::out_of_range{"matrix_view::at"};
+        const std::array<std::ptrdiff_t, sizeof...(Coords)> coords_arr = {
+            static_cast<std::ptrdiff_t>(coords)...};
+        for (std::size_t i = 0; i < sizeof...(Coords); ++i) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+            if (coords_arr[i] < 0 || static_cast<std::size_t>(coords_arr[i]) >= dimensions[i]) {
+                throw std::out_of_range(
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                    "matrix_view::at: coordinate " + std::to_string(coords_arr[i]) +
+                    " is out of bounds for dimension " + std::to_string(i) +
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                    " (size=" + std::to_string(dimensions[i]) + ")");
+            }
         }
         return (*this)(coords...);
     }
@@ -451,7 +464,11 @@ public:
      * @tparam Coords Integral coordinate types
      * @param coords  Coordinates of the element
      * @return Mutable reference to the element
-     * @throws std::out_of_range if any coordinate is negative or out of bounds
+     * @throws std::out_of_range if any coordinate is negative or out of bounds, with a message
+     *         of the form:
+     *         @code
+     *         "matrix_view::at: coordinate <c> is out of bounds for dimension <i> (size=<s>)"
+     *         @endcode
      *
      * @code
      * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
@@ -465,10 +482,18 @@ public:
     template <class... Coords>
         requires integral_coordinates<Coords...>
     T& at(Coords... coords) {
-        const bool any_of_coords_is_negative = ((coords < 0) || ...);
-        const bool any_of_coords_is_out_of_bound = ((coords >= Dimensions) || ...);
-        if (any_of_coords_is_negative || any_of_coords_is_out_of_bound) {
-            throw std::out_of_range{"matrix_view::at"};
+        const std::array<std::ptrdiff_t, sizeof...(Coords)> coords_arr = {
+            static_cast<std::ptrdiff_t>(coords)...};
+        for (std::size_t i = 0; i < sizeof...(Coords); ++i) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+            if (coords_arr[i] < 0 || static_cast<std::size_t>(coords_arr[i]) >= dimensions[i]) {
+                throw std::out_of_range(
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                    "matrix_view::at: coordinate " + std::to_string(coords_arr[i]) +
+                    " is out of bounds for dimension " + std::to_string(i) +
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                    " (size=" + std::to_string(dimensions[i]) + ")");
+            }
         }
         return (*this)(coords...);
     }
@@ -689,7 +714,11 @@ public:
      * @tparam Coords Integral coordinate types
      * @param coords  Coordinates of the element
      * @return Const reference to the element
-     * @throws std::out_of_range if any coordinate is negative or out of bounds
+     * @throws std::out_of_range if any coordinate is negative or out of bounds, with a message
+     *         of the form:
+     *         @code
+     *         "matrix_view::at: coordinate <c> is out of bounds for dimension <i> (size=<s>)"
+     *         @endcode
      *
      * @code
      * ysc::matrix<int, 3, 4> m{};
@@ -702,11 +731,18 @@ public:
     template <class... Coords>
         requires integral_coordinates<Coords...> && (sizeof...(Coords) == sizeof...(Dimensions))
     [[nodiscard]] const T& at(Coords... coords) const {
-        const bool any_of_coords_is_negative = ((coords < 0) || ...);
-        const bool any_of_coords_is_out_of_bound =
-            ((static_cast<std::size_t>(coords) >= Dimensions) || ...);
-        if (any_of_coords_is_negative || any_of_coords_is_out_of_bound) {
-            throw std::out_of_range{"matrix_view::at"};
+        const std::array<std::ptrdiff_t, sizeof...(Coords)> coords_arr = {
+            static_cast<std::ptrdiff_t>(coords)...};
+        for (std::size_t i = 0; i < sizeof...(Coords); ++i) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+            if (coords_arr[i] < 0 || static_cast<std::size_t>(coords_arr[i]) >= dimensions[i]) {
+                throw std::out_of_range(
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                    "matrix_view::at: coordinate " + std::to_string(coords_arr[i]) +
+                    " is out of bounds for dimension " + std::to_string(i) +
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                    " (size=" + std::to_string(dimensions[i]) + ")");
+            }
         }
         return (*this)(coords...);
     }
@@ -717,7 +753,11 @@ public:
      * @tparam Coords Integral coordinate types
      * @param coords  Coordinates of the element
      * @return Mutable reference to the element
-     * @throws std::out_of_range if any coordinate is negative or out of bounds
+     * @throws std::out_of_range if any coordinate is negative or out of bounds, with a message
+     *         of the form:
+     *         @code
+     *         "matrix_view::at: coordinate <c> is out of bounds for dimension <i> (size=<s>)"
+     *         @endcode
      *
      * @code
      * ysc::matrix<int, 3, 4> m{};
@@ -731,11 +771,18 @@ public:
     template <class... Coords>
         requires integral_coordinates<Coords...> && (sizeof...(Coords) == sizeof...(Dimensions))
     [[nodiscard]] T& at(Coords... coords) {
-        const bool any_of_coords_is_negative = ((coords < 0) || ...);
-        const bool any_of_coords_is_out_of_bound =
-            ((static_cast<std::size_t>(coords) >= Dimensions) || ...);
-        if (any_of_coords_is_negative || any_of_coords_is_out_of_bound) {
-            throw std::out_of_range{"matrix_view::at"};
+        const std::array<std::ptrdiff_t, sizeof...(Coords)> coords_arr = {
+            static_cast<std::ptrdiff_t>(coords)...};
+        for (std::size_t i = 0; i < sizeof...(Coords); ++i) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+            if (coords_arr[i] < 0 || static_cast<std::size_t>(coords_arr[i]) >= dimensions[i]) {
+                throw std::out_of_range(
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                    "matrix_view::at: coordinate " + std::to_string(coords_arr[i]) +
+                    " is out of bounds for dimension " + std::to_string(i) +
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                    " (size=" + std::to_string(dimensions[i]) + ")");
+            }
         }
         return (*this)(coords...);
     }

--- a/test/src/access.cpp
+++ b/test/src/access.cpp
@@ -2,6 +2,7 @@
 #include <matrix.hpp>
 
 #include <gtest/gtest.h>
+#include <string>
 
 //
 // --- ELEMENT ACCESS ---
@@ -134,5 +135,79 @@ TEST(access, mutable_with_check_outofbound) {
             out_of_range_exception_catch = true;
         }
         ASSERT_TRUE(out_of_range_exception_catch);
+    }
+}
+
+// at() exception message contains the offending coordinate value
+TEST(access, at_message_contains_coordinate) {
+    ysc::matrix<int, 3, 4> m{ysc::zero};
+    try {
+        (void)m.at(0, 7);
+        FAIL() << "Expected std::out_of_range";
+    } catch (const std::out_of_range& e) {
+        const std::string what{e.what()};
+        ASSERT_NE(what.find('7'), std::string::npos) << "message: " << what;
+    }
+}
+
+// at() exception message contains the dimension size
+TEST(access, at_message_contains_dimension_size) {
+    ysc::matrix<int, 3, 4> m{ysc::zero};
+    try {
+        (void)m.at(0, 7);
+        FAIL() << "Expected std::out_of_range";
+    } catch (const std::out_of_range& e) {
+        const std::string what{e.what()};
+        ASSERT_NE(what.find('4'), std::string::npos) << "message: " << what;
+    }
+}
+
+// at() const exception message contains the offending coordinate value
+TEST(access, at_const_message_contains_coordinate) {
+    const ysc::matrix<int, 2, 5> m{ysc::zero};
+    try {
+        (void)m.at(9, 0);
+        FAIL() << "Expected std::out_of_range";
+    } catch (const std::out_of_range& e) {
+        const std::string what{e.what()};
+        ASSERT_NE(what.find('9'), std::string::npos) << "message: " << what;
+    }
+}
+
+// at() const exception message contains the dimension size
+TEST(access, at_const_message_contains_dimension_size) {
+    const ysc::matrix<int, 2, 5> m{ysc::zero};
+    try {
+        (void)m.at(9, 0);
+        FAIL() << "Expected std::out_of_range";
+    } catch (const std::out_of_range& e) {
+        const std::string what{e.what()};
+        ASSERT_NE(what.find('2'), std::string::npos) << "message: " << what;
+    }
+}
+
+// matrix_view::at() exception message contains the offending coordinate value
+TEST(access, view_at_message_contains_coordinate) {
+    ysc::matrix<int, 3, 4> m{ysc::zero};
+    ysc::matrix_view<int, ysc::contiguous, 3, 4> v = m;
+    try {
+        (void)v.at(0, 10);
+        FAIL() << "Expected std::out_of_range";
+    } catch (const std::out_of_range& e) {
+        const std::string what{e.what()};
+        ASSERT_NE(what.find("10"), std::string::npos) << "message: " << what;
+    }
+}
+
+// matrix_view::at() exception message contains the dimension size
+TEST(access, view_at_message_contains_dimension_size) {
+    ysc::matrix<int, 3, 4> m{ysc::zero};
+    ysc::matrix_view<int, ysc::contiguous, 3, 4> v = m;
+    try {
+        (void)v.at(0, 10);
+        FAIL() << "Expected std::out_of_range";
+    } catch (const std::out_of_range& e) {
+        const std::string what{e.what()};
+        ASSERT_NE(what.find('4'), std::string::npos) << "message: " << what;
     }
 }


### PR DESCRIPTION
## Résumé

Les méthodes `at()` de `matrix` et `matrix_view` (contiguous et strided) lèvent désormais des exceptions `std::out_of_range` avec un message détaillé indiquant la coordonnée fautive, l'index de dimension et la taille de cette dimension. Le format du message est :

```
matrix::at: coordinate <c> is out of bounds for dimension <i> (size=<s>)
matrix_view::at: coordinate <c> is out of bounds for dimension <i> (size=<s>)
```

## Critères d'acceptation

- [x] `e.what()` contient la coordonnée fautive et la taille de la dimension
- [x] Format du message documenté dans `@throws` Doxygen sur toutes les surcharges de `at()`
- [x] Tests dans `test/src/access.cpp` vérifiant le contenu du message pour `matrix` (const et mutable) et `matrix_view` (contiguous)