### PR TITLE
US-053 — Constructeurs std::array, std::span et generate()

### DIFF
--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -13,10 +13,10 @@
 | **G — Algorithmes** | ✅ Terminée | 5/5 | ✅ US-030, ✅ US-031, ✅ US-032, ✅ US-033, ✅ US-034 |
 | **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
 | **I — Packaging & préparation v1.0.0** | ⬜ Non démarrée | 0/10 | ⬜ US-038, US-040 à US-043, US-045 à US-049 |
-| **J — Ergonomie & finition** | ⬜ Non démarrée | 0/11 | ⬜ US-039, US-050 à US-059 |
+| **J — Ergonomie & finition** | 🔄 En cours | 1/11 | ✅ US-053, ⬜ US-039, US-050 à US-052, US-054 à US-059 |
 | **K — Extensions post-v1** | ⬜ Non démarrée | 0/9 | ⬜ US-060 à US-068 |
 
-**Total : 38 / 68 US**
+**Total : 39 / 68 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -53,7 +53,7 @@
 | US-050 | Cookbook Doxygen | P1 | ⬜ À faire |
 | US-051 | `matrix_view` : itérateurs strided + `front`/`back`/`fill` | P1 | ⬜ À faire |
 | US-052 | `matrix_view` : I/O, ctor const, vues composables | P1 | ⬜ À faire |
-| US-053 | Constructeurs additionnels : `std::array`, `std::span`, générateur | P1 | ⬜ À faire |
+| US-053 | Constructeurs additionnels : `std::array`, `std::span`, générateur | P1 | ✅ Done |
 | US-054 | `matrix::rows()` / `cols()` + `matmul` vecteur 1D | P1 | ⬜ À faire |
 | US-055 | `CHANGELOG.md` versionné | P1 | ⬜ À faire |
 | US-056 | Messages d'exception détaillés dans `at()` | P1 | ⬜ À faire |

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -947,8 +947,8 @@ public:
      */
     template <class F>
         requires std::invocable<F, const T&>
-    [[nodiscard]] constexpr auto map(F f) const
-        -> matrix<std::invoke_result_t<F, const T&>, Dimensions...> {
+    [[nodiscard]] constexpr auto
+    map(F f) const -> matrix<std::invoke_result_t<F, const T&>, Dimensions...> {
         matrix<std::invoke_result_t<F, const T&>, Dimensions...> result(zero);
         std::transform(_data.cbegin(), _data.cend(), result.begin(),
                        [&f](const T& v) { return std::invoke(f, v); });
@@ -1608,8 +1608,8 @@ template <class T, std::size_t R, std::size_t C>
  */
 template <class Ta, class Tb, std::size_t M, std::size_t N, std::size_t P>
     requires std::invocable<std::multiplies<>, const Ta&, const Tb&> &&
-             requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc, const Ta& a,
-                      const Tb& b) { tc += a * b; }
+                 requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc,
+                          const Ta& a, const Tb& b) { tc += a * b; }
 [[nodiscard]] constexpr auto matmul(const matrix<Ta, M, N>& a, const matrix<Tb, N, P>& b)
     -> matrix<std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>, M, P> {
     using Tc = std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>;
@@ -1645,8 +1645,8 @@ template <class Ta, class Tb, std::size_t M, std::size_t N, std::size_t P>
  */
 template <class Ta, class Tb, std::size_t N>
     requires std::invocable<std::multiplies<>, const Ta&, const Tb&> &&
-             requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc, const Ta& a,
-                      const Tb& b) { tc += a * b; }
+                 requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc,
+                          const Ta& a, const Tb& b) { tc += a * b; }
 [[nodiscard]] constexpr auto dot(const matrix<Ta, N>& a, const matrix<Tb, N>& b)
     -> std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> {
     using Tc = std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>;

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -20,6 +20,7 @@
 #include <iterator>
 #include <numeric>
 #include <ostream>
+#include <span>
 #include <stdexcept>
 #include <tuple>
 #include <type_traits>
@@ -394,6 +395,38 @@ public:
             const auto coords = detail::index_to_coordinates(dimensions, k++);
             elem = std::apply([&v](auto... cs) -> T { return v(cs...); }, coords);
         }
+    }
+
+    // constructors from std::array and std::span
+    /**
+     * @brief Constructs from a @c std::array.
+     * @param data Array of exactly @c linear_size elements to move into the matrix.
+     *
+     * @code
+     * ysc::matrix<int, 3> m(std::array<int, 3>{1, 2, 3});
+     * assert(m(0) == 1);
+     * @endcode
+     *
+     * @ingroup ysc_matrix
+     */
+    explicit matrix(std::array<T, linear_size> data) noexcept(
+        std::is_nothrow_move_constructible_v<T>)
+        : _data(std::move(data)) {}
+
+    /**
+     * @brief Constructs from a @c std::span.
+     * @param data Span of exactly @c linear_size elements; copied into the matrix.
+     *
+     * @code
+     * int buf[3] = {4, 5, 6};
+     * ysc::matrix<int, 3> m(std::span<const int, 3>{buf, 3});
+     * assert(m(0) == 4);
+     * @endcode
+     *
+     * @ingroup ysc_matrix
+     */
+    explicit matrix(std::span<const T, linear_size> data) {
+        std::copy(data.begin(), data.end(), _data.begin());
     }
 
     // assignment operators (copy)
