### PR TITLE
US-046 — Correctifs docs + .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Building
 _cmake
-/build
-/build-cov
+/build*/
 
 # Editing
 *.orig

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,13 +58,13 @@ The CHANGELOG is generated automatically from these messages on each release via
 
 ## Releasing
 
-`release.sh` at the root of the repository semi-automates the release process.
+`.github/github-release.sh` at the root of the repository semi-automates the release process.
 It requires `git` and `gh` (GitHub CLI, authenticated).
 
 ### Step 1 — Prepare the release
 
 ```bash
-./release.sh prepare M.m.p
+./.github/github-release.sh prepare M.m.p
 ```
 
 This:
@@ -80,7 +80,7 @@ Wait for CI to be green, then merge the PR into `master` (merge commit).
 ### Step 3 — Finalize the release
 
 ```bash
-./release.sh finalize M.m.p
+./.github/github-release.sh finalize M.m.p
 ```
 
 This:

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -803,7 +803,7 @@ EXCLUDE_SYMBOLS        =
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           = @PROJECT_SOURCE_DIR@/doc/sample
+EXAMPLE_PATH           =
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and


### PR DESCRIPTION
## Résumé
Trois correctifs mineurs de cohérence : commande de release documentée,
`.gitignore` couvrant tous les répertoires `build*/`, et suppression de
`EXAMPLE_PATH` vers un dossier inexistant dans `Doxyfile.in`.

## Critères d'acceptation
- [x] `./.github/github-release.sh prepare X.Y.Z` est la commande documentée dans `CONTRIBUTING.md`
- [x] `build-cov/` et autres `build*/` n'apparaissent plus en untracked dans `git status`
- [x] `cmake --build build --target doc` ne produit aucun avertissement sur `EXAMPLE_PATH`