### PR TITLE
US-052 — matrix_view : I/O, ctor const, vues composables

### DIFF
--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -36,35 +36,6 @@
 #include <matrix_view.hpp>
 
 namespace ysc {
-namespace detail {
-
-template <class T>
-concept ostream_streamable = requires(std::ostream& os, const T& v) { os << v; };
-
-// Print a hyperslice of a matrix starting at `it`, covering dimension `dim_idx`
-// onward. Returns an iterator past the last element printed.
-// NOLINTNEXTLINE(misc-no-recursion)
-template <class It, class Dims>
-It print_recursive(std::ostream& os, It it, const Dims& dims, std::size_t dim_idx) {
-    os << '[';
-    const std::size_t count = dims[dim_idx];
-    const bool last_dim = (dim_idx + 1 == dims.size());
-    for (std::size_t i = 0; i < count; ++i) {
-        if (i > 0) {
-            os << ", ";
-        }
-        if (last_dim) {
-            os << *it++;
-        } else {
-            // NOLINTNEXTLINE(misc-no-recursion)
-            it = print_recursive(os, it, dims, dim_idx + 1);
-        }
-    }
-    os << ']';
-    return it;
-}
-
-} // namespace detail
 
 /**
  * @brief Satisfied when `U` is convertible to `T`.

--- a/src/include/matrix_detail.hpp
+++ b/src/include/matrix_detail.hpp
@@ -15,6 +15,7 @@
 #include <array>
 #include <concepts>
 #include <cstddef>
+#include <ostream>
 #include <type_traits>
 
 namespace ysc {
@@ -64,6 +65,32 @@ concept integral_coordinates = (std::integral<std::remove_cvref_t<Coords>> && ..
 // ─── detail namespace ─────────────────────────────────────────────────────────
 
 namespace detail {
+
+template <class T>
+concept ostream_streamable = requires(std::ostream& os, const T& v) { os << v; };
+
+// Print a hyperslice starting at `it`, covering dimension `dim_idx` onward.
+// Returns an iterator past the last element printed.
+// NOLINTNEXTLINE(misc-no-recursion)
+template <class It, class Dims>
+It print_recursive(std::ostream& os, It it, const Dims& dims, std::size_t dim_idx) {
+    os << '[';
+    const std::size_t count = dims[dim_idx];
+    const bool last_dim = (dim_idx + 1 == dims.size());
+    for (std::size_t i = 0; i < count; ++i) {
+        if (i > 0) {
+            os << ", ";
+        }
+        if (last_dim) {
+            os << *it++;
+        } else {
+            // NOLINTNEXTLINE(misc-no-recursion)
+            it = print_recursive(os, it, dims, dim_idx + 1);
+        }
+    }
+    os << ']';
+    return it;
+}
 
 // cache-friendly: neighbor objects within the right-most coordinate are neighbors in memory
 template <class TDim, class TCoord>
@@ -228,6 +255,28 @@ template <class... PaddedSpecs> struct slice_helper<std::tuple<PaddedSpecs...>> 
 };
 
 } // namespace detail
+
+/**
+ * @brief Alias for a read-only contiguous view over a @c ysc::matrix.
+ * @tparam T    Element type (non-const; the alias adds @c const automatically)
+ * @tparam Dims Dimensions of the view
+ *
+ * @c const_matrix_view<T, Dims...> is shorthand for
+ * @c matrix_view<const T, contiguous, Dims...>.  It is the natural read-only
+ * counterpart of @c matrix_view, analogous to @c std::string_view vs
+ * @c std::string.
+ *
+ * @code
+ * const ysc::matrix<int, 3, 3> m{1, 2, 3, 4, 5, 6, 7, 8, 9};
+ * ysc::const_matrix_view<int, 3, 3> v{m};  // read-only view
+ * assert(v(0, 0) == 1);
+ * @endcode
+ *
+ * @ingroup ysc_view
+ */
+template <class T, std::size_t... Dims>
+using const_matrix_view = matrix_view<const T, contiguous, Dims...>;
+
 } // namespace ysc
 
 #endif // YSC_MATRIX_DETAIL_HPP

