### PR TITLE
fix(matmul): support mixed types Ta/Tb in matmul(matrix, vector)

### DIFF
--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -12,11 +12,11 @@
 | **F — Arithmétique** | ✅ Terminée | 4/4 | ✅ US-026, ✅ US-027, ✅ US-028, ✅ US-029 |
 | **G — Algorithmes** | ✅ Terminée | 5/5 | ✅ US-030, ✅ US-031, ✅ US-032, ✅ US-033, ✅ US-034 |
 | **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
-| **I — Packaging & préparation v1.0.0** | ⬜ Non démarrée | 0/10 | ⬜ US-038, US-040 à US-043, US-045 à US-049 |
-| **J — Ergonomie & finition** | 🔄 En cours | 6/11 | ✅ US-053, ✅ US-055 à ✅ US-057, ✅ US-059, ✅ US-039, US-050 à US-052, US-054, US-058 |
+| **I — Packaging & préparation v1.0.0** | 🔄 En cours | 1/10 | ✅ US-046, ⬜ US-038, US-040 à US-043, US-045, US-047 à US-049 |
+| **J — Ergonomie & finition** | 🔄 En cours | 9/11 | ✅ US-039, ✅ US-051 à ✅ US-059, US-050 |
 | **K — Extensions post-v1** | ⬜ Non démarrée | 0/9 | ⬜ US-060 à US-068 |
 
-**Total : 39 / 68 US**
+**Total : 43 / 68 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -40,7 +40,7 @@
 | US-042 | Tag `v1.0.0` | P0 (final) | ⬜ À faire |
 | US-043 | Documentation Doxygen complète | P1 | ⬜ À faire |
 | US-045 | Packaging CMake : cible `ysc-matrix`, alias, install, find_package | P0 | ⬜ À faire |
-| US-046 | Correctifs docs + `.gitignore` | P0 | ⬜ À faire |
+| US-046 | Correctifs docs + `.gitignore` | P0 | ✅ Done |
 | US-047 | README marketing + `mainpage.md` v1 | P0 | ⬜ À faire |
 | US-048 | Job CI consumer test | P0 | ⬜ À faire |
 | US-049 | Amalgamation auto-générée par CI | P0 | ⬜ À faire |
@@ -52,13 +52,13 @@
 | US-039 | Suite de benchmarks (Google Benchmark) | P1 | ✅ Done |
 | US-050 | Cookbook Doxygen | P1 | ⬜ À faire |
 | US-051 | `matrix_view` : itérateurs strided + `front`/`back`/`fill` | P1 | ✅ Done |
-| US-052 | `matrix_view` : I/O, ctor const, vues composables | P1 | ⬜ À faire |
+| US-052 | `matrix_view` : I/O, ctor const, vues composables | P1 | ✅ Done |
 | US-053 | Constructeurs additionnels : `std::array`, `std::span`, générateur | P1 | ✅ Done |
-| US-054 | `matrix::rows()` / `cols()` + `matmul` vecteur 1D | P1 | ⬜ À faire |
+| US-054 | `matrix::rows()` / `cols()` + `matmul` vecteur 1D | P1 | ✅ Done |
 | US-055 | `CHANGELOG.md` versionné | P1 | ✅ Done |
 | US-056 | Messages d'exception détaillés dans `at()` | P1 | ✅ Done |
 | US-057 | Centraliser `NOLINTNEXTLINE` dans `matrix.hpp` | P1 | ✅ Done |
-| US-058 | Optimiser `matrix(matrix_view<strided>)` | P1 | ⬜ À faire |
+| US-058 | Optimiser `matrix(matrix_view<strided>)` | P1 | ✅ Done |
 | US-059 | `operator-()` `constexpr` + hash combine 64-bit | P1 | ✅ Done |
 
 ## EPIC K — Extensions post-v1

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -1745,24 +1745,31 @@ template <class Ta, class Tb, std::size_t N>
 
 /**
  * @brief Multiply a matrix by a column vector.
- * @tparam T Element type
- * @tparam M Number of rows of the matrix
- * @tparam N Number of columns of the matrix (= size of the vector)
+ * @tparam Ta Element type of @a mat — must be multipliable with @a Tb
+ * @tparam Tb Element type of @a vec — must be multipliable with @a Ta
+ * @tparam M  Number of rows of @a mat and the result
+ * @tparam N  Number of columns of @a mat (= size of @a vec)
  * @param mat The M×N matrix
  * @param vec The column vector of size N
- * @return The result vector of size M
+ * @return New @c matrix<Tc,M> where `Tc = decltype(Ta{} * Tb{})`, equal to
+ * the matrix-vector product `mat × vec`
  *
  * @code
  * ysc::matrix<int, 2, 3> A{1, 0, 0, 0, 1, 0};
- * ysc::matrix<int, 3> v{1, 2, 3};
- * auto r = ysc::matmul(A, v); // matrix<int,2>{1,2}
+ * ysc::matrix<double, 3> v{1.0, 2.0, 3.0};
+ * auto r = ysc::matmul(A, v); // matrix<double,2>{1.0,2.0}
  * @endcode
  *
  * @ingroup ysc_linalg
  */
