### PR TITLE
US-051 — matrix_view : itérateurs strided + front/back/fill

### DIFF
--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -51,7 +51,7 @@
 |----|-------|----------|--------|
 | US-039 | Suite de benchmarks (Google Benchmark) | P1 | ⬜ À faire |
 | US-050 | Cookbook Doxygen | P1 | ⬜ À faire |
-| US-051 | `matrix_view` : itérateurs strided + `front`/`back`/`fill` | P1 | ⬜ À faire |
+| US-051 | `matrix_view` : itérateurs strided + `front`/`back`/`fill` | P1 | ✅ Done |
 | US-052 | `matrix_view` : I/O, ctor const, vues composables | P1 | ⬜ À faire |
 | US-053 | Constructeurs additionnels : `std::array`, `std::span`, générateur | P1 | ⬜ À faire |
 | US-054 | `matrix::rows()` / `cols()` + `matmul` vecteur 1D | P1 | ⬜ À faire |
@@ -1386,11 +1386,11 @@ En tant qu'utilisateur, je veux itérer sur une `matrix_view<T, strided, N>` ave
 - `fill()` sur strided : boucle sur indices, pas d'accès linéaire au buffer
 
 ### Critères d'acceptation
-- [ ] `for (auto& v : col_view)` compile et fonctionne pour `col_view` issu de `m.col(j)`
-- [ ] `std::accumulate(v.begin(), v.end(), 0)` fonctionne sur une vue 1D strided
-- [ ] `std::ranges::sort(v)` compile (random-access iterator)
-- [ ] `v.fill(42)` fonctionne sur une vue strided
-- [ ] `v.front()` et `v.back()` disponibles sur toute vue strided
+- [x] `for (auto& v : col_view)` compile et fonctionne pour `col_view` issu de `m.col(j)`
+- [x] `std::accumulate(v.begin(), v.end(), 0)` fonctionne sur une vue 1D strided
+- [x] `std::ranges::sort(v)` compile (random-access iterator)
+- [x] `v.fill(42)` fonctionne sur une vue strided
+- [x] `v.front()` et `v.back()` disponibles sur toute vue strided
 
 ---
 

--- a/src/include/matrix_view.hpp
+++ b/src/include/matrix_view.hpp
@@ -21,7 +21,6 @@
 #include <string>
 #include <tuple>
 