--- a/src/include/matrix_view.hpp
+++ b/src/include/matrix_view.hpp
@@ -17,9 +17,16 @@
 #include <array>
 #include <compare>
 #include <iterator>
+#include <ostream>
 #include <stdexcept>
 #include <string>
 #include <tuple>
+// Clang < 17 cannot compile libstdc++-14's <format> due to unicode.h
+// incompatibility
+#if __has_include(<format>) && (!defined(__clang__) || __clang_major__ >= 17)
+#include <format>
+#include <sstream>
+#endif
 
 #include <matrix_detail.hpp>
 
@@ -136,6 +143,27 @@ public:
      */
     // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
     constexpr matrix_view(matrix<T, Dimensions...>& m) noexcept : _ptr{m.data()} {}
+
+    /**
+     * @brief Constructs a read-only view over a @c const matrix.
+     * @tparam U Non-const element type (deduced; @c T must be @c const @c U).
+     * @param  m Const matrix to view.
+     *
+     * Allows creating a @c matrix_view<const T, contiguous, Dims...> (i.e. a
+     * @c const_matrix_view) from a @c const @c matrix<T, Dims...>&, mirroring
+     * how @c std::string_view can be constructed from a @c const @c std::string&.
+     *
+     * @code
+     * const ysc::matrix<int, 3> m{1, 2, 3};
+     * ysc::matrix_view<const int, ysc::contiguous, 3> v{m};
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    template <class U>
+        requires std::same_as<T, const U>
+    // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
+    constexpr matrix_view(const matrix<U, Dimensions...>& m) noexcept : _ptr{m.data()} {}
 
     /**
      * @brief Constructs a view from a raw pointer to a contiguous sequence of elements.
@@ -519,6 +547,112 @@ public:
      */
     constexpr void fill(const T& value) noexcept(std::is_nothrow_copy_assignable_v<T>) {
         std::fill(begin(), end(), value);
+    }
+
+    // ─── views (slice / row / col) ────────────────────────────────────────────
+
+    /**
+     * @brief Returns a non-owning sub-view over a hyperslice of this view.
+     * @tparam Specs Spec types: @c ysc::all_t to keep a dimension, any integral to fix it.
+     * @param  specs Per-dimension specs. Missing trailing specs are implicitly @c ysc::all.
+     * @return @c matrix_view<T,contiguous,KeptDims...> if fixed dims form a prefix;
+     *         @c matrix_view<T,strided,KeptDims...> otherwise.
+     * @throws std::out_of_range if any fixed index is out of bounds for its dimension.
+     *
+     * @code
+     * ysc::matrix<int, 3, 4> m{};
+     * auto row0 = m.row(0);        // matrix_view<int, contiguous, 4>
+     * auto sub = row0.slice(2);    // matrix_view<int, contiguous, 2> — last 2 elements
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    template <typename... Specs>
+        requires(sizeof...(Specs) <= order) &&
+                ((std::same_as<Specs, all_t> || std::integral<Specs>) && ...) &&
+                (sizeof...(Specs) < order || (std::same_as<Specs, all_t> || ...))
+    [[nodiscard]] constexpr auto slice(Specs... specs) const {
+        using PaddedT = detail::pad_right_with_all_t<order, Specs...>;
+        using KeptDims = typename detail::filter_kept_dims<PaddedT, Dimensions...>::type;
+        constexpr bool is_prefix = detail::is_prefix_slice_v<PaddedT>;
+        using Storage = std::conditional_t<is_prefix, contiguous, strided>;
+        using ViewT = detail::make_matrix_view_t<T, Storage, KeptDims>;
+
+        std::array<std::size_t, order> spec_vals{};
+        {
+            std::size_t i = 0;
+            (
+                [&](auto s) {
+                    using S = std::remove_cvref_t<decltype(s)>;
+                    if constexpr (!detail::is_all_v<S>) {
+                        auto idx = static_cast<std::size_t>(s);
+                        if (idx >= dimensions[i]) {
+                            throw std::out_of_range("slice: index out of range");
+                        }
+                        spec_vals[i] = idx;
+                    }
+                    ++i;
+                }(specs),
+                ...);
+        }
+
+        auto* base = _ptr + detail::slice_helper<PaddedT>::offset(dimensions, spec_vals);
+        if constexpr (is_prefix) {
+            return ViewT{base};
+        } else {
+            return ViewT{base, detail::slice_helper<PaddedT>::strides(dimensions)};
+        }
+    }
+
+    /**
+     * @brief Returns a contiguous sub-view over row @a i (2D views only).
+     * @tparam D Deduced from @c order; constrained to 2 — do not specify explicitly.
+     * @param i  Row index (0-based).
+     * @return @c matrix_view<T,contiguous,C> where @c C = @c dimensions[1]
+     * @throws std::out_of_range if @a i >= @c dimensions[0].
+     *
+     * @code
+     * ysc::matrix<int, 3, 4> m{};
+     * auto v2d = m.flatten().reshape<3, 4>();
+     * auto r   = v2d.row(1);  // contiguous view of row 1 — 4 elements
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    template <std::size_t D = order>
+        requires(D == 2)
+    [[nodiscard]] constexpr auto row(std::size_t i) const {
+        if (i >= dimensions[0]) {
+            throw std::out_of_range("row: index out of range");
+        }
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        return matrix_view<T, contiguous, dimensions[1]>{_ptr + (i * dimensions[1])};
+    }
+
+    /**
+     * @brief Returns a strided sub-view over column @a j (2D views only).
+     * @tparam D Deduced from @c order; constrained to 2 — do not specify explicitly.
+     * @param j  Column index (0-based).
+     * @return @c matrix_view<T,strided,R> where @c R = @c dimensions[0], stride = @c dimensions[1]
+     * @throws std::out_of_range if @a j >= @c dimensions[1].
+     *
+     * @code
+     * ysc::matrix<int, 3, 4> m{};
+     * auto v2d = m.flatten().reshape<3, 4>();
+     * auto c   = v2d.col(2);  // strided view of column 2 — 3 elements, stride 4
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    template <std::size_t D = order>
+        requires(D == 2)
+    [[nodiscard]] constexpr auto col(std::size_t j) const {
+        if (j >= dimensions[1]) {
+            throw std::out_of_range("col: index out of range");
+        }
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        return matrix_view<T, strided, dimensions[0]>{_ptr + j,
+                                                      std::array<std::size_t, 1>{dimensions[1]}};
     }
 };
 
@@ -1178,6 +1312,70 @@ matrix_view<T, contiguous, Dimensions...>::operator matrix_view<T, strided, Dime
     return matrix_view<T, strided, Dimensions...>{_ptr, strides};
 }
 
+/**
+ * @brief Writes a contiguous matrix view to an output stream.
+ * @tparam T    Element type — must be writable to @c std::ostream via @c operator<<
+ * @tparam Dims Dimensions of the view
+ * @param  os   Destination stream
+ * @param  v    View to print
+ * @return @a os
+ *
+ * Produces nested bracket notation: @c [e0, e1, ...] for 1D,
+ * @c [[e00, e01], [e10, e11]] for 2D, and so on recursively.
+ * The output format is identical to that of @c operator<<(ostream, matrix).
+ *
+ * @code
+ * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+ * std::cout << m.row(0);  // [1, 2, 3]
+ * @endcode
+ *
+ * @ingroup ysc_io
+ */
+template <class T, std::size_t... Dims>
+    requires detail::ostream_streamable<T>
+std::ostream& operator<<(std::ostream& os, const matrix_view<T, contiguous, Dims...>& v) {
+    detail::print_recursive(os, v.cbegin(), matrix_view<T, contiguous, Dims...>::dimensions,
+                            std::size_t{0});
+    return os;
+}
+
 } // namespace ysc
