### PR TITLE
US-058 — Optimiser matrix(matrix_view<strided>)

### DIFF
--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -373,26 +373,33 @@ public:
     }
 
     /**
-     * @brief Constructs an owning matrix by copying elements from a strided view.
+     * @brief Constructs an owning matrix by copying elements from a strided view using its
+     *        iterators.
      * @param v Strided view to copy from
      *
-     * Elements are copied one by one via @c operator(). The resulting matrix is independent
-     * of @p v: mutations to either do not affect the other.
+     * For 1-D strided views, elements are copied via the view's random-access iterators
+     * (@c std::copy(v.begin(), v.end(), ...)), which is O(N).  For higher-order strided views,
+     * elements are copied one by one via @c index_to_coordinates and @c operator().
+     * The resulting matrix is independent of @p v: mutations to either do not affect the other.
      *
      * @code
      * ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
      * auto col1 = m.col(1);                    // strided view of column 1
-     * auto m2   = ysc::matrix<int, 3>(col1);   // owning copy
+     * auto m2   = ysc::matrix<int, 3>(col1);   // owning copy via iterators
      * m2(0) = 99;                              // does not affect m
      * @endcode
      *
      * @ingroup ysc_view
      */
     explicit matrix(const matrix_view<T, strided, Dimensions...>& v) {
-        std::size_t k = 0;
-        for (auto& elem : _data) {
-            const auto coords = detail::index_to_coordinates(dimensions, k++);
-            elem = std::apply([&v](auto... cs) -> T { return v(cs...); }, coords);
+        if constexpr (sizeof...(Dimensions) == 1) {
+            std::copy(v.begin(), v.end(), _data.begin());
+        } else {
+            std::size_t k = 0;
+            for (auto& elem : _data) {
+                const auto coords = detail::index_to_coordinates(dimensions, k++);
+                elem = std::apply([&v](auto... cs) -> T { return v(cs...); }, coords);
+            }
         }
     }
 

--- a/test/src/matrix_from_view.cpp
+++ b/test/src/matrix_from_view.cpp
@@ -178,3 +178,41 @@ TEST(matrix_from_view, ctad_strided) {
     EXPECT_EQ(m2(0), 1);
     EXPECT_EQ(m2(2), 9);
 }
+
+// ─── US-058: strided ctor uses iterators ──────────────────────────────────────
+
+TEST(matrix_from_view, strided_1d_iterator_copies_correct_values) {
+    // Verify that the 1-D strided ctor (now using iterators) yields the same
+    // result as constructing element by element.
+    ysc::matrix<int, 4, 5> m{};
+    for (std::size_t i = 0; i < 4; ++i) {
+        for (std::size_t j = 0; j < 5; ++j) {
+            m(i, j) = static_cast<int>(i * 5 + j + 1);
+        }
+    }
+    // col(3): elements m(0,3), m(1,3), m(2,3), m(3,3) — values 4, 9, 14, 19
+    auto col3 = m.col(3);
+    auto m2 = ysc::matrix<int, 4>(col3);
+    EXPECT_EQ(m2(0), m(0, 3));
+    EXPECT_EQ(m2(1), m(1, 3));
+    EXPECT_EQ(m2(2), m(2, 3));
+    EXPECT_EQ(m2(3), m(3, 3));
+}
+
+TEST(matrix_from_view, strided_1d_copy_does_not_alias_source) {
+    // After construction, mutating the copy must not affect the original.
+    ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    auto col1 = m.col(1);
+    auto m2 = ysc::matrix<int, 3>(col1);
+    // Mutate the copy
+    m2(0) = 42;
+    m2(1) = 43;
+    m2(2) = 44;
+    // Source must be unchanged
+    EXPECT_EQ(m(0, 1), 2);
+    EXPECT_EQ(m(1, 1), 6);
+    EXPECT_EQ(m(2, 1), 10);
+    // And mutating the source must not affect the copy
+    m(0, 1) = 99;
+    EXPECT_EQ(m2(0), 42);
+}


### PR DESCRIPTION
## Résumé

Le constructeur `matrix(const matrix_view<T, strided, Dims...>&)` utilisait une boucle
`index_to_coordinates` → `std::apply` → `operator()` en O(N·order) pour copier chaque
élément. Grâce aux itérateurs strided introduits par US-051, ce chemin est désormais
remplacé par `std::copy(v.begin(), v.end(), _data.begin())` en O(N) pour les vues 1D.
Pour les vues d'ordre supérieur (N>1), où les itérateurs ne sont pas disponibles dans
la spécialisation strided, la boucle existante est conservée via `if constexpr`.

## Critères d'acceptation

- [x] Le ctor strided 1D utilise les itérateurs (`std::copy(v.begin(), v.end(), ...)`) — plus de `index_to_coordinates` en boucle pour ce cas
- [x] Pour les vues strided ND (order > 1), l'implémentation existante est conservée via `if constexpr`
- [x] Tests existants `test/src/matrix_from_view.cpp` restent verts
- [x] Deux nouveaux tests vérifient la copie correcte des valeurs et l'absence d'aliasing pour le chemin itérateur

## Notes d'implémentation

Les itérateurs `begin()`/`end()` de `matrix_view<T, strided, Dims...>` sont contraints à
`requires(order == 1)` (US-051). Un seul constructeur avec `if constexpr` couvre les deux
cas sans duplication de code.