-template <class T, std::size_t M, std::size_t N>
-[[nodiscard]] constexpr matrix<T, M> matmul(const matrix<T, M, N>& mat, const matrix<T, N>& vec) {
-    matrix<T, M> result(zero);
+template <class Ta, class Tb, std::size_t M, std::size_t N>
+    requires std::invocable<std::multiplies<>, const Ta&, const Tb&> &&
+                 requires(std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&> tc,
+                          const Ta& a, const Tb& b) { tc += a * b; }
+[[nodiscard]] constexpr auto matmul(const matrix<Ta, M, N>& mat, const matrix<Tb, N>& vec)
+    -> matrix<std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>, M> {
+    using Tc = std::invoke_result_t<std::multiplies<>, const Ta&, const Tb&>;
+    matrix<Tc, M> result(zero);
     for (std::size_t i = 0; i < M; ++i) {
         for (std::size_t k = 0; k < N; ++k) {
             result(i) += mat(i, k) * vec(k);

--- a/test/src/matmul.cpp
+++ b/test/src/matmul.cpp
@@ -139,6 +139,18 @@ TEST(MatrixMatmulVec, SingleRowMatrix) {
     EXPECT_EQ(r(0), 32);
 }
 
+TEST(MatrixMatmulVec, MixedTypes) {
+    // [[1,2,3],[4,5,6]] * [0.5, 1.0, 1.5]
+    // row 0: 1*0.5 + 2*1.0 + 3*1.5 = 7.0
+    // row 1: 4*0.5 + 5*1.0 + 6*1.5 = 16.0
+    ysc::matrix<int, 2, 3> mat{1, 2, 3, 4, 5, 6};
+    ysc::matrix<double, 3> vec{0.5, 1.0, 1.5};
+    auto r = ysc::matmul(mat, vec);
+    static_assert(std::is_same_v<decltype(r), ysc::matrix<double, 2>>);
+    EXPECT_DOUBLE_EQ(r(0), 7.0);
+    EXPECT_DOUBLE_EQ(r(1), 16.0);
+}
+
 // constexpr verification
 static_assert([] {
     ysc::matrix<int, 2, 3> mat{1, 0, 0, 0, 1, 0};


### PR DESCRIPTION
## Résumé

Corrige un bug introduit par PR #87 (US-054) : la surcharge `matmul(matrix<T,M,N>, matrix<T,N>)` imposait un type unique `T` pour la matrice, le vecteur et le résultat. Cette restriction est trop forte et incohérente avec la surcharge 2D et `dot`, qui déduisent `Tc = decltype(Ta{} * Tb{})`.

La correction généralise la signature en `matmul(matrix<Ta,M,N>, matrix<Tb,N>) -> matrix<Tc,M>` avec les mêmes contraintes `requires` que les autres fonctions linéaires.

Un test `MatrixMatmulVec, MixedTypes` est ajouté pour couvrir le cas `matrix<int> × matrix<double> → matrix<double>`.

## Critères d'acceptation

- [x] `matmul(matrix<int,M,N>, matrix<double,N>)` compile et retourne `matrix<double,M>`
- [x] `static_assert(is_same_v<decltype(r), matrix<double,2>>)` vérifié dans le test
- [x] Tous les tests existants passent (types homogènes inchangés)
- [x] Dashboard mis à jour : US-046, US-052, US-054, US-058 marquées Done

## Décisions d'implémentation

- Même pattern `requires` que `matmul` 2D et `dot` — cohérence de l'API
- Trailing return type `-> matrix<Tc, M>` pour exposer le type au site d'appel