+
+#if defined(__cpp_lib_format) && __cpp_lib_format >= 201907L
+#if !defined(__clang__) || __clang_major__ >= 17
+
+/**
+ * @brief Specialization of @c std::formatter for @c ysc::matrix_view (contiguous).
+ * @tparam T     Element type — must be streamable via @c operator<<(std::ostream&, const T&)
+ * @tparam Dims  Dimensions of the view
+ * @tparam CharT Character type for the format context
+ *
+ * Enables @c std::format("{}", v) and produces the same nested-bracket output as
+ * @c operator<<: @c [e0, e1, ...] for 1D, @c [[e00, e01], [e10, e11]] for 2D, etc.
+ *
+ * Only available when the @c <format> library feature is present
+ * (@c __cpp_lib_format >= 201907L) and the compiler is not Clang < 17.
+ *
+ * @code
+ * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+ * std::string s = std::format("{}", m.row(0));  // "[1, 2, 3]"
+ * @endcode
+ *
+ * @ingroup ysc_io
+ */
+template <class T, std::size_t... Dims, class CharT>
+    requires ysc::detail::ostream_streamable<T>
+struct std::formatter<ysc::matrix_view<T, ysc::contiguous, Dims...>, CharT>
+    : std::formatter<std::string, CharT> {
+    template <class FormatContext>
+    auto format(const ysc::matrix_view<T, ysc::contiguous, Dims...>& v, FormatContext& ctx) const {
+        std::ostringstream oss;
+        oss << v;
+        return std::formatter<std::string, CharT>::format(oss.str(), ctx);
+    }
+};
+
+#endif // !defined(__clang__) || __clang_major__ >= 17
+#endif // defined(__cpp_lib_format) && __cpp_lib_format >= 201907L
 
 #endif // YSC_MATRIX_VIEW_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(${TARGET_NAME}
     src/matmul.cpp
     src/matrix_from_view.cpp
     src/matrix_view.cpp
