### PR TITLE
US-039 — Suite de benchmarks Google Benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,25 @@
+name: Benchmark
+
+on:
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure
+        run: cmake -S . -B build -DBUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build --target matrix-bench
+
+      - name: Run
+        run: ./build/bench/matrix-bench --benchmark_format=json | tee benchmark_results.json
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: benchmark_results.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,15 @@ endif()
 
 
 ##
+# benchmark configuration
+#
+option(BUILD_BENCHMARKS "Build benchmarks" OFF)
+if(BUILD_BENCHMARKS)
+    add_subdirectory(bench)
+endif()
+
+
+##
 # doc generation
 #
 find_package(Doxygen)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.20)
+
+include(FetchContent)
+FetchContent_Declare(
+    googlebenchmark
+    GIT_REPOSITORY https://github.com/google/benchmark.git
+    GIT_TAG        v1.8.3
+    GIT_SHALLOW    TRUE
+)
+set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googlebenchmark)
+
+add_executable(matrix-bench
+    src/main.cpp
+    src/bench_construct.cpp
+    src/bench_access.cpp
+    src/bench_arithmetic.cpp
+    src/bench_linalg.cpp
+)
+target_include_directories(matrix-bench PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/include
+)
+target_link_libraries(matrix-bench PRIVATE benchmark::benchmark)
+target_compile_features(matrix-bench PRIVATE cxx_std_20)