-
 #include <matrix_detail.hpp>
 
 namespace ysc {

--- a/src/include/matrix_view.hpp
+++ b/src/include/matrix_view.hpp
@@ -646,7 +646,7 @@ public:
         /** @brief Subscript. */
         reference operator[](difference_type n) const noexcept {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-            return *(_ptr + n * static_cast<difference_type>(_stride));
+            return *(_ptr + (n * static_cast<difference_type>(_stride)));
         }
 
         /** @brief Equality comparison. */
@@ -746,7 +746,7 @@ public:
         /** @brief Subscript. */
         reference operator[](difference_type n) const noexcept {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-            return *(_ptr + n * static_cast<difference_type>(_stride));
+            return *(_ptr + (n * static_cast<difference_type>(_stride)));
         }
 
         /** @brief Equality comparison. */

--- a/src/include/matrix_view.hpp
+++ b/src/include/matrix_view.hpp
@@ -15,8 +15,10 @@
 
 #include <algorithm>
 #include <array>
+#include <compare>
 #include <iterator>
 #include <stdexcept>
+#include <tuple>
 
 #include <matrix_detail.hpp>
 
@@ -555,6 +557,204 @@ public:
     /** @brief Const pointer to element type. */
     using const_pointer = const T*;
 
+    // ─── strided iterator (random-access, 1-D views) ─────────────────────────
+
+    /**
+     * @brief Random-access iterator over a 1-D strided view.
+     *
+     * Advances by @c _stride elements per step.  Satisfies
+     * `std::random_access_iterator` (but not `std::contiguous_iterator`).
+     *
+     * @ingroup ysc_view
+     */
+    struct iterator {
+        /** @brief Iterator category: random-access (not contiguous). */
+        using iterator_category = std::random_access_iterator_tag;
+        /** @brief Element type. */
+        using value_type = T;
+        /** @brief Signed difference type. */
+        using difference_type = std::ptrdiff_t;
+        /** @brief Pointer type. */
+        using pointer = T*;
+        /** @brief Reference type. */
+        using reference = T&;
+
+        T* _ptr;             ///< Pointer to current element
+        std::size_t _stride; ///< Stride in number of T elements
+
+        /** @brief Dereference. */
+        reference operator*() const noexcept { return *_ptr; }
+        /** @brief Arrow. */
+        pointer operator->() const noexcept { return _ptr; }
+
+        /** @brief Pre-increment. */
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        iterator& operator++() noexcept {
+            _ptr += static_cast<difference_type>(_stride);
+            return *this;
+        }
+        /** @brief Post-increment. */
+        iterator operator++(int) noexcept {
+            auto tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+        /** @brief Pre-decrement. */
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        iterator& operator--() noexcept {
+            _ptr -= static_cast<difference_type>(_stride);
+            return *this;
+        }
+        /** @brief Post-decrement. */
+        iterator operator--(int) noexcept {
+            auto tmp = *this;
+            --(*this);
+            return tmp;
+        }
+
+        /** @brief Advance by @p n steps. */
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        iterator& operator+=(difference_type n) noexcept {
+            _ptr += n * static_cast<difference_type>(_stride);
+            return *this;
+        }
+        /** @brief Retreat by @p n steps. */
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        iterator& operator-=(difference_type n) noexcept {
+            _ptr -= n * static_cast<difference_type>(_stride);
+            return *this;
+        }
+        /** @brief Iterator + n. */
+        [[nodiscard]] iterator operator+(difference_type n) const noexcept {
+            auto tmp = *this;
+            return tmp += n;
+        }
+        /** @brief n + iterator. */
+        [[nodiscard]] friend iterator operator+(difference_type n, iterator it) noexcept {
+            return it + n;
+        }
+        /** @brief Iterator - n. */
+        [[nodiscard]] iterator operator-(difference_type n) const noexcept {
+            auto tmp = *this;
+            return tmp -= n;
+        }
+        /** @brief Distance between iterators. */
+        [[nodiscard]] difference_type operator-(const iterator& other) const noexcept {
+            return (_ptr - other._ptr) / static_cast<difference_type>(_stride);
+        }
+        /** @brief Subscript. */
+        reference operator[](difference_type n) const noexcept {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            return *(_ptr + n * static_cast<difference_type>(_stride));
+        }
+
+        /** @brief Equality comparison. */
+        bool operator==(const iterator& other) const noexcept = default;
+        /** @brief Three-way comparison (by pointer address). */
+        [[nodiscard]] auto operator<=>(const iterator& other) const noexcept {
+            return _ptr <=> other._ptr;
+        }
+    };
+
+    /**
+     * @brief Const random-access iterator over a 1-D strided view.
+     * @ingroup ysc_view
+     */
+    struct const_iterator {
+        /** @brief Iterator category: random-access (not contiguous). */
+        using iterator_category = std::random_access_iterator_tag;
+        /** @brief Element type. */
+        using value_type = T;
+        /** @brief Signed difference type. */
+        using difference_type = std::ptrdiff_t;
+        /** @brief Pointer type. */
+        using pointer = const T*;
+        /** @brief Reference type. */
+        using reference = const T&;
+
+        const T* _ptr = nullptr; ///< Pointer to current element
+        std::size_t _stride = 0; ///< Stride in number of T elements
+
+        const_iterator() noexcept = default;
+        const_iterator(const T* ptr, std::size_t stride) noexcept : _ptr{ptr}, _stride{stride} {}
+        // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
+        const_iterator(iterator it) noexcept : _ptr{it._ptr}, _stride{it._stride} {}
+
+        /** @brief Dereference. */
+        reference operator*() const noexcept { return *_ptr; }
+        /** @brief Arrow. */
+        pointer operator->() const noexcept { return _ptr; }
+
+        /** @brief Pre-increment. */
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        const_iterator& operator++() noexcept {
+            _ptr += static_cast<difference_type>(_stride);
+            return *this;
+        }
+        /** @brief Post-increment. */
+        const_iterator operator++(int) noexcept {
+            auto tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+        /** @brief Pre-decrement. */
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        const_iterator& operator--() noexcept {
+            _ptr -= static_cast<difference_type>(_stride);
+            return *this;
+        }
+        /** @brief Post-decrement. */
+        const_iterator operator--(int) noexcept {
+            auto tmp = *this;
+            --(*this);
+            return tmp;
+        }
+
+        /** @brief Advance by @p n steps. */
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        const_iterator& operator+=(difference_type n) noexcept {
+            _ptr += n * static_cast<difference_type>(_stride);
+            return *this;
+        }
+        /** @brief Retreat by @p n steps. */
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        const_iterator& operator-=(difference_type n) noexcept {
+            _ptr -= n * static_cast<difference_type>(_stride);
+            return *this;
+        }
+        /** @brief Iterator + n. */
+        [[nodiscard]] const_iterator operator+(difference_type n) const noexcept {
+            auto tmp = *this;
+            return tmp += n;
+        }
+        /** @brief n + const_iterator. */
+        [[nodiscard]] friend const_iterator operator+(difference_type n,
+                                                      const_iterator it) noexcept {
+            return it + n;
+        }
+        /** @brief Iterator - n. */
+        [[nodiscard]] const_iterator operator-(difference_type n) const noexcept {
+            auto tmp = *this;
+            return tmp -= n;
+        }
+        /** @brief Distance between iterators. */
+        [[nodiscard]] difference_type operator-(const const_iterator& other) const noexcept {
+            return (_ptr - other._ptr) / static_cast<difference_type>(_stride);
+        }
+        /** @brief Subscript. */
+        reference operator[](difference_type n) const noexcept {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            return *(_ptr + n * static_cast<difference_type>(_stride));
+        }
+
+        /** @brief Equality comparison. */
+        bool operator==(const const_iterator& other) const noexcept = default;
+        /** @brief Three-way comparison (by pointer address). */
+        [[nodiscard]] auto operator<=>(const const_iterator& other) const noexcept {
+            return _ptr <=> other._ptr;
+        }
+    };
+
     // ─── construction ────────────────────────────────────────────────────────
 
     matrix_view() = delete;
@@ -617,6 +817,89 @@ public:
      * @ingroup ysc_view
      */
     [[nodiscard]] static constexpr bool empty() noexcept { return linear_size == 0; }
+
+    // ─── iterators (1-D strided views only) ──────────────────────────────────
+
+    /**
+     * @brief Returns an iterator to the first element of a 1-D strided view.
+     * @return Iterator to the first element
+     *
+     * Only available for 1-D views (@c order == 1).
+     *
+     * @code
+     * ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+     * auto col = m.col(1);  // strided view of column 1
+     * int sum = std::accumulate(col.begin(), col.end(), 0);
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    iterator begin() noexcept
+        requires(order == 1)
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+        return {_ptr, _strides[0]};
+    }
+
+    /**
+     * @brief Returns a const iterator to the first element of a 1-D strided view.
+     * @return Const iterator to the first element
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] const_iterator begin() const noexcept
+        requires(order == 1)
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+        return {_ptr, _strides[0]};
+    }
+
+    /**
+     * @brief Returns a const iterator to the first element of a 1-D strided view.
+     * @return Const iterator to the first element
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] const_iterator cbegin() const noexcept
+        requires(order == 1)
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+        return {_ptr, _strides[0]};
+    }
+
+    /**
+     * @brief Returns an iterator past the last element of a 1-D strided view.
+     * @return Iterator past the last element
+     * @ingroup ysc_view
+     */
+    iterator end() noexcept
+        requires(order == 1)
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index,cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        return {_ptr + static_cast<difference_type>(linear_size * _strides[0]), _strides[0]};
+    }
+
+    /**
+     * @brief Returns a const iterator past the last element of a 1-D strided view.
+     * @return Const iterator past the last element
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] const_iterator end() const noexcept
+        requires(order == 1)
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index,cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        return {_ptr + static_cast<difference_type>(linear_size * _strides[0]), _strides[0]};
+    }
+
+    /**
+     * @brief Returns a const iterator past the last element of a 1-D strided view.
+     * @return Const iterator past the last element
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] const_iterator cend() const noexcept
+        requires(order == 1)
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index,cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        return {_ptr + static_cast<difference_type>(linear_size * _strides[0]), _strides[0]};
+    }
 
     // ─── element access ──────────────────────────────────────────────────────
 
@@ -738,6 +1021,85 @@ public:
             throw std::out_of_range{"matrix_view::at"};
         }
         return (*this)(coords...);
+    }
+
+    // ─── modifiers ───────────────────────────────────────────────────────────
+
+    /**
+     * @brief Returns a reference to the first element (all coordinates zero).
+     *
+     * Calling @c front() on an empty view is undefined behavior.
+     *
+     * @code
+     * ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+     * auto col = m.col(1);
+     * assert(col.front() == m(0, 1));
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    constexpr reference front() noexcept { return (*this)(((void)Dimensions, std::size_t{0})...); }
+
+    /**
+     * @brief Returns a const reference to the first element (all coordinates zero).
+     *
+     * Calling @c front() on an empty view is undefined behavior.
+     *
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] constexpr const_reference front() const noexcept {
+        return (*this)(((void)Dimensions, std::size_t{0})...);
+    }
+
+    /**
+     * @brief Returns a reference to the last element (each coordinate at its maximum).
+     *
+     * Calling @c back() on an empty view is undefined behavior.
+     *
+     * @code
+     * ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+     * auto col = m.col(1);
+     * assert(col.back() == m(2, 1));
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    constexpr reference back() noexcept { return (*this)((Dimensions - 1)...); }
+
+    /**
+     * @brief Returns a const reference to the last element (each coordinate at its maximum).
+     *
+     * Calling @c back() on an empty view is undefined behavior.
+     *
+     * @ingroup ysc_view
+     */
+    [[nodiscard]] constexpr const_reference back() const noexcept {
+        return (*this)((Dimensions - 1)...);
+    }
+
+    /**
+     * @brief Assigns @p value to every element of the strided view.
+     * @param value Value to assign
+     *
+     * Iterates over all logical indices and writes through @c operator(),
+     * so each element is visited exactly once regardless of strides.
+     * Modifications are reflected in the underlying @c matrix.
+     *
+     * @code
+     * ysc::matrix<int, 3, 4> m{};
+     * auto col = m.col(2);
+     * col.fill(7);
+     * assert(m(1, 2) == 7);
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    constexpr void fill(const T& value) noexcept(std::is_nothrow_copy_assignable_v<T>) {
+        for (std::size_t k = 0; k < linear_size; ++k) {
+            const auto coords = detail::index_to_coordinates(dimensions, k);
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+            std::apply([&](auto... c) { (*this)(c...) = value; }, coords);
+        }
     }
 };
 

--- a/src/include/matrix_view.hpp
+++ b/src/include/matrix_view.hpp
@@ -588,8 +588,8 @@ public:
         pointer operator->() const noexcept { return _ptr; }
 
         /** @brief Pre-increment. */
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         iterator& operator++() noexcept {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             _ptr += static_cast<difference_type>(_stride);
             return *this;
         }
@@ -600,8 +600,8 @@ public:
             return tmp;
         }
         /** @brief Pre-decrement. */
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         iterator& operator--() noexcept {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             _ptr -= static_cast<difference_type>(_stride);
             return *this;
         }
@@ -613,14 +613,14 @@ public:
         }
 
         /** @brief Advance by @p n steps. */
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         iterator& operator+=(difference_type n) noexcept {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             _ptr += n * static_cast<difference_type>(_stride);
             return *this;
         }
         /** @brief Retreat by @p n steps. */
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         iterator& operator-=(difference_type n) noexcept {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             _ptr -= n * static_cast<difference_type>(_stride);
             return *this;
         }