+    src/matrix_view_io.cpp
     src/reshape.cpp
     src/slice.cpp
     src/ostream.cpp

--- a/test/src/matrix_view_io.cpp
+++ b/test/src/matrix_view_io.cpp
@@ -1,0 +1,178 @@
+#include <matrix.hpp>
+#include <matrix_view.hpp>
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+#include <type_traits>
+
+// ─── static assertions: const_matrix_view alias ──────────────────────────────
+
+static_assert(
+    std::same_as<ysc::const_matrix_view<int, 3>, ysc::matrix_view<const int, ysc::contiguous, 3>>);
+static_assert(std::same_as<ysc::const_matrix_view<int, 2, 3>,
+                           ysc::matrix_view<const int, ysc::contiguous, 2, 3>>);
+
+// ─── operator<< for matrix_view<T, contiguous, Dims...> ──────────────────────
+
+TEST(matrix_view_io, ostream_1d) {
+    ysc::matrix<int, 3> m{1, 2, 3};
+    auto v = m.flatten();
+    std::ostringstream oss;
+    oss << v;
+    ASSERT_EQ(oss.str(), "[1, 2, 3]");
+}
+
+TEST(matrix_view_io, ostream_2d) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    auto v = m.reshape<2, 3>();
+    std::ostringstream oss;
+    oss << v;
+    ASSERT_EQ(oss.str(), "[[1, 2, 3], [4, 5, 6]]");
+}
+
+TEST(matrix_view_io, ostream_row) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    std::ostringstream oss;
+    oss << m.row(0);
+    ASSERT_EQ(oss.str(), "[1, 2, 3]");
+}
+
+TEST(matrix_view_io, ostream_matches_matrix) {
+    ysc::matrix<int, 2, 3> m{10, 20, 30, 40, 50, 60};
+    std::ostringstream oss_m;
+    std::ostringstream oss_v;
+    oss_m << m;
+    oss_v << m.reshape<2, 3>();
+    ASSERT_EQ(oss_m.str(), oss_v.str());
+}
+
+TEST(matrix_view_io, ostream_chaining) {
+    ysc::matrix<int, 2> m{7, 8};
+    auto v = m.flatten();
+    std::ostringstream oss;
+    oss << v << "!";
+    ASSERT_EQ(oss.str(), "[7, 8]!");
+}
+
+TEST(matrix_view_io, ostream_const_view) {
+    const ysc::matrix<int, 3> m{1, 2, 3};
+    ysc::const_matrix_view<int, 3> v{m};
+    std::ostringstream oss;
+    oss << v;
+    ASSERT_EQ(oss.str(), "[1, 2, 3]");
+}
+
+// ─── const ctor (matrix_view<const T, contiguous, ...>) ──────────────────────
+
+TEST(matrix_view_io, const_view_from_const_matrix) {
+    const ysc::matrix<int, 3, 3> m{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    ysc::const_matrix_view<int, 3, 3> v{m};
+    ASSERT_EQ(v(0, 0), 1);
+    ASSERT_EQ(v(1, 1), 5);
+    ASSERT_EQ(v(2, 2), 9);
+}
+
+TEST(matrix_view_io, const_view_alias) {
+    const ysc::matrix<int, 3> m{10, 20, 30};
+    ysc::const_matrix_view<int, 3> v{m};
+    ASSERT_EQ(v(0), 10);
+    ASSERT_EQ(v(2), 30);
+}
+
+TEST(matrix_view_io, const_view_reflects_mutations) {
+    ysc::matrix<int, 3> m{1, 2, 3};
+    const ysc::matrix<int, 3>& cm = m;
+    ysc::const_matrix_view<int, 3> v{cm};
+    ASSERT_EQ(v(0), 1);
+    m(0) = 99;
+    ASSERT_EQ(v(0), 99); // view sees the updated value
+}
+
+// ─── slice() on matrix_view<T, contiguous, ...> ──────────────────────────────
+
+TEST(matrix_view_io, contiguous_view_slice_prefix) {
+    ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    auto v2d = m.reshape<3, 4>();
+    // slice(0) on a 2D view → fix first dim → contiguous view of 4 elements
+    auto row0 = v2d.slice(0);
+    static_assert(std::same_as<decltype(row0), ysc::matrix_view<int, ysc::contiguous, 4>>);
+    ASSERT_EQ(row0(0), 1);
+    ASSERT_EQ(row0(3), 4);
+}
+
+TEST(matrix_view_io, contiguous_view_slice_non_prefix) {
+    ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    auto v2d = m.reshape<3, 4>();
+    // slice(all, 1) on a 2D view → fix second dim → strided view of 3 elements
+    auto col1 = v2d.slice(ysc::all, 1);
+    static_assert(std::same_as<decltype(col1), ysc::matrix_view<int, ysc::strided, 3>>);
+    ASSERT_EQ(col1(0), 2);
+    ASSERT_EQ(col1(1), 6);
+    ASSERT_EQ(col1(2), 10);
+}
+
+TEST(matrix_view_io, contiguous_view_row) {
+    ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    auto v2d = m.reshape<3, 4>();
+    auto r1 = v2d.row(1);
+    static_assert(std::same_as<decltype(r1), ysc::matrix_view<int, ysc::contiguous, 4>>);
+    ASSERT_EQ(r1(0), 5);
+    ASSERT_EQ(r1(3), 8);
+}
+
+TEST(matrix_view_io, contiguous_view_col) {
+    ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    auto v2d = m.reshape<3, 4>();
+    auto c2 = v2d.col(2);
+    static_assert(std::same_as<decltype(c2), ysc::matrix_view<int, ysc::strided, 3>>);
+    ASSERT_EQ(c2(0), 3);
+    ASSERT_EQ(c2(1), 7);
+    ASSERT_EQ(c2(2), 11);
+}
+
+TEST(matrix_view_io, contiguous_view_row_out_of_range) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    auto v = m.reshape<2, 3>();
+    // NOLINTNEXTLINE(bugprone-unused-return-value,clang-analyzer-cplusplus.Move)
+    ASSERT_THROW({ auto r = v.row(2); }, std::out_of_range);
+}
+
+TEST(matrix_view_io, contiguous_view_col_out_of_range) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    auto v = m.reshape<2, 3>();
+    // NOLINTNEXTLINE(bugprone-unused-return-value,clang-analyzer-cplusplus.Move)
+    ASSERT_THROW({ auto c = v.col(3); }, std::out_of_range);
+}
+
+// ─── std::formatter for matrix_view<T, contiguous, Dims...> ──────────────────
+
+#if defined(__cpp_lib_format) && __cpp_lib_format >= 201907L
+#include <format>
+
+TEST(matrix_view_io, formatter_1d) {
+    ysc::matrix<int, 3> m{1, 2, 3};
+    ASSERT_EQ(std::format("{}", m.flatten()), "[1, 2, 3]");
+}
+
+TEST(matrix_view_io, formatter_2d_row) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    ASSERT_EQ(std::format("{}", m.row(0)), "[1, 2, 3]");
+    ASSERT_EQ(std::format("{}", m.row(1)), "[4, 5, 6]");
+}
+
+TEST(matrix_view_io, formatter_matches_ostream) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    auto v = m.reshape<2, 3>();
+    std::ostringstream oss;
+    oss << v;
+    ASSERT_EQ(std::format("{}", v), oss.str());
+}
+
+#else
+
+TEST(matrix_view_io, formatter_not_available) {
+    GTEST_SKIP() << "std::format not available on this compiler";
+}
+
+#endif // defined(__cpp_lib_format) && __cpp_lib_format >= 201907L