@@ -914,8 +947,8 @@ public:
      */
     template <class F>
         requires std::invocable<F, const T&>
-    [[nodiscard]] constexpr auto
-    map(F f) const -> matrix<std::invoke_result_t<F, const T&>, Dimensions...> {
+    [[nodiscard]] constexpr auto map(F f) const
+        -> matrix<std::invoke_result_t<F, const T&>, Dimensions...> {
         matrix<std::invoke_result_t<F, const T&>, Dimensions...> result(zero);
         std::transform(_data.cbegin(), _data.cend(), result.begin(),
                        [&f](const T& v) { return std::invoke(f, v); });
@@ -1496,6 +1529,31 @@ constexpr matrix<T, N, N> identity() {
 }
 
 /**
+ * @brief Returns a matrix filled by calling @a f(i) for each linear index @a i.
+ * @tparam T    Element type
+ * @tparam Dims Dimensions of the result matrix
+ * @tparam F    Callable type — must satisfy @c std::invocable<F, std::size_t>
+ * @param  f    Generator callable: @c f(i) must be convertible to @c T
+ * @return New @c matrix<T, Dims...> where element at linear index @a i equals @c f(i)
+ *
+ * @code
+ * auto m = ysc::generate<int, 3>([](std::size_t i) { return static_cast<int>(i * 2); });
+ * // m == ysc::matrix<int, 3>{0, 2, 4}
+ * @endcode
+ *
+ * @ingroup ysc_matrix
+ */
+template <class T, std::size_t... Dims, std::invocable<std::size_t> F>
+[[nodiscard]] constexpr matrix<T, Dims...> generate(F f) {
+    matrix<T, Dims...> result;
+    for (std::size_t i = 0; i < matrix<T, Dims...>::size(); ++i) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        result.begin()[i] = f(i);
+    }
+    return result;
+}
+
+/**
  * @defgroup ysc_linalg Linear algebra
  * @brief Linear algebra operations on @c ysc::matrix.
  */
@@ -1550,8 +1608,8 @@ template <class T, std::size_t R, std::size_t C>
  */
 template <class Ta, class Tb, std::size_t M, std::size_t N, std::size_t P>
     requires std::invocable<std::multiplies<>, const Ta&, const Tb&> &&
-                 requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc,
-                          const Ta& a, const Tb& b) { tc += a * b; }
+             requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc, const Ta& a,
+                      const Tb& b) { tc += a * b; }
 [[nodiscard]] constexpr auto matmul(const matrix<Ta, M, N>& a, const matrix<Tb, N, P>& b)
     -> matrix<std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>, M, P> {
     using Tc = std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>;
@@ -1587,8 +1645,8 @@ template <class Ta, class Tb, std::size_t M, std::size_t N, std::size_t P>
  */
 template <class Ta, class Tb, std::size_t N>
     requires std::invocable<std::multiplies<>, const Ta&, const Tb&> &&
-                 requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc,
-                          const Ta& a, const Tb& b) { tc += a * b; }
+             requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc, const Ta& a,
+                      const Tb& b) { tc += a * b; }
 [[nodiscard]] constexpr auto dot(const matrix<Ta, N>& a, const matrix<Tb, N>& b)
     -> std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> {
     using Tc = std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(${TARGET_NAME}
     src/comparison.cpp
     src/concepts.cpp
     src/construct.cpp
+    src/construct_from_buffer.cpp
     src/factories.cpp
     src/fill.cpp
     src/formatter.cpp

--- a/test/src/construct_from_buffer.cpp
+++ b/test/src/construct_from_buffer.cpp
@@ -13,6 +13,7 @@ TEST(construct_from_array, basic) {
 
 TEST(construct_from_array, values_are_moved) {
     std::array<int, 3> arr{10, 20, 30};
+    // NOLINTNEXTLINE(performance-move-const-arg) -- demonstrates move ctor; trivial copy is fine
     ysc::matrix<int, 3> m(std::move(arr));
     EXPECT_EQ(m(0), 10);
     EXPECT_EQ(m(1), 20);
@@ -26,21 +27,21 @@ TEST(construct_from_array, 2d) {
 }
 
 TEST(construct_from_span, basic) {
-    int buf[3] = {4, 5, 6};
-    ysc::matrix<int, 3> m(std::span<const int, 3>{buf, 3});
+    std::array<int, 3> buf{4, 5, 6};
+    ysc::matrix<int, 3> m(std::span<const int, 3>{buf.data(), 3});
     EXPECT_EQ(m(0), 4);
 }
 
 TEST(construct_from_span, copies_not_aliases) {
-    int buf[3] = {7, 8, 9};
-    ysc::matrix<int, 3> m(std::span<const int, 3>{buf, 3});
+    std::array<int, 3> buf{7, 8, 9};
+    ysc::matrix<int, 3> m(std::span<const int, 3>{buf.data(), 3});
     buf[0] = 99;
     EXPECT_EQ(m(0), 7); // m is independent of buf
 }
 
 TEST(construct_from_span, 2d) {
-    int buf[6] = {1, 2, 3, 4, 5, 6};
-    ysc::matrix<int, 2, 3> m(std::span<const int, 6>{buf, 6});
+    std::array<int, 6> buf{1, 2, 3, 4, 5, 6};
+    ysc::matrix<int, 2, 3> m(std::span<const int, 6>{buf.data(), 6});
     EXPECT_EQ(m(0, 0), 1);
     EXPECT_EQ(m(1, 2), 6);
 }

--- a/test/src/construct_from_buffer.cpp
+++ b/test/src/construct_from_buffer.cpp
@@ -1,0 +1,69 @@
+#include <array>
+#include <span>
+
+#include <gtest/gtest.h>
+
+#include "matrix.hpp"
+
+TEST(construct_from_array, basic) {
+    ysc::matrix<int, 3> m(std::array<int, 3>{1, 2, 3});
+    EXPECT_EQ(m(0), 1);
+    EXPECT_EQ(m(2), 3);
+}
+
+TEST(construct_from_array, values_are_moved) {
+    std::array<int, 3> arr{10, 20, 30};
+    ysc::matrix<int, 3> m(std::move(arr));
+    EXPECT_EQ(m(0), 10);
+    EXPECT_EQ(m(1), 20);
+    EXPECT_EQ(m(2), 30);
+}
+
+TEST(construct_from_array, 2d) {
+    ysc::matrix<int, 2, 3> m(std::array<int, 6>{1, 2, 3, 4, 5, 6});
+    EXPECT_EQ(m(0, 0), 1);
+    EXPECT_EQ(m(1, 2), 6);
+}
+
+TEST(construct_from_span, basic) {
+    int buf[3] = {4, 5, 6};
+    ysc::matrix<int, 3> m(std::span<const int, 3>{buf, 3});
+    EXPECT_EQ(m(0), 4);
+}
+
+TEST(construct_from_span, copies_not_aliases) {
+    int buf[3] = {7, 8, 9};
+    ysc::matrix<int, 3> m(std::span<const int, 3>{buf, 3});
+    buf[0] = 99;
+    EXPECT_EQ(m(0), 7); // m is independent of buf
+}
+
+TEST(construct_from_span, 2d) {
+    int buf[6] = {1, 2, 3, 4, 5, 6};
+    ysc::matrix<int, 2, 3> m(std::span<const int, 6>{buf, 6});
+    EXPECT_EQ(m(0, 0), 1);
+    EXPECT_EQ(m(1, 2), 6);
+}
+
+TEST(generate_linear, basic) {
+    auto m = ysc::generate<int, 3>([](std::size_t i) { return static_cast<int>(i * 2); });
+    EXPECT_EQ(m(0), 0);
+    EXPECT_EQ(m(1), 2);
+    EXPECT_EQ(m(2), 4);
+}
+
+TEST(generate_linear, identity_function) {
+    auto m = ysc::generate<int, 5>([](std::size_t i) { return static_cast<int>(i); });
+    for (std::size_t i = 0; i < 5; ++i) {
+        EXPECT_EQ(m(static_cast<int>(i)), static_cast<int>(i));
+    }
+}
+
+TEST(generate_linear, 2d) {
+    auto m = ysc::generate<int, 2, 3>([](std::size_t i) { return static_cast<int>(i); });
+    // linear indices: (0,0)=0, (0,1)=1, (0,2)=2, (1,0)=3, (1,1)=4, (1,2)=5
+    EXPECT_EQ(m(0, 0), 0);
+    EXPECT_EQ(m(0, 2), 2);
+    EXPECT_EQ(m(1, 0), 3);
+    EXPECT_EQ(m(1, 2), 5);
+}


### PR DESCRIPTION
## Résumé

Ajout de deux constructeurs explicites (`std::array<T, N>` et `std::span<const T, N>`) dans `ysc::matrix`, ainsi que la factory libre `ysc::generate<T, Dims...>(f)` qui construit une matrice en appelant `f(i)` pour chaque indice linéaire `i`.

## Critères d'acceptation

- [x] `matrix<int,3>(std::array<int,3>{1,2,3})` compile et produit la valeur attendue
- [x] `matrix<int,3>(std::span<const int,3>{buf,3})` compile et copie les données indépendamment
- [x] `ysc::generate<int,3>(f)` compile et génère les valeurs via `f(i)`
- [x] Tests dans `test/src/construct_from_buffer.cpp` (8 cas de test)
- [x] Build et tests verts
- [x] Documenté avec Doxygen (`@brief`, `@param`, `@code`…`@endcode`, `@ingroup`)
- [x] clang-format appliqué

## Notes d'implémentation

- `linear_size` étant privé, la fonction `generate()` utilise `matrix<T,Dims...>::size()` (public static constexpr) pour la borne de boucle.
- Le constructeur `std::array` prend par valeur et délègue à `std::move`, ce qui évite une copie inutile pour les rvalues.
- Le constructeur `std::span` utilise `std::copy` (même approche que le constructeur depuis `matrix_view<contiguous>`).