@@ -640,6 +640,7 @@ public:
         }
         /** @brief Distance between iterators. */
         [[nodiscard]] difference_type operator-(const iterator& other) const noexcept {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             return (_ptr - other._ptr) / static_cast<difference_type>(_stride);
         }
         /** @brief Subscript. */
@@ -686,8 +687,8 @@ public:
         pointer operator->() const noexcept { return _ptr; }
 
         /** @brief Pre-increment. */
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         const_iterator& operator++() noexcept {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             _ptr += static_cast<difference_type>(_stride);
             return *this;
         }
@@ -698,8 +699,8 @@ public:
             return tmp;
         }
         /** @brief Pre-decrement. */
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         const_iterator& operator--() noexcept {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             _ptr -= static_cast<difference_type>(_stride);
             return *this;
         }
@@ -711,14 +712,14 @@ public:
         }
 
         /** @brief Advance by @p n steps. */
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         const_iterator& operator+=(difference_type n) noexcept {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             _ptr += n * static_cast<difference_type>(_stride);
             return *this;
         }
         /** @brief Retreat by @p n steps. */
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         const_iterator& operator-=(difference_type n) noexcept {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             _ptr -= n * static_cast<difference_type>(_stride);
             return *this;
         }
@@ -739,6 +740,7 @@ public:
         }
         /** @brief Distance between iterators. */
         [[nodiscard]] difference_type operator-(const const_iterator& other) const noexcept {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             return (_ptr - other._ptr) / static_cast<difference_type>(_stride);
         }
         /** @brief Subscript. */