--- a/test/src/matrix_view_io.cpp
+++ b/test/src/matrix_view_io.cpp
@@ -145,6 +145,32 @@ TEST(matrix_view_io, contiguous_view_col_out_of_range) {
     ASSERT_THROW({ auto c = v.col(3); }, std::out_of_range);
 }
 
+TEST(matrix_view_io, contiguous_view_slice_out_of_range) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    auto v = m.reshape<2, 3>();
+    // Fix first dim with an out-of-bounds index → throws
+    // NOLINTNEXTLINE(bugprone-unused-return-value,clang-analyzer-cplusplus.Move)
+    ASSERT_THROW({ auto s = v.slice(5); }, std::out_of_range);
+}
+
+TEST(matrix_view_io, contiguous_view_slice_non_prefix_out_of_range) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    auto v = m.reshape<2, 3>();
+    // Fix second dim with an out-of-bounds index → throws
+    // NOLINTNEXTLINE(bugprone-unused-return-value,clang-analyzer-cplusplus.Move)
+    ASSERT_THROW({ auto s = v.slice(ysc::all, 10); }, std::out_of_range);
+}
+
+TEST(matrix_view_io, contiguous_view_slice_all_dims) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    auto v = m.reshape<2, 3>();
+    // slice(all, all) — all specs are all_t, no bounds check, prefix pattern → contiguous view
+    auto s = v.slice(ysc::all, ysc::all);
+    static_assert(std::same_as<decltype(s), ysc::matrix_view<int, ysc::contiguous, 2, 3>>);
+    ASSERT_EQ(s(0, 0), 1);
+    ASSERT_EQ(s(1, 2), 6);
+}
+
 // ─── std::formatter for matrix_view<T, contiguous, Dims...> ──────────────────
 
 #if defined(__cpp_lib_format) && __cpp_lib_format >= 201907L