--- a/bench/src/bench_access.cpp
+++ b/bench/src/bench_access.cpp
@@ -1,0 +1,55 @@
+#include <array>
+#include <cstddef>
+
+#include <benchmark/benchmark.h>
+
+#include "matrix.hpp"
+
+static void BM_AccessOperator(benchmark::State& state)
+{
+    ysc::matrix<double, 64, 64> m{};
+    for (auto _ : state)
+        benchmark::DoNotOptimize(m(32, 32));
+}
+BENCHMARK(BM_AccessOperator);
+
+static void BM_AccessAt(benchmark::State& state)
+{
+    ysc::matrix<double, 64, 64> m{};
+    for (auto _ : state)
+        benchmark::DoNotOptimize(m.at(32, 32));
+}
+BENCHMARK(BM_AccessAt);
+
+static void BM_AccessOperator_StdArray(benchmark::State& state)
+{
+    std::array<double, 64 * 64> a{};
+    for (auto _ : state)
+        benchmark::DoNotOptimize(a[32 * 64 + 32]); // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+}
+BENCHMARK(BM_AccessOperator_StdArray);
+
+static void BM_IterateRangeFor(benchmark::State& state)
+{
+    ysc::matrix<double, 64, 64> m{};
+    for (auto _ : state) {
+        double sum = 0.0;
+        for (const auto& v : m)
+            sum += v;
+        benchmark::DoNotOptimize(sum);
+    }
+}
+BENCHMARK(BM_IterateRangeFor);
+
+static void BM_IterateIndex(benchmark::State& state)
+{
+    ysc::matrix<double, 64, 64> m{};
+    for (auto _ : state) {
+        double sum = 0.0;
+        for (std::size_t i = 0; i < 64; ++i)
+            for (std::size_t j = 0; j < 64; ++j)
+                sum += m(i, j);
+        benchmark::DoNotOptimize(sum);
+    }
+}
+BENCHMARK(BM_IterateIndex);

--- a/bench/src/bench_arithmetic.cpp
+++ b/bench/src/bench_arithmetic.cpp
@@ -1,0 +1,29 @@
+#include <benchmark/benchmark.h>
+
+#include "matrix.hpp"
+
+static void BM_AddMatrices(benchmark::State& state)
+{
+    ysc::matrix<double, 64, 64> a{}, b{};
+    for (auto _ : state)
+        benchmark::DoNotOptimize(a + b);
+}
+BENCHMARK(BM_AddMatrices);
+
+static void BM_MulHadamard(benchmark::State& state)
+{
+    ysc::matrix<double, 64, 64> a{}, b{};
+    for (auto _ : state)
+        benchmark::DoNotOptimize(a * b);
+}
+BENCHMARK(BM_MulHadamard);
+
+static void BM_AddAssignMatrices(benchmark::State& state)
+{
+    ysc::matrix<double, 64, 64> a{}, b{};
+    for (auto _ : state) {
+        a += b;
+        benchmark::DoNotOptimize(a);
+    }
+}
+BENCHMARK(BM_AddAssignMatrices);

--- a/bench/src/bench_construct.cpp
+++ b/bench/src/bench_construct.cpp
@@ -1,0 +1,26 @@
+#include <array>
+
+#include <benchmark/benchmark.h>
+
+#include "matrix.hpp"
+
+static void BM_ConstructDefault(benchmark::State& state)
+{
+    for (auto _ : state)
+        benchmark::DoNotOptimize(ysc::matrix<double, 4, 4>{});
+}
+BENCHMARK(BM_ConstructDefault);
+
+static void BM_ConstructZeros(benchmark::State& state)
+{
+    for (auto _ : state)
+        benchmark::DoNotOptimize(ysc::matrix<double, 4, 4>(ysc::zero));
+}
+BENCHMARK(BM_ConstructZeros);
+
+static void BM_ConstructDefault_StdArray(benchmark::State& state)
+{
+    for (auto _ : state)
+        benchmark::DoNotOptimize(std::array<double, 16>{});
+}
+BENCHMARK(BM_ConstructDefault_StdArray);

--- a/bench/src/bench_linalg.cpp
+++ b/bench/src/bench_linalg.cpp
@@ -1,0 +1,35 @@
+#include <benchmark/benchmark.h>
+
+#include "matrix.hpp"
+
+static void BM_Matmul4x4(benchmark::State& state)
+{
+    ysc::matrix<double, 4, 4> a{}, b{};
+    for (auto _ : state)
+        benchmark::DoNotOptimize(ysc::matmul(a, b));
+}
+BENCHMARK(BM_Matmul4x4);
+
+static void BM_Matmul16x16(benchmark::State& state)
+{
+    ysc::matrix<double, 16, 16> a{}, b{};
+    for (auto _ : state)
+        benchmark::DoNotOptimize(ysc::matmul(a, b));
+}
+BENCHMARK(BM_Matmul16x16);
+
+static void BM_Transpose4x4(benchmark::State& state)
+{
+    ysc::matrix<double, 4, 4> m{};
+    for (auto _ : state)
+        benchmark::DoNotOptimize(ysc::transpose(m));
+}
+BENCHMARK(BM_Transpose4x4);
+
+static void BM_DotProduct(benchmark::State& state)
+{
+    ysc::matrix<double, 256> a{}, b{};
+    for (auto _ : state)
+        benchmark::DoNotOptimize(ysc::dot(a, b));
+}
+BENCHMARK(BM_DotProduct);

--- a/bench/src/main.cpp
+++ b/bench/src/main.cpp
@@ -1,0 +1,3 @@
+#include <benchmark/benchmark.h>
+
+BENCHMARK_MAIN(); // NOLINT(misc-definitions-in-headers)

--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -13,10 +13,10 @@
 | **G — Algorithmes** | ✅ Terminée | 5/5 | ✅ US-030, ✅ US-031, ✅ US-032, ✅ US-033, ✅ US-034 |
 | **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
 | **I — Packaging & préparation v1.0.0** | ⬜ Non démarrée | 0/10 | ⬜ US-038, US-040 à US-043, US-045 à US-049 |
-| **J — Ergonomie & finition** | ⬜ Non démarrée | 0/11 | ⬜ US-039, US-050 à US-059 |
+| **J — Ergonomie & finition** | 🚧 En cours | 1/11 | ✅ US-039, ⬜ US-050 à US-059 |
 | **K — Extensions post-v1** | ⬜ Non démarrée | 0/9 | ⬜ US-060 à US-068 |
 
-**Total : 38 / 68 US**
+**Total : 39 / 68 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -49,7 +49,7 @@
 
 | US | Titre | Priorité | Statut |
 |----|-------|----------|--------|
-| US-039 | Suite de benchmarks (Google Benchmark) | P1 | ⬜ À faire |
+| US-039 | Suite de benchmarks (Google Benchmark) | P1 | ✅ Done |
 | US-050 | Cookbook Doxygen | P1 | ⬜ À faire |
 | US-051 | `matrix_view` : itérateurs strided + `front`/`back`/`fill` | P1 | ⬜ À faire |
 | US-052 | `matrix_view` : I/O, ctor const, vues composables | P1 | ⬜ À faire |


### PR DESCRIPTION
## Résumé

Ajout d'une suite de benchmarks Google Benchmark dans `bench/`, couvrant la construction, l'accès aux éléments, l'itération, l'arithmétique et les opérations linéaires (matmul, transpose, dot). L'option CMake `BUILD_BENCHMARKS=ON` active la compilation (désactivée par défaut). Un job CI `benchmark` déclenché manuellement via `workflow_dispatch` compile le binaire en Release et archive les résultats au format JSON en artefact.

## Critères d'acceptation

- [x] `cmake -DBUILD_BENCHMARKS=ON && cmake --build build --target matrix-bench` fonctionne
- [x] Job CI benchmark déclenché manuellement via `workflow_dispatch`
- [x] Résultats archivés en artefact JSON

## Détails d'implémentation

- `bench/CMakeLists.txt` : FetchContent pour `google/benchmark` v1.8.3 ; target `matrix-bench`
- `bench/src/bench_construct.cpp` : défaut vs zeros vs `std::array` brut
- `bench/src/bench_access.cpp` : `operator()` vs `at()` vs `std::array`, itération range-for vs index
- `bench/src/bench_arithmetic.cpp` : addition et multiplication hadamard 64×64
- `bench/src/bench_linalg.cpp` : matmul 4×4 et 16×16, transpose, dot
- `BUILD_BENCHMARKS` est `OFF` par défaut : aucun impact sur le build/test habituels