--- a/test/src/matrix_view.cpp
+++ b/test/src/matrix_view.cpp
@@ -252,3 +252,143 @@ TEST(matrix_view_1d, single_coord_access) {
     EXPECT_EQ(v(2), 30);
     EXPECT_EQ(v(4), 50);
 }
+
+// ─── strided iterator (US-051) ────────────────────────────────────────────────
+
+// Verify random_access_iterator concept is satisfied on strided iterator
+static_assert(std::random_access_iterator<ysc::matrix_view<int, ysc::strided, 3>::iterator>);
+static_assert(std::random_access_iterator<ysc::matrix_view<int, ysc::strided, 3>::const_iterator>);
+
+TEST(matrix_view_strided_iterators, range_for_over_column) {
+    ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    auto col = m.col(1); // column 1: m(0,1)=2, m(1,1)=6, m(2,1)=10
+    int sum = 0;
+    for (auto& v : col) {
+        sum += v;
+    }
+    EXPECT_EQ(sum, 2 + 6 + 10);
+}
+
+TEST(matrix_view_strided_iterators, range_for_write_reflects_in_matrix) {
+    ysc::matrix<int, 3, 4> m{};
+    auto col = m.col(2);
+    for (auto& v : col) {
+        v = 7;
+    }
+    EXPECT_EQ(m(0, 2), 7);
+    EXPECT_EQ(m(1, 2), 7);
+    EXPECT_EQ(m(2, 2), 7);
+    // Other columns not touched
+    EXPECT_EQ(m(0, 0), 0);
+    EXPECT_EQ(m(1, 3), 0);
+}
+
+TEST(matrix_view_strided_iterators, accumulate_on_1d_strided_view) {
+    ysc::matrix<int, 4, 3> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    auto col = m.col(0); // column 0: 1, 4, 7, 10
+    const int total = std::accumulate(col.begin(), col.end(), 0);
+    EXPECT_EQ(total, 1 + 4 + 7 + 10);
+}
+
+TEST(matrix_view_strided_iterators, cbegin_cend_const_view) {
+    const ysc::matrix<int, 3, 3> m{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    const auto row = m.row(1); // row 1: 4, 5, 6
+    const int total = std::accumulate(row.cbegin(), row.cend(), 0);
+    EXPECT_EQ(total, 4 + 5 + 6);
+}
+
+TEST(matrix_view_strided_iterators, ranges_sort_on_strided_view) {
+    ysc::matrix<int, 4, 1> m{5, 3, 1, 4};
+    auto col = m.col(0); // strided view: elements m(0,0)..m(3,0)
+    std::ranges::sort(col);
+    EXPECT_EQ(m(0, 0), 1);
+    EXPECT_EQ(m(1, 0), 3);
+    EXPECT_EQ(m(2, 0), 4);
+    EXPECT_EQ(m(3, 0), 5);
+}
+
+TEST(matrix_view_strided_iterators, distance_equals_size) {
+    ysc::matrix<int, 5, 2> m{};
+    auto col = m.col(0);
+    EXPECT_EQ(std::distance(col.begin(), col.end()), static_cast<std::ptrdiff_t>(col.size()));
+}
+
+// ─── strided front() / back() (US-051) ───────────────────────────────────────
+
+TEST(matrix_view_strided_accessors, front_1d_strided) {
+    ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    auto col = m.col(1); // column 1: m(0,1)=2, m(1,1)=6, m(2,1)=10
+    EXPECT_EQ(col.front(), m(0, 1));
+}
+
+TEST(matrix_view_strided_accessors, back_1d_strided) {
+    ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    auto col = m.col(1); // column 1: last element is m(2,1)=10
+    EXPECT_EQ(col.back(), m(2, 1));
+}
+
+TEST(matrix_view_strided_accessors, front_write_reflects) {
+    ysc::matrix<int, 3, 4> m{};
+    auto col = m.col(2);
+    col.front() = 42;
+    EXPECT_EQ(m(0, 2), 42);
+}
+
+TEST(matrix_view_strided_accessors, back_write_reflects) {
+    ysc::matrix<int, 3, 4> m{};
+    auto col = m.col(2);
+    col.back() = 99;
+    EXPECT_EQ(m(2, 2), 99);
+}
+
+TEST(matrix_view_strided_accessors, front_back_2d_strided_view) {
+    ysc::matrix<int, 2, 3, 4> m{};
+    // Set known values
+    m(0, 0, 0) = 1;
+    m(1, 2, 3) = 42;
+    auto sv = m.slice(ysc::all, ysc::all, 0); // 2x3 strided view, fixing last dim at 0
+    EXPECT_EQ(sv.front(), m(0, 0, 0));
+    EXPECT_EQ(sv.back(), m(1, 2, 0));
+}
+
+// ─── strided fill() (US-051) ─────────────────────────────────────────────────
+
+TEST(matrix_view_strided_fill, fill_column_reflects_in_matrix) {
+    ysc::matrix<int, 4, 3> m{};
+    auto col = m.col(1);
+    col.fill(5);
+    // Column 1 is all 5
+    EXPECT_EQ(m(0, 1), 5);
+    EXPECT_EQ(m(1, 1), 5);
+    EXPECT_EQ(m(2, 1), 5);
+    EXPECT_EQ(m(3, 1), 5);
+    // Other columns untouched
+    EXPECT_EQ(m(0, 0), 0);
+    EXPECT_EQ(m(0, 2), 0);
+}
+
+TEST(matrix_view_strided_fill, fill_row_reflects_in_matrix) {
+    ysc::matrix<int, 3, 4> m{};
+    auto row = m.row(2);
+    row.fill(99);
+    EXPECT_EQ(m(2, 0), 99);
+    EXPECT_EQ(m(2, 1), 99);
+    EXPECT_EQ(m(2, 2), 99);
+    EXPECT_EQ(m(2, 3), 99);
+    // Other rows untouched
+    EXPECT_EQ(m(0, 0), 0);
+}
+
+TEST(matrix_view_strided_fill, fill_2d_strided_view) {
+    ysc::matrix<int, 2, 3, 4> m{};
+    auto sv = m.slice(ysc::all, ysc::all, 0); // 2x3 strided view
+    sv.fill(7);
+    EXPECT_EQ(m(0, 0, 0), 7);
+    EXPECT_EQ(m(0, 1, 0), 7);
+    EXPECT_EQ(m(0, 2, 0), 7);
+    EXPECT_EQ(m(1, 0, 0), 7);
+    EXPECT_EQ(m(1, 2, 0), 7);
+    // Dim index != 0 untouched
+    EXPECT_EQ(m(0, 0, 1), 0);
+    EXPECT_EQ(m(1, 1, 3), 0);
+}

--- a/test/src/matrix_view.cpp
+++ b/test/src/matrix_view.cpp
@@ -392,3 +392,36 @@ TEST(matrix_view_strided_fill, fill_2d_strided_view) {
     EXPECT_EQ(m(0, 0, 1), 0);
     EXPECT_EQ(m(1, 1, 3), 0);
 }
+
+// ─── strided iterator arithmetic & comparison ─────────────────────────────────
+
+TEST(matrix_view_strided_iterators, iterator_minus_n_retreat) {
+    ysc::matrix<int, 4, 3> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    auto col = m.col(0); // column 0: 1, 4, 7, 10
+    auto it = col.end() - 2;
+    EXPECT_EQ(*it, 7); // third element (index 2)
+}
+
+TEST(matrix_view_strided_iterators, iterator_minus_assign_retreat) {
+    ysc::matrix<int, 4, 3> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    auto col = m.col(0); // column 0: 1, 4, 7, 10
+    auto it = col.end();
+    it -= 1;
+    EXPECT_EQ(*it, 10); // last element
+}
+
+TEST(matrix_view_strided_iterators, iterator_three_way_comparison) {
+    // Tests matrix_view<int, strided, 3> and matrix_view<int, strided, 4> specializations
+    ysc::matrix<int, 3, 4> m{};
+    auto col3 = m.col(0); // 3-element strided view
+    auto a3 = col3.begin();
+    auto b3 = col3.begin() + 1;
+    EXPECT_TRUE((a3 <=> b3) < 0);
+    EXPECT_TRUE((b3 <=> a3) > 0);
+
+    ysc::matrix<int, 4, 3> m2{};
+    auto col4 = m2.col(0); // 4-element strided view
+    auto a4 = col4.begin();
+    auto b4 = col4.begin() + 1;
+    EXPECT_TRUE((a4 <=> b4) < 0); // NOLINT(misc-redundant-expression)
+}


### PR DESCRIPTION
## Résumé

Ajout d'un itérateur random-access (`iterator` et `const_iterator`) sur `matrix_view<T, strided, N>` (1D uniquement), permettant l'usage avec `std::ranges::sort`, `std::accumulate` et la boucle range-for. Les méthodes `begin()`/`end()`/`cbegin()`/`cend()` sont contraintes à `order == 1` via `requires`. Les méthodes `front()`, `back()` et `fill()` sont disponibles sur toutes les vues strided (N-D quelconque). Le `fill()` strided itère sur les indices logiques via `detail::index_to_coordinates` + `std::apply`, sans accès linéaire au buffer.

## Critères d'acceptation

- [x] `for (auto& v : col_view)` compile et fonctionne pour une vue colonne
- [x] `std::accumulate(v.begin(), v.end(), 0)` fonctionne sur vue 1D strided
- [x] `std::ranges::sort(v)` compile (random-access iterator)
- [x] `v.fill(42)` fonctionne sur vue strided
- [x] `v.front()` et `v.back()` disponibles sur toute vue strided

## Décisions d'implémentation

- `iterator` est un agrégat (default-constructible) ; `const_iterator` a un constructeur par défaut explicite `= default` pour satisfaire `std::default_initializable` requis par `std::random_access_iterator`.
- `const_iterator` possède une conversion implicite depuis `iterator` (NOLINTNEXTLINE justifié, analogue à `const T*` depuis `T*`).
- Les surcharges `begin()`/`end()` sur la spécialisation N-D générale sont contraintes `requires(order == 1)` plutôt que d'introduire une nouvelle spécialisation partielle, ce qui maintient le code concis.
- `fill()` strided utilise `detail::index_to_coordinates` (déjà dans `matrix_detail.hpp`) + `std::apply` pour générer les coordonnées N-D depuis un index plat, évitant toute hypothèse de contiguïté mémoire.