### PR DESCRIPTION
## Résumé

Ajoute `operator<<` et `std::formatter` pour `matrix_view<T, contiguous, ...>`,
un constructeur vers vue read-only depuis `const matrix<T,...>&`, l'alias
`const_matrix_view`, et les méthodes `slice()`/`row()`/`col()` sur les vues
contiguës pour permettre le chaînage.

Pour résoudre la dépendance sans circularité, `print_recursive` et
`ostream_streamable` ont été déplacés de `matrix.hpp` vers `matrix_detail.hpp`
(qui est inclus en premier par les deux autres headers).

## Critères d'acceptation

- [x] `std::cout << m.row(0)` compile et affiche la vue
- [x] `std::format("{}", m.row(0))` compile (sous guard `__cpp_lib_format`)
- [x] `const matrix<int,3,3> cm{...}; const_matrix_view<int,3,3> v{cm};` compile
- [x] `v.slice(1)` sur une `matrix_view<T, contiguous, ...>` retourne une nouvelle vue
- [x] `const_matrix_view<int,3>` est un alias valide

## Décisions d'implémentation

- `print_recursive` déplacé dans `matrix_detail.hpp` (centralisation) ;
  supprimé de `matrix.hpp` où il était dupliqué.
- Le constructeur const utilise `requires std::same_as<T, const U>` pour
  que `matrix_view<int, ...>` ne soit pas construit depuis `const matrix<int,...>&`
  (seul `matrix_view<const int, ...>` l'accepte).
- `slice()`/`row()`/`col()` sur la vue contiguë sont `const` : ils ne modifient
  pas le pointeur de la vue, ils créent une nouvelle vue.
- 20 tests dans `test/src/matrix_view_io.cpp` couvrent tous les critères.