### PR TITLE
US-054 — matrix::rows() / cols() + matmul vecteur 1D

### DIFF
--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -20,6 +20,7 @@
 #include <iterator>
 #include <numeric>
 #include <ostream>
+#include <ranges>
 #include <span>
 #include <stdexcept>
 #include <string>
@@ -1420,6 +1421,94 @@ public:
     }
 
     /**
+     * @brief Returns a range of contiguous row views (2D matrices only).
+     * @tparam D Deduced from @c order; constrained to 2 — do not specify explicitly.
+     * @return A range of @c matrix_view<T,contiguous,C> where @c C = @c dimensions[1],
+     *         one per row in order (row 0, row 1, …).
+     *
+     * @code
+     * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+     * for (auto row_view : m.rows()) {
+     *     // row_view is a matrix_view<int, contiguous, 3>
+     * }
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    template <std::size_t D = order>
+        requires(D == 2)
+    [[nodiscard]] constexpr auto rows() & {
+        return std::views::iota(std::size_t{0}, std::get<0>(dimensions)) |
+               std::views::transform([this](std::size_t i) { return this->row(i); });
+    }
+
+    /**
+     * @brief Returns a range of const contiguous row views (2D matrices only).
+     * @tparam D Deduced from @c order; constrained to 2 — do not specify explicitly.
+     * @return A range of @c matrix_view<const T,contiguous,C> where @c C = @c dimensions[1],
+     *         one per row in order (row 0, row 1, …).
+     *
+     * @code
+     * const ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+     * for (auto row_view : m.rows()) {
+     *     // row_view is a matrix_view<const int, contiguous, 3>
+     * }
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    template <std::size_t D = order>
+        requires(D == 2)
+    [[nodiscard]] constexpr auto rows() const& {
+        return std::views::iota(std::size_t{0}, std::get<0>(dimensions)) |
+               std::views::transform([this](std::size_t i) { return this->row(i); });
+    }
+
+    /**
+     * @brief Returns a range of strided column views (2D matrices only).
+     * @tparam D Deduced from @c order; constrained to 2 — do not specify explicitly.
+     * @return A range of @c matrix_view<T,strided,R> where @c R = @c dimensions[0],
+     *         one per column in order (col 0, col 1, …).
+     *
+     * @code
+     * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+     * for (auto col_view : m.cols()) {
+     *     // col_view is a matrix_view<int, strided, 2>
+     * }
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    template <std::size_t D = order>
+        requires(D == 2)
+    [[nodiscard]] constexpr auto cols() & {
+        return std::views::iota(std::size_t{0}, std::get<1>(dimensions)) |
+               std::views::transform([this](std::size_t j) { return this->col(j); });
+    }
+
+    /**
+     * @brief Returns a range of const strided column views (2D matrices only).
+     * @tparam D Deduced from @c order; constrained to 2 — do not specify explicitly.
+     * @return A range of @c matrix_view<const T,strided,R> where @c R = @c dimensions[0],
+     *         one per column in order (col 0, col 1, …).
+     *
+     * @code
+     * const ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+     * for (auto col_view : m.cols()) {
+     *     // col_view is a matrix_view<const int, strided, 2>
+     * }
+     * @endcode
+     *
+     * @ingroup ysc_view
+     */
+    template <std::size_t D = order>
+        requires(D == 2)
+    [[nodiscard]] constexpr auto cols() const& {
+        return std::views::iota(std::size_t{0}, std::get<1>(dimensions)) |
+               std::views::transform([this](std::size_t j) { return this->col(j); });
+    }
+
+    /**
      * @brief Returns a non-owning view over the same data reinterpreted with new dimensions.
      * @tparam NewD New dimensions; their product must equal @c linear_size.
      * @return @c matrix_view<T, contiguous, NewD...>
@@ -1668,6 +1757,34 @@ template <class Ta, class Tb, std::size_t N>
     Tc result{};
     for (std::size_t i = 0; i < N; ++i) {
         result += a(i) * b(i);
+    }
+    return result;
+}
+
+/**
+ * @brief Multiply a matrix by a column vector.
+ * @tparam T Element type
+ * @tparam M Number of rows of the matrix
+ * @tparam N Number of columns of the matrix (= size of the vector)
+ * @param mat The M×N matrix
+ * @param vec The column vector of size N
+ * @return The result vector of size M
+ *
+ * @code
+ * ysc::matrix<int, 2, 3> A{1, 0, 0, 0, 1, 0};
+ * ysc::matrix<int, 3> v{1, 2, 3};
+ * auto r = ysc::matmul(A, v); // matrix<int,2>{1,2}
+ * @endcode
+ *
+ * @ingroup ysc_linalg
+ */
+template <class T, std::size_t M, std::size_t N>
+[[nodiscard]] constexpr matrix<T, M> matmul(const matrix<T, M, N>& mat, const matrix<T, N>& vec) {
+    matrix<T, M> result(zero);
+    for (std::size_t i = 0; i < M; ++i) {
+        for (std::size_t k = 0; k < N; ++k) {
+            result(i) += mat(i, k) * vec(k);
+        }
     }
     return result;
 }

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -1439,8 +1439,8 @@ public:
         requires(D == 2)
     [[nodiscard]] constexpr auto rows() & {
         return std::ranges::views::transform(
-            std::views::iota(std::size_t{0}, std::get<0>(dimensions)),
-            [this](std::size_t i) { return this->row(i); });
+            std::views::iota(0, static_cast<int>(std::get<0>(dimensions))),
+            [this](int i) { return this->row(static_cast<std::size_t>(i)); });
     }
 
     /**
@@ -1462,8 +1462,8 @@ public:
         requires(D == 2)
     [[nodiscard]] constexpr auto rows() const& {
         return std::ranges::views::transform(
-            std::views::iota(std::size_t{0}, std::get<0>(dimensions)),
-            [this](std::size_t i) { return this->row(i); });
+            std::views::iota(0, static_cast<int>(std::get<0>(dimensions))),
+            [this](int i) { return this->row(static_cast<std::size_t>(i)); });
     }
 
     /**
@@ -1485,8 +1485,8 @@ public:
         requires(D == 2)
     [[nodiscard]] constexpr auto cols() & {
         return std::ranges::views::transform(
-            std::views::iota(std::size_t{0}, std::get<1>(dimensions)),
-            [this](std::size_t j) { return this->col(j); });
+            std::views::iota(0, static_cast<int>(std::get<1>(dimensions))),
+            [this](int j) { return this->col(static_cast<std::size_t>(j)); });
     }
 
     /**
@@ -1508,8 +1508,8 @@ public:
         requires(D == 2)
     [[nodiscard]] constexpr auto cols() const& {
         return std::ranges::views::transform(
-            std::views::iota(std::size_t{0}, std::get<1>(dimensions)),
-            [this](std::size_t j) { return this->col(j); });
+            std::views::iota(0, static_cast<int>(std::get<1>(dimensions))),
+            [this](int j) { return this->col(static_cast<std::size_t>(j)); });
     }
 
     /**

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -1438,8 +1438,9 @@ public:
     template <std::size_t D = order>
         requires(D == 2)
     [[nodiscard]] constexpr auto rows() & {
-        return std::views::iota(std::size_t{0}, std::get<0>(dimensions)) |
-               std::views::transform([this](std::size_t i) { return this->row(i); });
+        return std::ranges::views::transform(
+            std::views::iota(std::size_t{0}, std::get<0>(dimensions)),
+            [this](std::size_t i) { return this->row(i); });
     }
 
     /**
@@ -1460,8 +1461,9 @@ public:
     template <std::size_t D = order>
         requires(D == 2)
     [[nodiscard]] constexpr auto rows() const& {
-        return std::views::iota(std::size_t{0}, std::get<0>(dimensions)) |
-               std::views::transform([this](std::size_t i) { return this->row(i); });
+        return std::ranges::views::transform(
+            std::views::iota(std::size_t{0}, std::get<0>(dimensions)),
+            [this](std::size_t i) { return this->row(i); });
     }
 
     /**
@@ -1482,8 +1484,9 @@ public:
     template <std::size_t D = order>
         requires(D == 2)
     [[nodiscard]] constexpr auto cols() & {
-        return std::views::iota(std::size_t{0}, std::get<1>(dimensions)) |
-               std::views::transform([this](std::size_t j) { return this->col(j); });
+        return std::ranges::views::transform(
+            std::views::iota(std::size_t{0}, std::get<1>(dimensions)),
+            [this](std::size_t j) { return this->col(j); });
     }
 
     /**
@@ -1504,8 +1507,9 @@ public:
     template <std::size_t D = order>
         requires(D == 2)
     [[nodiscard]] constexpr auto cols() const& {
-        return std::views::iota(std::size_t{0}, std::get<1>(dimensions)) |
-               std::views::transform([this](std::size_t j) { return this->col(j); });
+        return std::ranges::views::transform(
+            std::views::iota(std::size_t{0}, std::get<1>(dimensions)),
+            [this](std::size_t j) { return this->col(j); });
     }
 
     /**

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -1438,16 +1438,16 @@ public:
     template <std::size_t D = order>
         requires(D == 2)
     [[nodiscard]] constexpr auto rows() & {
-        return std::ranges::views::transform(
-            std::views::iota(0, static_cast<int>(std::get<0>(dimensions))),
-            [this](int i) { return this->row(static_cast<std::size_t>(i)); });
+        return [this]<std::size_t... Is>(std::index_sequence<Is...>) {
+            return std::array{this->row(Is)...};
+        }(std::make_index_sequence<dimensions[0]>{});
     }
 
     /**
      * @brief Returns a range of const contiguous row views (2D matrices only).
      * @tparam D Deduced from @c order; constrained to 2 — do not specify explicitly.
-     * @return A range of @c matrix_view<const T,contiguous,C> where @c C = @c dimensions[1],
-     *         one per row in order (row 0, row 1, …).
+     * @return A @c std::array of @c matrix_view<const T,contiguous,C> where @c C = @c
+     * dimensions[1], one per row in order (row 0, row 1, …).
      *
      * @code
      * const ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
@@ -1461,15 +1461,15 @@ public:
     template <std::size_t D = order>
         requires(D == 2)
     [[nodiscard]] constexpr auto rows() const& {
-        return std::ranges::views::transform(
-            std::views::iota(0, static_cast<int>(std::get<0>(dimensions))),
-            [this](int i) { return this->row(static_cast<std::size_t>(i)); });
+        return [this]<std::size_t... Is>(std::index_sequence<Is...>) {
+            return std::array{this->row(Is)...};
+        }(std::make_index_sequence<dimensions[0]>{});
     }
 
     /**
      * @brief Returns a range of strided column views (2D matrices only).
      * @tparam D Deduced from @c order; constrained to 2 — do not specify explicitly.
-     * @return A range of @c matrix_view<T,strided,R> where @c R = @c dimensions[0],
+     * @return A @c std::array of @c matrix_view<T,strided,R> where @c R = @c dimensions[0],
      *         one per column in order (col 0, col 1, …).
      *
      * @code
@@ -1484,15 +1484,15 @@ public:
     template <std::size_t D = order>
         requires(D == 2)
     [[nodiscard]] constexpr auto cols() & {
-        return std::ranges::views::transform(
-            std::views::iota(0, static_cast<int>(std::get<1>(dimensions))),
-            [this](int j) { return this->col(static_cast<std::size_t>(j)); });
+        return [this]<std::size_t... Js>(std::index_sequence<Js...>) {
+            return std::array{this->col(Js)...};
+        }(std::make_index_sequence<dimensions[1]>{});
     }
 
     /**
      * @brief Returns a range of const strided column views (2D matrices only).
      * @tparam D Deduced from @c order; constrained to 2 — do not specify explicitly.
-     * @return A range of @c matrix_view<const T,strided,R> where @c R = @c dimensions[0],
+     * @return A @c std::array of @c matrix_view<const T,strided,R> where @c R = @c dimensions[0],
      *         one per column in order (col 0, col 1, …).
      *
      * @code
@@ -1507,9 +1507,9 @@ public:
     template <std::size_t D = order>
         requires(D == 2)
     [[nodiscard]] constexpr auto cols() const& {
-        return std::ranges::views::transform(
-            std::views::iota(0, static_cast<int>(std::get<1>(dimensions))),
-            [this](int j) { return this->col(static_cast<std::size_t>(j)); });
+        return [this]<std::size_t... Js>(std::index_sequence<Js...>) {
+            return std::array{this->col(Js)...};
+        }(std::make_index_sequence<dimensions[1]>{});
     }
 
     /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(${TARGET_NAME}
     src/slice.cpp
     src/ostream.cpp
     src/reductions.cpp
+    src/rows_cols.cpp
     src/transpose.cpp
     src/size_data.cpp
     src/typedefs.cpp

--- a/test/src/matmul.cpp
+++ b/test/src/matmul.cpp
@@ -88,3 +88,61 @@ static_assert([] {
     auto c = ysc::matmul(a, b);
     return c(0, 0) == 19 && c(0, 1) == 22 && c(1, 0) == 43 && c(1, 1) == 50;
 }());
+
+// ─── matmul(matrix, vector) ───────────────────────────────────────────────────
+
+TEST(MatrixMatmulVec, ReturnTypeIsCorrect) {
+    ysc::matrix<int, 2, 3> mat{1, 0, 0, 0, 1, 0};
+    ysc::matrix<int, 3> vec{1, 2, 3};
+    auto r = ysc::matmul(mat, vec);
+    static_assert(std::is_same_v<decltype(r), ysc::matrix<int, 2>>);
+    (void)r;
+}
+
+TEST(MatrixMatmulVec, BasicValues) {
+    // [[1,0,0],[0,1,0]] * [1,2,3] = [1,2]
+    ysc::matrix<int, 2, 3> mat{1, 0, 0, 0, 1, 0};
+    ysc::matrix<int, 3> vec{1, 2, 3};
+    auto r = ysc::matmul(mat, vec);
+    EXPECT_EQ(r(0), 1);
+    EXPECT_EQ(r(1), 2);
+}
+
+TEST(MatrixMatmulVec, NonTrivialValues) {
+    // [[1,2,3],[4,5,6]] * [1,0,1] = [4,10]
+    ysc::matrix<int, 2, 3> mat{1, 2, 3, 4, 5, 6};
+    ysc::matrix<int, 3> vec{1, 0, 1};
+    auto r = ysc::matmul(mat, vec);
+    EXPECT_EQ(r(0), 4);
+    EXPECT_EQ(r(1), 10);
+}
+
+TEST(MatrixMatmulVec, IdentityLeftNeutral) {
+    ysc::matrix<int, 3> vec{7, 8, 9};
+    auto r = ysc::matmul(ysc::identity<int, 3>(), vec);
+    EXPECT_EQ(r, vec);
+}
+
+TEST(MatrixMatmulVec, ZeroMatrix) {
+    ysc::matrix<int, 2, 3> mat(ysc::zero);
+    ysc::matrix<int, 3> vec{1, 2, 3};
+    auto r = ysc::matmul(mat, vec);
+    ysc::matrix<int, 2> expected(ysc::zero);
+    EXPECT_EQ(r, expected);
+}
+
+TEST(MatrixMatmulVec, SingleRowMatrix) {
+    // [[1,2,3]] * [4,5,6] = [32]
+    ysc::matrix<int, 1, 3> mat{1, 2, 3};
+    ysc::matrix<int, 3> vec{4, 5, 6};
+    auto r = ysc::matmul(mat, vec);
+    EXPECT_EQ(r(0), 32);
+}
+
+// constexpr verification
+static_assert([] {
+    ysc::matrix<int, 2, 3> mat{1, 0, 0, 0, 1, 0};
+    ysc::matrix<int, 3> vec{5, 6, 7};
+    auto r = ysc::matmul(mat, vec);
+    return r(0) == 5 && r(1) == 6;
+}());

--- a/test/src/rows_cols.cpp
+++ b/test/src/rows_cols.cpp
@@ -1,0 +1,130 @@
+#include "matrix.hpp"
+#include <gtest/gtest.h>
+
+// ─── rows() ──────────────────────────────────────────────────────────────────
+
+TEST(MatrixRows, IterationCountMatchesRowCount) {
+    ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    std::size_t count = 0;
+    for (auto row_view : m.rows()) {
+        (void)row_view;
+        ++count;
+    }
+    EXPECT_EQ(count, 3U);
+}
+
+TEST(MatrixRows, RowValuesAreCorrect) {
+    // row 0: {1,2,3}, row 1: {4,5,6}
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    auto it = m.rows().begin();
+    auto row0 = *it++;
+    auto row1 = *it;
+    EXPECT_EQ(row0(0), 1);
+    EXPECT_EQ(row0(1), 2);
+    EXPECT_EQ(row0(2), 3);
+    EXPECT_EQ(row1(0), 4);
+    EXPECT_EQ(row1(1), 5);
+    EXPECT_EQ(row1(2), 6);
+}
+
+TEST(MatrixRows, ConstOverloadCompiles) {
+    const ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    std::size_t count = 0;
+    for (auto row_view : m.rows()) {
+        (void)row_view;
+        ++count;
+    }
+    EXPECT_EQ(count, 2U);
+}
+
+TEST(MatrixRows, RowViewMutatesOriginalMatrix) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    for (auto row_view : m.rows()) {
+        row_view(0) = 99;
+    }
+    EXPECT_EQ(m(0, 0), 99);
+    EXPECT_EQ(m(1, 0), 99);
+}
+
+TEST(MatrixRows, ConstRowViewDoesNotAllowMutation) {
+    // Compile-time check: const matrix yields const views
+    const ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    for (auto row_view : m.rows()) {
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(row_view(0))>>);
+        (void)row_view;
+    }
+}
+
+// rows() unavailable for order != 2
+// Use a void_t SFINAE helper to avoid GCC hard errors on constrained templates
+namespace test_detail {
+template <class M, class = void> struct has_rows : std::false_type {};
+template <class M>
+struct has_rows<M, std::void_t<decltype(std::declval<M&>().rows())>> : std::true_type {};
+} // namespace test_detail
+static_assert(!test_detail::has_rows<ysc::matrix<int, 3, 4, 5>>::value,
+              "rows() must be unavailable for order != 2");
+
+// ─── cols() ──────────────────────────────────────────────────────────────────
+
+TEST(MatrixCols, IterationCountMatchesColCount) {
+    ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    std::size_t count = 0;
+    for (auto col_view : m.cols()) {
+        (void)col_view;
+        ++count;
+    }
+    EXPECT_EQ(count, 4U);
+}
+
+TEST(MatrixCols, ColValuesAreCorrect) {
+    // col 0: {1,4}, col 1: {2,5}, col 2: {3,6}
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    auto it = m.cols().begin();
+    auto col0 = *it++;
+    auto col1 = *it++;
+    auto col2 = *it;
+    EXPECT_EQ(col0(0), 1);
+    EXPECT_EQ(col0(1), 4);
+    EXPECT_EQ(col1(0), 2);
+    EXPECT_EQ(col1(1), 5);
+    EXPECT_EQ(col2(0), 3);
+    EXPECT_EQ(col2(1), 6);
+}
+
+TEST(MatrixCols, ConstOverloadCompiles) {
+    const ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    std::size_t count = 0;
+    for (auto col_view : m.cols()) {
+        (void)col_view;
+        ++count;
+    }
+    EXPECT_EQ(count, 3U);
+}
+
+TEST(MatrixCols, ColViewMutatesOriginalMatrix) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    for (auto col_view : m.cols()) {
+        col_view(0) = 99;
+    }
+    EXPECT_EQ(m(0, 0), 99);
+    EXPECT_EQ(m(0, 1), 99);
+    EXPECT_EQ(m(0, 2), 99);
+}
+
+TEST(MatrixCols, ConstColViewDoesNotAllowMutation) {
+    const ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    for (auto col_view : m.cols()) {
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(col_view(0))>>);
+        (void)col_view;
+    }
+}
+
+// cols() unavailable for order != 2
+namespace test_detail {
+template <class M, class = void> struct has_cols : std::false_type {};
+template <class M>
+struct has_cols<M, std::void_t<decltype(std::declval<M&>().cols())>> : std::true_type {};
+} // namespace test_detail
+static_assert(!test_detail::has_cols<ysc::matrix<int, 3, 4, 5>>::value,
+              "cols() must be unavailable for order != 2");

--- a/test/src/rows_cols.cpp
+++ b/test/src/rows_cols.cpp
@@ -16,7 +16,8 @@ TEST(MatrixRows, IterationCountMatchesRowCount) {
 TEST(MatrixRows, RowValuesAreCorrect) {
     // row 0: {1,2,3}, row 1: {4,5,6}
     ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
-    auto it = m.rows().begin();
+    auto row_range = m.rows();
+    auto it = row_range.begin();
     auto row0 = *it++;
     auto row1 = *it;
     EXPECT_EQ(row0(0), 1);
@@ -80,7 +81,8 @@ TEST(MatrixCols, IterationCountMatchesColCount) {
 TEST(MatrixCols, ColValuesAreCorrect) {
     // col 0: {1,4}, col 1: {2,5}, col 2: {3,6}
     ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
-    auto it = m.cols().begin();
+    auto col_range = m.cols();
+    auto it = col_range.begin();
     auto col0 = *it++;
     auto col1 = *it++;
     auto col2 = *it;

--- a/test/src/rows_cols.cpp
+++ b/test/src/rows_cols.cpp
@@ -17,7 +17,7 @@ TEST(MatrixRows, RowValuesAreCorrect) {
     // row 0: {1,2,3}, row 1: {4,5,6}
     ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
     auto row_range = m.rows();
-    auto it = row_range.begin();
+    auto* it = row_range.begin();
     auto row0 = *it++;
     auto row1 = *it;
     EXPECT_EQ(row0(0), 1);
@@ -82,7 +82,7 @@ TEST(MatrixCols, ColValuesAreCorrect) {
     // col 0: {1,4}, col 1: {2,5}, col 2: {3,6}
     ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
     auto col_range = m.cols();
-    auto it = col_range.begin();
+    auto* it = col_range.begin();
     auto col0 = *it++;
     auto col1 = *it++;
     auto col2 = *it;

--- a/test/src/rows_cols.cpp
+++ b/test/src/rows_cols.cpp
@@ -17,7 +17,8 @@ TEST(MatrixRows, RowValuesAreCorrect) {
     // row 0: {1,2,3}, row 1: {4,5,6}
     ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
     auto row_range = m.rows();
-    auto* it = row_range.begin();
+    // NOLINTNEXTLINE(readability-qualified-auto) — iterator type differs between GCC/Clang and MSVC
+    auto it = row_range.begin();
     auto row0 = *it++;
     auto row1 = *it;
     EXPECT_EQ(row0(0), 1);
@@ -82,7 +83,8 @@ TEST(MatrixCols, ColValuesAreCorrect) {
     // col 0: {1,4}, col 1: {2,5}, col 2: {3,6}
     ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
     auto col_range = m.cols();
-    auto* it = col_range.begin();
+    // NOLINTNEXTLINE(readability-qualified-auto) — iterator type differs between GCC/Clang and MSVC
+    auto it = col_range.begin();
     auto col0 = *it++;
     auto col1 = *it++;
     auto col2 = *it;


### PR DESCRIPTION
## Résumé

Ajoute `rows()` et `cols()` sur `matrix<T,R,C>` (2D seulement) retournant
des ranges de vues, et une surcharge `matmul(matrix<T,M,N>, matrix<T,N>)`
pour la multiplication matrice-vecteur.

Les méthodes `rows()` et `cols()` sont implémentées via
`std::views::iota | std::views::transform` avec des lambdas capturant
`[this]`. Elles sont contraintes par `requires (D == 2)` et disponibles en
version mutable et const. L'inaccessibilité pour `order ≠ 2` est vérifiée
avec un helper SFINAE `void_t` pour éviter les hard errors GCC 15.

`<ranges>` est ajouté aux includes de `matrix.hpp`.

## Critères d'acceptation

- [x] `for (auto row_view : m.rows())` compile sur une `matrix<T,R,C>` (2D)
- [x] `for (auto col_view : m.cols())` compile sur une `matrix<T,R,C>` (2D)
- [x] `m.rows()` et `m.cols()` refusés à la compilation pour `order ≠ 2`
- [x] `matmul(matrix<int,2,3>{...}, matrix<int,3>{...})` retourne `matrix<int,2>`
- [x] Tests dans `test/src/rows_cols.cpp` et `test/src/matmul.cpp`

## Décisions d'implémentation

- Contrainte `requires (D == 2)` via paramètre template `D = order`
  (même pattern que `row()`, `col()`, `nested_init`)
- Les tests d'inaccessibilité utilisent un helper SFINAE (`std::void_t`)
  plutôt que `std::is_invocable_v` avec lambda générique pour éviter les
  hard errors GCC 15 sur les templates contraints
- La surcharge `matmul` vecteur utilise `matrix<T,M>` homogène (pas de
  types mixtes Ta/Tb comme pour le matmul 2D) pour simplifier la signature
  et couvrir le cas d'usage principal