### PR TITLE
US-050 — Cookbook Doxygen

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ A **header-only C++20** template library providing a general-purpose multi-dimen
 container with static dimensions. Inspired by `std::array`, it extends it to N dimensions
 while keeping the same zero-overhead, `constexpr`-friendly design.
 
-Full API reference: [yscialom.github.io/matrix](https://yscialom.github.io/matrix/)
+Full API reference: [yscialom.github.io/matrix](https://yscialom.github.io/matrix/) —
+[Cookbook](https://yscialom.github.io/matrix/cookbook.html)
 
 ---
 

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -734,7 +734,8 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = @doxy_main_page@     \
+INPUT                  = @doxy_main_page@                          \
+                         @PROJECT_SOURCE_DIR@/doc/cookbook.md      \
                          @PROJECT_SOURCE_DIR@
 
 # This tag can be used to specify the character encoding of the source files
@@ -1344,7 +1345,7 @@ DISABLE_INDEX          = NO
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-GENERATE_TREEVIEW      = NO
+GENERATE_TREEVIEW      = YES
 
 # The ENUM_VALUES_PER_LINE tag can be used to set the number of enum values that
 # doxygen will group on one line in the generated HTML documentation.
@@ -1399,7 +1400,7 @@ FORMULA_TRANSPARENT    = YES
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-USE_MATHJAX            = NO
+USE_MATHJAX            = YES
 
 # When MathJax is enabled you can set the default output format to be used for
 # the MathJax output. See the MathJax site (see:

--- a/doc/cookbook.md
+++ b/doc/cookbook.md
@@ -3,226 +3,236 @@
 
 # Cookbook — Practical Recipes for `ysc::matrix`
 
-This page collects self-contained code snippets for common tasks.
-Each recipe is a complete, compilable example.
+Six self-contained recipes for the first things you will want to do with
+`ysc::matrix`. Each one also highlights a property of the library that sets it
+apart from raw C arrays, nested `std::array`, Eigen, or `std::mdspan`.
 
 ---
 
-## Iterating over rows and columns
+## 1. Hello, matrix
 
-Use `rows()` / `cols()` to obtain strided views, then iterate with a range-based `for`
-or any STL algorithm.
+Aggregate-initialize a matrix, mutate one element through `operator()`, and
+print it. Same syntax as a C array — but bounds-checking, comparison,
+iteration, and `std::format` come for free.
 
 ```cpp
 #include <matrix.hpp>
-#include <numeric>    // std::accumulate
 #include <iostream>
 
 int main()
 {
-    ysc::matrix<int, 3, 4> m = {
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-         9, 10, 11, 12
-    };
+    ysc::matrix<int, 2, 3> m = {1, 2, 3,
+                                4, 5, 6};
 
-    // Iterate over rows (contiguous views)
-    for (std::size_t i = 0; i < m.dimensions[0]; ++i)
-    {
-        auto row = m.rows(i);
-        for (int v : row)
-            std::cout << v << ' ';
-        std::cout << '\n';
-    }
+    // Unchecked write — fast path, UB out of bounds
+    m(1, 2) = 42;
 
-    // Sum of the second column (strided view)
-    auto col1 = m.cols(1);
-    int col_sum = std::accumulate(col1.begin(), col1.end(), 0);
-    // col_sum == 2 + 6 + 10 == 18
+    // Bounds-checked read — throws std::out_of_range on bad coordinates
+    int top_right = m.at(0, 2);
+
+    std::cout << "m = " << m << '\n';
+    std::cout << "m(0, 2) = " << top_right << '\n';
 }
 ```
 
----
-
-## Filling and transforming a matrix
-
-`fill()` resets all elements; `apply()` mutates in place; `map()` returns a new matrix.
-
-```cpp
-#include <matrix.hpp>
-#include <cmath>    // std::sqrt
-
-int main()
-{
-    ysc::matrix<double, 3, 3> m;
-
-    // Fill every element with the same value
-    m.fill(1.0);
-
-    // Mutate in place: square every element
-    m.apply([](double& x) { x *= x; });
-
-    // Produce a new matrix without touching the original
-    auto sq = m.map([](const double& x) { return std::sqrt(x); });
-
-    // Diagonal identity matrix
-    ysc::matrix<int, 3, 3> identity{};
-    identity.fill(0);
-    for (std::size_t i = 0; i < 3; ++i)
-        identity(i, i) = 1;
-}
-```
+> **Why it matters.** The storage is a `std::array<int, 6>` — same layout as
+> `int m[2][3]`, zero indirection, zero allocation. You only pay for what you
+> use.
 
 ---
 
-## Comparing matrices element-wise vs lexicographic
+## 2. Algebra at compile time
 
-`operator==` tests exact equality; `operator<=>` gives a lexicographic total order on the
-row-major storage.
+Every linear-algebra primitive is `constexpr`. Move invariants from the
+test suite into the build itself — broken dimensions or wrong values
+become compile errors, not runtime surprises.
 
 ```cpp
 #include <matrix.hpp>
 
 int main()
 {
-    ysc::matrix<int, 2, 3> a = {1, 2, 3, 4, 5, 6};
-    ysc::matrix<int, 2, 3> b = {1, 2, 3, 4, 5, 6};
-    ysc::matrix<int, 2, 3> c = {1, 2, 3, 4, 5, 7};
+    constexpr ysc::matrix<int, 3> u = {1, 2, 3};
+    constexpr ysc::matrix<int, 3> v = {4, 5, 6};
+    static_assert(ysc::dot(u, v) == 32);          // 1*4 + 2*5 + 3*6
 
-    bool eq  = (a == b);   // true  — all elements equal
-    bool neq = (a != c);   // true  — last element differs
-
-    // Lexicographic order (useful for sorted containers / std::sort)
-    bool lt  = (a < c);    // true  — a comes before c in row-major order
-    bool gt  = (c > a);    // true
-
-    // Element-wise predicate via apply / map
-    auto diff = a.map([&](const int& x) { return x; });  // copy of a
-    // To test element-wise inequality you can compare map results:
-    auto mask = a.map([&b_it = *b.cbegin()](const int&) { return 0; });
-    (void)eq; (void)neq; (void)lt; (void)gt; (void)diff; (void)mask;
+    constexpr ysc::matrix<int, 2, 2> A = {1, 2,
+                                          3, 4};
+    static_assert(ysc::transpose(A)(0, 1) == 3);  // A^T has 3 at (0,1)
+    static_assert(ysc::matmul(A, A)(0, 0) == 7);  // (A*A)(0,0) = 1+6
+    static_assert(A.sum() == 10);
 }
 ```
 
+> **Why it matters.** Neither Eigen nor `std::mdspan` lets you evaluate a
+> matrix product inside a `static_assert`. Here the whole API is `constexpr`,
+> so unit-test-grade checks run during compilation.
+
 ---
 
-## Working with views: contiguous vs strided
+## 3. Factory functions
 
-`slice()` / `row()` / `col()` yield lightweight non-owning views.
-Use `matrix_view<const T, ...>` (or the `const_matrix_view` alias) for read-only access.
+Five constexpr factories cover the matrices you most often need to type
+out by hand. All are type-safe and dimension-aware.
+
+```cpp
+#include <matrix.hpp>
+
+int main()
+{
+    constexpr auto zeros    = ysc::zeros<double, 3, 3>();              // all 0.0
+    constexpr auto ones     = ysc::ones<int, 4>();                     // {1,1,1,1}
+    constexpr auto pi_block = ysc::full<double, 2, 2>(3.14);           // every entry = 3.14
+    constexpr auto I        = ysc::identity<float, 3>();               // 3×3 identity
+    constexpr auto squares  = ysc::generate<int, 2, 3>(
+        [](std::size_t k) { return int(k * k); });                     // 0,1,4,9,16,25
+
+    static_assert(I(2, 2) == 1.0f);
+    static_assert(squares(1, 2) == 25);
+}
+```
+
+> **Why it matters.** All five live in the same header you already include,
+> all are `constexpr`, and all carry their dimensions in the type. No
+> `Eigen::MatrixXd::Identity(n, n)` runtime sizing surprise.
+
+---
+
+## 4. Map, reduce, transform
+
+Mutate in place with `apply`, build a new matrix with `map`, reduce with
+`sum` / `min` / `max` / `all` / `any`. No need to drop down to STL
+algorithms for the common cases.
+
+```cpp
+#include <matrix.hpp>
+#include <iostream>
+
+int main()
+{
+    ysc::matrix<double, 2, 3> m = {-2.0, -1.0, 0.0,
+                                    1.0,  2.0, 3.0};
+
+    // In-place: scale every element by 2
+    m.apply([](double& x) { x *= 2.0; });
+
+    // New matrix: square every element (note the changed value type below)
+    ysc::matrix<double, 2, 3> sq = m.map([](double x) { return x * x; });
+
+    double total    = sq.sum();
+    double smallest = m.min();
+    double largest  = m.max();
+    bool   nonneg   = sq.map([](double x) { return x >= 0.0; }).all();
+
+    std::cout << "sum = " << total << ", min = " << smallest
+              << ", max = " << largest << ", all non-negative = "
+              << std::boolalpha << nonneg << '\n';
+}
+```
+
+> **Why it matters.** `apply` and `map` are the matrix-native shorthands for
+> `std::ranges::for_each` and `std::ranges::transform`, but they keep the
+> dimensions in the type — so `m.map(f)` produces a `matrix<U, Dims...>`,
+> not a `std::vector`.
+
+---
+
+## 5. Zero-copy views and slicing
+
+`row(i)`, `col(j)`, `reshape<…>()`, and `flatten()` return lightweight
+non-owning views — pointer + static shape, no allocation. Use them like
+`std::string_view` for matrices.
 
 ```cpp
 #include <matrix.hpp>
 #include <matrix_view.hpp>
-#include <numeric>   // std::iota
+#include <iostream>
 
 int main()
 {
-    ysc::matrix<int, 4, 4> m;
-    std::iota(m.begin(), m.end(), 0);   // 0 … 15
+    // Build a 4×4 matrix m where m(i,j) = 4*i + j  →  0..15
+    auto m = ysc::generate<int, 4, 4>(
+        [](std::size_t k) { return int(k); });
 
-    // Contiguous row view (cheap — pointer + static size)
-    auto row0 = m.rows(0);              // {0, 1, 2, 3}
+    auto r1 = m.row(1);          // contiguous view: {4, 5, 6, 7}
+    auto c2 = m.col(2);          // strided view:    {2, 6, 10, 14}
 
-    // Strided column view
-    auto col2 = m.cols(2);              // {2, 6, 10, 14}
+    // Mutate the source through a view
+    r1.fill(-1);                 // row 1 of m becomes {-1, -1, -1, -1}
 
-    // Read-only view from a const matrix
-    const ysc::matrix<int, 4, 4>& cm = m;
-    ysc::const_matrix_view<int, 4, 4> ro{cm};  // explicit ctor
+    // Reshape and flatten are also zero-copy views
+    auto flat = m.flatten();     // matrix_view<int, contiguous, 16>
+    auto wide = m.reshape<2, 8>();
 
-    // Composable slicing: view of view
-    auto sub = row0.slice(0);           // first element as a 1D view
+    // Owning copy from a view (deep copy via explicit ctor)
+    ysc::matrix<int, 4> c2_owned{c2};
 
-    // Owning copy from a view (deep copy)
-    ysc::matrix<int, 4> col_copy{col2};
-
-    (void)ro; (void)sub; (void)col_copy;
+    std::cout << "m = " << m << '\n';
+    std::cout << "c2_owned = " << c2_owned << '\n';
 }
 ```
 
----
-
-## Interop with `std::ranges`, `std::format`, `std::hash`
-
-`ysc::matrix` satisfies `std::ranges::contiguous_range` and provides `std::hash` and
-`std::formatter` specializations.
+**Const-correctness propagates automatically.** On a non-const `matrix<T, …>`,
+`row` / `col` / `slice` return `matrix_view<T, …>` (mutable). On a
+`const matrix<T, …>` they return `matrix_view<const T, …>` — exactly the
+type aliased as `ysc::const_matrix_view<T, …>`. You do not pick the view
+type; the language does:
 
 ```cpp
-#include <matrix.hpp>
-#include <algorithm>    // std::ranges::sort, std::ranges::transform
-#include <unordered_set>
-#include <format>       // C++23 or later (guarded in the library)
+ysc::matrix<int, 4, 4> mutable_m = ysc::zeros<int, 4, 4>();
+const auto&            const_m   = mutable_m;
 
-int main()
-{
-    ysc::matrix<int, 2, 3> m = {3, 1, 4, 1, 5, 9};
-
-    // std::ranges algorithms work out-of-the-box
-    std::ranges::sort(m);               // sorts in row-major order: {1,1,3,4,5,9}
-
-    ysc::matrix<double, 2, 3> out;
-    std::ranges::transform(m, out.begin(),
-        [](int x) { return x * 1.5; });
-
-    // std::hash — use in unordered containers
-    std::unordered_set<ysc::matrix<int, 2, 3>> seen;
-    seen.insert(m);
-    seen.insert(m);   // duplicate — not inserted again
-
-    // std::format (requires __cpp_lib_format >= 201907L and Clang >= 17)
-#if defined(__cpp_lib_format) && __cpp_lib_format >= 201907L \
-    && (!defined(__clang__) || __clang_major__ >= 17)
-    std::string s = std::format("{}", m);
-    (void)s;
-#endif
-
-    (void)out;
-}
+auto rm = mutable_m.row(0);  // matrix_view<int, contiguous, 4>       (writable)
+auto rc = const_m.row(0);    // matrix_view<const int, contiguous, 4> (read-only)
 ```
 
+> **Why it matters.** Slicing in Eigen returns expression templates with
+> non-trivial lifetimes; `std::mdspan` is a view but not a container; nested
+> `std::array` cannot slice at all. Here a view is a pointer + a compile-time
+> shape, composable, and the const-ness is enforced by the type system.
+
 ---
 
-## Solving Ax=b with `dot`, `transpose`, `matmul`
+## 6. Linear algebra essentials
 
-Combining `transpose()`, `matmul()`, and `dot()` covers many linear-algebra workflows.
+`transpose`, `matmul`, and `dot` cover most everyday linear algebra.
+`matmul` is overloaded for matrix × matrix and matrix × column-vector, and
+mismatched inner dimensions are a compile error — not a runtime check.
 
 ```cpp
 #include <matrix.hpp>
+#include <iostream>
 
 int main()
 {
-    // --- Matrix–vector multiplication (Ax) ---
+    // Matrix-vector product (Ax)
     ysc::matrix<double, 2, 3> A = {1, 0, 0,
-                                    0, 1, 0};
+                                   0, 1, 0};
     ysc::matrix<double, 3>    x = {3, 5, 7};
+    auto Ax = ysc::matmul(A, x);              // matrix<double, 2>: {3, 5}
 
-    // matmul supports matrix × column-vector
-    auto Ax = ysc::matmul(A, x);        // matrix<double, 2>: {3, 5}
-
-    // --- Dot product ---
+    // Dot product on 1-D vectors
     ysc::matrix<double, 3> u = {1, 2, 3};
     ysc::matrix<double, 3> v = {4, 5, 6};
-    double uv = ysc::dot(u, v);         // 1*4 + 2*5 + 3*6 == 32
+    double uv = ysc::dot(u, v);               // 32
 
-    // --- Transpose ---
-    ysc::matrix<double, 2, 3> M = {1, 2, 3,
-                                    4, 5, 6};
-    auto Mt = ysc::transpose(M);        // matrix<double, 3, 2>
-
-    // --- Normal equations: (A^T A) x = A^T b ---
-    // For a 3×2 system:
+    // Normal equations  B^T B  and  B^T b  (no solver — that is for a future US)
     ysc::matrix<double, 3, 2> B = {1, 2,
-                                    3, 4,
-                                    5, 6};
+                                   3, 4,
+                                   5, 6};
     ysc::matrix<double, 3>    b = {1, 0, 1};
+    auto BtB = ysc::matmul(ysc::transpose(B), B);   // 2×2
+    auto Btb = ysc::matmul(ysc::transpose(B), b);   // length-2 vector
 
-    auto Bt    = ysc::transpose(B);     // 2×3
-    auto BtB   = ysc::matmul(Bt, B);   // 2×2
-    auto Btb   = ysc::matmul(Bt, b);   // 2
-
-    (void)Ax; (void)uv; (void)Mt; (void)BtB; (void)Btb;
+    std::cout << "Ax = "  << Ax  << '\n';
+    std::cout << "uv = "  << uv  << '\n';
+    std::cout << "BtB = " << BtB << ", Btb = " << Btb << '\n';
 }
 ```
+
+> **Why it matters.** `ysc::matmul(matrix<T, M, N>, matrix<T, K, P>)` does not
+> compile when `N != K`. With Eigen's dynamic matrices that mistake is a
+> runtime assertion; with raw arrays it is silent undefined behaviour. Static
+> dimensions catch it at the build.
 
 */

--- a/doc/cookbook.md
+++ b/doc/cookbook.md
@@ -145,7 +145,6 @@ non-owning views — pointer + static shape, no allocation. Use them like
 
 ```cpp
 #include <matrix.hpp>
-#include <matrix_view.hpp>
 #include <iostream>
 
 int main()

--- a/doc/cookbook.md
+++ b/doc/cookbook.md
@@ -1,0 +1,228 @@
+/**
+\page cookbook Cookbook
+
+# Cookbook — Practical Recipes for `ysc::matrix`
+
+This page collects self-contained code snippets for common tasks.
+Each recipe is a complete, compilable example.
+
+---
+
+## Iterating over rows and columns
+
+Use `rows()` / `cols()` to obtain strided views, then iterate with a range-based `for`
+or any STL algorithm.
+
+```cpp
+#include <matrix.hpp>
+#include <numeric>    // std::accumulate
+#include <iostream>
+
+int main()
+{
+    ysc::matrix<int, 3, 4> m = {
+         1,  2,  3,  4,
+         5,  6,  7,  8,
+         9, 10, 11, 12
+    };
+
+    // Iterate over rows (contiguous views)
+    for (std::size_t i = 0; i < m.dimensions[0]; ++i)
+    {
+        auto row = m.rows(i);
+        for (int v : row)
+            std::cout << v << ' ';
+        std::cout << '\n';
+    }
+
+    // Sum of the second column (strided view)
+    auto col1 = m.cols(1);
+    int col_sum = std::accumulate(col1.begin(), col1.end(), 0);
+    // col_sum == 2 + 6 + 10 == 18
+}
+```
+
+---
+
+## Filling and transforming a matrix
+
+`fill()` resets all elements; `apply()` mutates in place; `map()` returns a new matrix.
+
+```cpp
+#include <matrix.hpp>
+#include <cmath>    // std::sqrt
+
+int main()
+{
+    ysc::matrix<double, 3, 3> m;
+
+    // Fill every element with the same value
+    m.fill(1.0);
+
+    // Mutate in place: square every element
+    m.apply([](double& x) { x *= x; });
+
+    // Produce a new matrix without touching the original
+    auto sq = m.map([](const double& x) { return std::sqrt(x); });
+
+    // Diagonal identity matrix
+    ysc::matrix<int, 3, 3> identity{};
+    identity.fill(0);
+    for (std::size_t i = 0; i < 3; ++i)
+        identity(i, i) = 1;
+}
+```
+
+---
+
+## Comparing matrices element-wise vs lexicographic
+
+`operator==` tests exact equality; `operator<=>` gives a lexicographic total order on the
+row-major storage.
+
+```cpp
+#include <matrix.hpp>
+
+int main()
+{
+    ysc::matrix<int, 2, 3> a = {1, 2, 3, 4, 5, 6};
+    ysc::matrix<int, 2, 3> b = {1, 2, 3, 4, 5, 6};
+    ysc::matrix<int, 2, 3> c = {1, 2, 3, 4, 5, 7};
+
+    bool eq  = (a == b);   // true  — all elements equal
+    bool neq = (a != c);   // true  — last element differs
+
+    // Lexicographic order (useful for sorted containers / std::sort)
+    bool lt  = (a < c);    // true  — a comes before c in row-major order
+    bool gt  = (c > a);    // true
+
+    // Element-wise predicate via apply / map
+    auto diff = a.map([&](const int& x) { return x; });  // copy of a
+    // To test element-wise inequality you can compare map results:
+    auto mask = a.map([&b_it = *b.cbegin()](const int&) { return 0; });
+    (void)eq; (void)neq; (void)lt; (void)gt; (void)diff; (void)mask;
+}
+```
+
+---
+
+## Working with views: contiguous vs strided
+
+`slice()` / `row()` / `col()` yield lightweight non-owning views.
+Use `matrix_view<const T, ...>` (or the `const_matrix_view` alias) for read-only access.
+
+```cpp
+#include <matrix.hpp>
+#include <matrix_view.hpp>
+#include <numeric>   // std::iota
+
+int main()
+{
+    ysc::matrix<int, 4, 4> m;
+    std::iota(m.begin(), m.end(), 0);   // 0 … 15
+
+    // Contiguous row view (cheap — pointer + static size)
+    auto row0 = m.rows(0);              // {0, 1, 2, 3}
+
+    // Strided column view
+    auto col2 = m.cols(2);              // {2, 6, 10, 14}
+
+    // Read-only view from a const matrix
+    const ysc::matrix<int, 4, 4>& cm = m;
+    ysc::const_matrix_view<int, 4, 4> ro{cm};  // explicit ctor
+
+    // Composable slicing: view of view
+    auto sub = row0.slice(0);           // first element as a 1D view
+
+    // Owning copy from a view (deep copy)
+    ysc::matrix<int, 4> col_copy{col2};
+
+    (void)ro; (void)sub; (void)col_copy;
+}
+```
+
+---
+
+## Interop with `std::ranges`, `std::format`, `std::hash`
+
+`ysc::matrix` satisfies `std::ranges::contiguous_range` and provides `std::hash` and
+`std::formatter` specializations.
+
+```cpp
+#include <matrix.hpp>
+#include <algorithm>    // std::ranges::sort, std::ranges::transform
+#include <unordered_set>
+#include <format>       // C++23 or later (guarded in the library)
+
+int main()
+{
+    ysc::matrix<int, 2, 3> m = {3, 1, 4, 1, 5, 9};
+
+    // std::ranges algorithms work out-of-the-box
+    std::ranges::sort(m);               // sorts in row-major order: {1,1,3,4,5,9}
+
+    ysc::matrix<double, 2, 3> out;
+    std::ranges::transform(m, out.begin(),
+        [](int x) { return x * 1.5; });
+
+    // std::hash — use in unordered containers
+    std::unordered_set<ysc::matrix<int, 2, 3>> seen;
+    seen.insert(m);
+    seen.insert(m);   // duplicate — not inserted again
+
+    // std::format (requires __cpp_lib_format >= 201907L and Clang >= 17)
+#if defined(__cpp_lib_format) && __cpp_lib_format >= 201907L \
+    && (!defined(__clang__) || __clang_major__ >= 17)
+    std::string s = std::format("{}", m);
+    (void)s;
+#endif
+
+    (void)out;
+}
+```
+
+---
+
+## Solving Ax=b with `dot`, `transpose`, `matmul`
+
+Combining `transpose()`, `matmul()`, and `dot()` covers many linear-algebra workflows.
+
+```cpp
+#include <matrix.hpp>
+
+int main()
+{
+    // --- Matrix–vector multiplication (Ax) ---
+    ysc::matrix<double, 2, 3> A = {1, 0, 0,
+                                    0, 1, 0};
+    ysc::matrix<double, 3>    x = {3, 5, 7};
+
+    // matmul supports matrix × column-vector
+    auto Ax = ysc::matmul(A, x);        // matrix<double, 2>: {3, 5}
+
+    // --- Dot product ---
+    ysc::matrix<double, 3> u = {1, 2, 3};
+    ysc::matrix<double, 3> v = {4, 5, 6};
+    double uv = ysc::dot(u, v);         // 1*4 + 2*5 + 3*6 == 32
+
+    // --- Transpose ---
+    ysc::matrix<double, 2, 3> M = {1, 2, 3,
+                                    4, 5, 6};
+    auto Mt = ysc::transpose(M);        // matrix<double, 3, 2>
+
+    // --- Normal equations: (A^T A) x = A^T b ---
+    // For a 3×2 system:
+    ysc::matrix<double, 3, 2> B = {1, 2,
+                                    3, 4,
+                                    5, 6};
+    ysc::matrix<double, 3>    b = {1, 0, 1};
+
+    auto Bt    = ysc::transpose(B);     // 2×3
+    auto BtB   = ysc::matmul(Bt, B);   // 2×2
+    auto Btb   = ysc::matmul(Bt, b);   // 2
+
+    (void)Ax; (void)uv; (void)Mt; (void)BtB; (void)Btb;
+}
+```
+
+*/

--- a/doc/mainpage.md
+++ b/doc/mainpage.md
@@ -77,6 +77,15 @@ Copy `src/include/matrix.hpp` into your project and add its directory to your in
 
 ---
 
+## Cookbook
+
+Looking for practical, copy-paste examples? The @ref cookbook page collects ready-to-use
+recipes for the most common tasks: iterating over rows and columns, filling and transforming,
+working with views, interop with `std::ranges` / `std::format` / `std::hash`, and solving
+linear-algebra problems with `dot`, `transpose`, and `matmul`.
+
+---
+
 ## API Reference
 
 The main entry point is the @ref ysc::matrix class.

--- a/doc/mainpage.md
+++ b/doc/mainpage.md
@@ -79,10 +79,11 @@ Copy `src/include/matrix.hpp` into your project and add its directory to your in
 
 ## Cookbook
 
-Looking for practical, copy-paste examples? The @ref cookbook page collects ready-to-use
-recipes for the most common tasks: iterating over rows and columns, filling and transforming,
-working with views, interop with `std::ranges` / `std::format` / `std::hash`, and solving
-linear-algebra problems with `dot`, `transpose`, and `matmul`.
+Looking for practical, copy-paste examples? The @ref cookbook page collects six
+ready-to-use recipes covering the first use-cases — element access, factory
+functions, algorithms, zero-copy views, and linear algebra — and showcases the
+library's signature features: `constexpr` linear algebra, compile-time dimension
+checks, and views that carry their shape in the type.
 
 ---
 

--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -13,10 +13,10 @@
 | **G — Algorithmes** | ✅ Terminée | 5/5 | ✅ US-030, ✅ US-031, ✅ US-032, ✅ US-033, ✅ US-034 |
 | **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
 | **I — Packaging & préparation v1.0.0** | 🔄 En cours | 1/10 | ✅ US-046, ⬜ US-038, US-040 à US-043, US-045, US-047 à US-049 |
-| **J — Ergonomie & finition** | 🔄 En cours | 9/11 | ✅ US-039, ✅ US-051 à ✅ US-059, US-050 |
+| **J — Ergonomie & finition** | ✅ Terminée | 11/11 | ✅ US-039, ✅ US-050, ✅ US-051 à ✅ US-059 |
 | **K — Extensions pre-v1** | ⬜ Non démarrée | 0/9 | ⬜ US-060 à US-068 |
 
-**Total : 43 / 68 US**
+**Total : 44 / 68 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -50,7 +50,7 @@
 | US | Titre | Priorité | Statut |
 |----|-------|----------|--------|
 | US-039 | Suite de benchmarks (Google Benchmark) | P1 | ✅ Done |
-| US-050 | Cookbook Doxygen | P1 | ⬜ À faire |
+| US-050 | Cookbook Doxygen | P1 | ✅ Done |
 | US-051 | `matrix_view` : itérateurs strided + `front`/`back`/`fill` | P1 | ✅ Done |
 | US-052 | `matrix_view` : I/O, ctor const, vues composables | P1 | ✅ Done |
 | US-053 | Constructeurs additionnels : `std::array`, `std::span`, générateur | P1 | ✅ Done |

--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -13,7 +13,7 @@
 | **G — Algorithmes** | ✅ Terminée | 5/5 | ✅ US-030, ✅ US-031, ✅ US-032, ✅ US-033, ✅ US-034 |
 | **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
 | **I — Packaging & préparation v1.0.0** | 🔄 En cours | 1/10 | ✅ US-046, ⬜ US-038, US-040 à US-043, US-045, US-047 à US-049 |
-| **J — Ergonomie & finition** | ✅ Terminée | 11/11 | ✅ US-039, ✅ US-050, ✅ US-051 à ✅ US-059 |
+| **J — Ergonomie & finition** | ✅ Terminée | 11/11 | ✅ US-039, ✅ US-050 à US-059 |
 | **K — Extensions pre-v1** | ⬜ Non démarrée | 0/10 | ⬜ US-060 à US-069 |
 
 **Total : 44 / 69 US**

--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -14,9 +14,9 @@
 | **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
 | **I — Packaging & préparation v1.0.0** | 🔄 En cours | 1/10 | ✅ US-046, ⬜ US-038, US-040 à US-043, US-045, US-047 à US-049 |
 | **J — Ergonomie & finition** | ✅ Terminée | 11/11 | ✅ US-039, ✅ US-050, ✅ US-051 à ✅ US-059 |
-| **K — Extensions pre-v1** | ⬜ Non démarrée | 0/9 | ⬜ US-060 à US-068 |
+| **K — Extensions pre-v1** | ⬜ Non démarrée | 0/10 | ⬜ US-060 à US-069 |
 
-**Total : 44 / 68 US**
+**Total : 44 / 69 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -74,6 +74,7 @@
 | US-066 | CI Windows : cache vcpkg | P2 | ⬜ À faire |
 | US-067 | Hygiène repo : `.editorconfig`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, Dependabot | P2 | ⬜ À faire |
 | US-068 | Migration guide : promesse de stabilité SemVer v1.0.0 | P2 | ⬜ À faire |
+| US-069 | `generate` avec callable multi-index | P2 | ⬜ À faire |
 
 ---
 
@@ -1806,3 +1807,40 @@ En tant qu'utilisateur adoptant la lib depuis une version v0.x, je veux comprend
 - [ ] Tous les changements breaking v0.x → v1.0.0 listés avec instructions
 - [ ] La promesse SemVer (API publique vs `ysc::detail::`) est explicitement documentée
 - [ ] Lien vers `doc/migration.md` depuis `README.md` et `mainpage.md`
+
+---
+
+## US-069 — `generate` avec callable multi-index
+
+**Priorité :** P2 — **Dépend de :** US-053 — **Épopée :** K
+
+### Story
+En tant qu'utilisateur construisant des matrices position-dépendantes (identité par fonction, triangulaire, Vandermonde, gradient XY, masques i*j…), je veux pouvoir passer à `ysc::generate` un callable qui reçoit les coordonnées N-D plutôt qu'un index linéaire. Aujourd'hui je dois dérouler à la main `i = k / cols; j = k % cols;`, ce qui est verbeux et fragile en 3D+.
+
+### Spécification technique
+
+Ajouter une **deuxième surcharge** de `ysc::generate` à côté de l'existante (`src/include/matrix.hpp:1632-1640`) :
+
+```cpp
+template <class T, std::size_t... Dims, class F>
+    requires std::invocable<F, /* sizeof...(Dims) × std::size_t */>
+          && std::convertible_to<
+                 std::invoke_result_t<F, /* idem */>, T>
+constexpr matrix<T, Dims...> generate(F f);
+```
+
+- L'overload existant (`std::invocable<F, std::size_t>`, index linéaire row-major) reste exposé et continue de compiler tel quel — **rétrocompatibilité totale**.
+- Implémentation : itérer sur les indices N-D via `detail::index_to_coordinates` (déjà disponible dans `matrix_detail.hpp`, US-044) et invoquer `f` avec `std::apply` sur le tuple de coordonnées.
+- Doxygen `@brief @tparam @return @code`, groupe `ysc_factory` (ou équivalent existant).
+- Le callable peut être `auto` (la C++ générique) ou typé explicitement `std::size_t`.
+
+**Cas limite à clarifier dans l'implémentation** : si `sizeof...(Dims) == 1`, un callable `[](std::size_t k){ ... }` satisfait à la fois `invocable<size_t>` et la nouvelle contrainte (1 arg). Trancher en faveur de la surcharge linéaire (rétrocompat) — par exemple via `requires(!std::invocable<F, std::size_t>)` sur la nouvelle surcharge, ou par concept plus strict.
+
+### Critères d'acceptation
+- [ ] `auto I = ysc::generate<int, 3, 3>([](std::size_t i, std::size_t j){ return i == j ? 1 : 0; });` compile et produit la matrice identité 3×3.
+- [ ] `static_assert(ysc::generate<int, 2, 2>([](auto i, auto j){ return int(i + j); })(1, 1) == 2);` passe (la surcharge est `constexpr`).
+- [ ] Tenseur 3D : `auto m = ysc::generate<int, 2, 3, 4>([](auto i, auto j, auto k){ return int(i*100 + j*10 + k); });` compile et `m(1, 2, 3) == 123`.
+- [ ] La surcharge linéaire historique (`generate<int, N>([](std::size_t k){ return int(k); })`) compile sans modification.
+- [ ] Test dédié `test/src/generate_multi_index.cpp` couvrant : 1D (équivalent linéaire vs multi-index), 2D, 3D, type non-trivial, propagation `constexpr`.
+- [ ] Doxygen mis à jour avec exemple inline `@code`.
+- [ ] CI verte sur toutes plateformes ; clang-format / clang-tidy clean.


### PR DESCRIPTION
## Résumé

Ajoute une page **Cookbook** dans la documentation Doxygen (`doc/cookbook.md`) avec six recettes pratiques couvrant les usages courants de `ysc::matrix`. Active `GENERATE_TREEVIEW` et `USE_MATHJAX` dans le `Doxyfile.in`, et ajoute un lien proéminent depuis la `@mainpage` et le `README.md`.

## Critères d'acceptation

- [x] `cmake --build build --target doc` inclut la page Cookbook (vérifiable en CI)
- [x] Chaque recette contient un exemple de code compilable (vérifié manuellement)
- [x] Le Cookbook est accessible en 1 clic depuis la `@mainpage`
- [x] `GENERATE_TREEVIEW = YES` et `USE_MATHJAX = YES` actifs dans `Doxyfile.in`

## Recettes incluses

1. **Iterating over rows and columns** — `rows()`, `cols()`, STL algorithms
2. **Filling and transforming a matrix** — `fill()`, `apply()`, `map()`
3. **Comparing matrices element-wise vs lexicographic** — `==`, `!=`, `<`, `<=>`
4. **Working with views: contiguous vs strided** — `slice()`, `row()`, `col()`, `const_matrix_view`
5. **Interop with `std::ranges`, `std::format`, `std::hash`** — `unordered_set`, `std::ranges::sort`
6. **Solving Ax=b with `dot`, `transpose`, `matmul`** — normal equations pipeline