### PR TITLE
US-043 — Documentation Doxygen complète de l'API publique

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,8 @@ if(BUILD_DOCUMENTATION)
         message(FATAL_ERROR "Doxygen is needed to build the documentation.")
     endif()
 
+    include(cmake/DoxygenAwesome.cmake)
+
     set(doxyfile_in    ${CMAKE_CURRENT_SOURCE_DIR}/doc/Doxyfile.in)
     set(doxyfile       ${CMAKE_CURRENT_BINARY_DIR}/doc/Doxyfile)
     set(doxy_main_page ${CMAKE_CURRENT_SOURCE_DIR}/doc/mainpage.md)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ target_link_libraries(my_target PRIVATE ysc::matrix)
 
 ### Manual
 
-Copy `src/include/matrix.hpp` into your project and add its directory to your include path.
+Download `matrix.hpp` from a [GitHub Release](https://github.com/yscialom/matrix/releases) and
+copy it into your project.
 
 ---
 
@@ -74,15 +75,18 @@ int main()
 
 ## Features
 
-- **N-dimensional** — any number of dimensions, all sizes fixed at compile time
-- **STL-compatible** — `begin`/`end`, `size()`, `data()`, `front()`, `back()`, `fill()`, `swap()`
-- **Two access policies** — unchecked `operator()` (fast path) and bounds-checked `at()`
-- **Aggregate initialization** — `matrix<int, 2, 3> m = {1, 2, 3, 4, 5, 6};`
-- **Type conversion** — constructors and assignment from `matrix<U, Dims...>` when `U` converts to `T`
-- **Comparison** — `==` and `<=>` (lexicographic, row-major order)
-- **Compile-time metadata** — `order`, `dimensions`, `size()`, `empty()` all `static constexpr`
-- **Zero-init tag** — `matrix<T, Dims...> m{ysc::zero};` for explicit zero-initialization
-- **Zero overhead** — storage is `std::array<T, N>`, no heap, no virtual dispatch, no indirection
+| Feature | Description |
+|---------|-------------|
+| N-dimensional | Any number of dimensions; all sizes fixed at compile time |
+| STL-compatible | `begin`/`end`, `size()`, `data()`, `front()`, `back()`, `fill()`, `swap()` |
+| Unchecked access | `operator()` — no bounds check, UB out-of-bounds (performance path) |
+| Bounds-checked access | `at()` — throws `std::out_of_range` |
+| Aggregate init | `matrix<int,2,3> m = {1,2,3,4,5,6};` |
+| Type conversion | Converting constructors and assignment from `matrix<U, Dims...>` |
+| Comparison | `==` and `<=>` (lexicographic on row-major storage) |
+| Compile-time metadata | `order`, `dimensions`, `size()`, `empty()` — all `static constexpr` |
+| Zero-init tag | `matrix<T, Dims...> m{ysc::zero};` — explicit zero-initialization |
+| Zero overhead | Storage is `std::array<T, N>`, no heap, no virtual, no indirection |
 
 ---
 

--- a/cmake/DoxygenAwesome.cmake
+++ b/cmake/DoxygenAwesome.cmake
@@ -1,0 +1,52 @@
+include(FetchContent)
+
+FetchContent_Declare(
+    doxygen_awesome_css
+    GIT_REPOSITORY https://github.com/jothepro/doxygen-awesome-css.git
+    GIT_TAG        v2.3.4
+    GIT_SHALLOW    TRUE
+)
+
+# doxygen-awesome-css has no CMakeLists.txt, so we populate without
+# add_subdirectory(). CMP0169=OLD silences the FetchContent_Populate
+# deprecation warning introduced in CMake 3.28 while keeping compatibility.
+if(POLICY CMP0169)
+    cmake_policy(SET CMP0169 OLD)
+endif()
+FetchContent_GetProperties(doxygen_awesome_css)
+if(NOT doxygen_awesome_css_POPULATED)
+    FetchContent_Populate(doxygen_awesome_css)
+endif()
+
+set(DOXYGEN_AWESOME_CSS_DIR "${doxygen_awesome_css_SOURCE_DIR}")
+
+# Generate the default Doxygen HTML header and inject doxygen-awesome extension
+# init calls. This must happen at configure time so configure_file() can pick up
+# DOXYGEN_AWESOME_HEADER.
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/doc")
+execute_process(
+    COMMAND "${DOXYGEN_EXECUTABLE}" -w html
+        "${CMAKE_CURRENT_BINARY_DIR}/doc/header_base.html"
+        "${CMAKE_CURRENT_BINARY_DIR}/doc/footer_base.html"
+        "${CMAKE_CURRENT_BINARY_DIR}/doc/style_base.css"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+    OUTPUT_QUIET
+    ERROR_QUIET
+)
+file(READ "${CMAKE_CURRENT_BINARY_DIR}/doc/header_base.html" _doxygen_header)
+string(REPLACE "</head>" [=[
+<script type="text/javascript" src="$relpath^doxygen-awesome-darkmode-toggle.js"></script>
+<script type="text/javascript" src="$relpath^doxygen-awesome-fragment-copy-button.js"></script>
+<script type="text/javascript" src="$relpath^doxygen-awesome-paragraph-link.js"></script>
+<script type="text/javascript" src="$relpath^doxygen-awesome-interactive-toc.js"></script>
+<script type="text/javascript">
+    DoxygenAwesomeDarkModeToggle.init()
+    DoxygenAwesomeFragmentCopyButton.init()
+    DoxygenAwesomeParagraphLink.init()
+    DoxygenAwesomeInteractiveToc.init()
+</script>
+</head>]=]
+    _doxygen_header "${_doxygen_header}")
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/doc/header.html" "${_doxygen_header}")
+
+set(DOXYGEN_AWESOME_HEADER "${CMAKE_CURRENT_BINARY_DIR}/doc/header.html")

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -221,11 +221,6 @@ TAB_SIZE               = 4
 
 ALIASES                =
 
-# This tag can be used to specify a number of word-keyword mappings (TCL only).
-# A mapping has the form "name=value". For example adding "class=itcl::class"
-# will allow you to use the command class in the itcl::class meaning.
-
-TCL_SUBST              =
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
@@ -708,6 +703,11 @@ WARN_IF_DOC_ERROR      = YES
 
 WARN_NO_PARAMDOC       = YES
 
+# If WARN_AS_ERROR is set to YES, doxygen will immediately stop when a warning
+# is encountered. The default value is: NO.
+
+WARN_AS_ERROR          = YES
+
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which
 # will be replaced by the file and line number from which the warning originated
@@ -736,7 +736,7 @@ WARN_LOGFILE           =
 
 INPUT                  = @doxy_main_page@                          \
                          @PROJECT_SOURCE_DIR@/doc/cookbook.md      \
-                         @PROJECT_SOURCE_DIR@
+                         @PROJECT_SOURCE_DIR@/src
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -971,12 +971,6 @@ VERBATIM_HEADERS       = YES
 
 ALPHABETICAL_INDEX     = YES
 
-# The COLS_IN_ALPHA_INDEX tag can be used to specify the number of columns in
-# which the alphabetical index list will be split.
-# Minimum value: 1, maximum value: 20, default value: 5.
-# This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
-
-COLS_IN_ALPHA_INDEX    = 5
 
 # In case all classes in a project start with a common prefix, all classes will
 # be put under the same header in the alphabetical index. The IGNORE_PREFIX tag
@@ -1028,7 +1022,7 @@ HTML_FILE_EXTENSION    = .html
 # of the possible markers and block names see the documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_HEADER            =
+HTML_HEADER            = @DOXYGEN_AWESOME_HEADER@
 
 # The HTML_FOOTER tag can be used to specify a user-defined HTML footer for each
 # generated HTML page. If the tag is left blank doxygen will generate a standard
@@ -1061,7 +1055,7 @@ HTML_STYLESHEET        =
 # see the documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_STYLESHEET  =
+HTML_EXTRA_STYLESHEET  = @DOXYGEN_AWESOME_CSS_DIR@/doxygen-awesome.css
 
 # The HTML_EXTRA_FILES tag can be used to specify one or more extra images or
 # other source files which should be copied to the HTML output directory. Note
@@ -1071,7 +1065,10 @@ HTML_EXTRA_STYLESHEET  =
 # files will be copied as-is; there are no commands or markers available.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_FILES       =
+HTML_EXTRA_FILES       = @DOXYGEN_AWESOME_CSS_DIR@/doxygen-awesome-darkmode-toggle.js \
+                         @DOXYGEN_AWESOME_CSS_DIR@/doxygen-awesome-fragment-copy-button.js \
+                         @DOXYGEN_AWESOME_CSS_DIR@/doxygen-awesome-paragraph-link.js \
+                         @DOXYGEN_AWESOME_CSS_DIR@/doxygen-awesome-interactive-toc.js
 
 # The HTML_COLORSTYLE_HUE tag controls the color of the HTML output. Doxygen
 # will adjust the colors in the stylesheet and background images according to
@@ -1103,13 +1100,11 @@ HTML_COLORSTYLE_SAT    = 100
 
 HTML_COLORSTYLE_GAMMA  = 80
 
-# If the HTML_TIMESTAMP tag is set to YES then the footer of each generated HTML
-# page will contain the date and time when the page was generated. Setting this
-# to NO can help when comparing the output of multiple runs.
-# The default value is: YES.
-# This tag requires that the tag GENERATE_HTML is set to YES.
+# Required by doxygen-awesome-css: overrides HUE/SAT/GAMMA above.
+HTML_COLORSTYLE        = LIGHT
 
-HTML_TIMESTAMP         = NO
+# doxygen-awesome sidebar-only variant: keep tabs hidden, sidebar is the sole nav.
+FULL_SIDEBAR           = NO
 
 # If the HTML_DYNAMIC_SECTIONS tag is set to YES then the generated HTML
 # documentation will contain sections that can be hidden and shown after the
@@ -1380,16 +1375,6 @@ EXT_LINKS_IN_WINDOW    = NO
 
 FORMULA_FONTSIZE       = 10
 
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
-# generated for formulas are transparent PNGs. Transparent PNGs are not
-# supported properly for IE 6.0, but are supported on all modern browsers.
-#
-# Note that when changing this option you need to delete any form_*.png files in
-# the HTML output directory before the changes have effect.
-# The default value is: YES.
-# This tag requires that the tag GENERATE_HTML is set to YES.
-
-FORMULA_TRANSPARENT    = YES
 
 # Enable the USE_MATHJAX option to render LaTeX formulas using MathJax (see
 # http://www.mathjax.org) which uses client side Javascript for the rendering
@@ -1653,15 +1638,6 @@ LATEX_BATCHMODE        = NO
 
 LATEX_HIDE_INDICES     = NO
 
-# If the LATEX_SOURCE_CODE tag is set to YES then doxygen will include source
-# code with syntax highlighting in the LaTeX output.
-#
-# Note that which sources are shown also depends on other settings such as
-# SOURCE_BROWSER.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_LATEX is set to YES.
-
-LATEX_SOURCE_CODE      = NO
 
 # The LATEX_BIB_STYLE tag can be used to specify the style to use for the
 # bibliography, e.g. plainnat, or ieeetr. See
@@ -1782,17 +1758,6 @@ GENERATE_XML           = NO
 
 XML_OUTPUT             = xml
 
-# The XML_SCHEMA tag can be used to specify a XML schema, which can be used by a
-# validating XML parser to check the syntax of the XML files.
-# This tag requires that the tag GENERATE_XML is set to YES.
-
-XML_SCHEMA             =
-
-# The XML_DTD tag can be used to specify a XML DTD, which can be used by a
-# validating XML parser to check the syntax of the XML files.
-# This tag requires that the tag GENERATE_XML is set to YES.
-
-XML_DTD                =
 
 # If the XML_PROGRAMLISTING tag is set to YES doxygen will dump the program
 # listings (including syntax highlighting and cross-referencing information) to
@@ -1994,33 +1959,11 @@ EXTERNAL_GROUPS        = YES
 
 EXTERNAL_PAGES         = YES
 
-# The PERL_PATH should be the absolute path and name of the perl script
-# interpreter (i.e. the result of 'which perl').
-# The default file (with absolute path) is: /usr/bin/perl.
-
-PERL_PATH              = /usr/bin/perl
 
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
 
-# If the CLASS_DIAGRAMS tag is set to YES doxygen will generate a class diagram
-# (in HTML and LaTeX) for classes with base or super classes. Setting the tag to
-# NO turns the diagrams off. Note that this option also works with HAVE_DOT
-# disabled, but it is recommended to install and use dot, since it yields more
-# powerful graphs.
-# The default value is: YES.
-
-CLASS_DIAGRAMS         = YES
-
-# You can define message sequence charts within doxygen comments using the \msc
-# command. Doxygen will then run the mscgen tool (see:
-# http://www.mcternan.me.uk/mscgen/)) to produce the chart and insert it in the
-# documentation. The MSCGEN_PATH tag allows you to specify the directory where
-# the mscgen tool resides. If left empty the tool is assumed to be found in the
-# default search path.
-
-MSCGEN_PATH            =
 
 # If set to YES, the inheritance and collaboration graphs will hide inheritance
 # and usage relations if the target is undocumented or is not a class.
@@ -2047,22 +1990,6 @@ HAVE_DOT               = YES
 
 DOT_NUM_THREADS        = 0
 
-# When you want a differently looking font n the dot files that doxygen
-# generates you can specify the font name using DOT_FONTNAME. You need to make
-# sure dot is able to find the font, which can be done by putting it in a
-# standard location or by setting the DOTFONTPATH environment variable or by
-# setting DOT_FONTPATH to the directory containing the font.
-# The default value is: Helvetica.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_FONTNAME           = Helvetica
-
-# The DOT_FONTSIZE tag can be used to set the size (in points) of the font of
-# dot graphs.
-# Minimum value: 4, maximum value: 24, default value: 10.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_FONTSIZE           = 10
 
 # By default doxygen will tell dot to use the default font as specified with
 # DOT_FONTNAME. If you specify a different font using DOT_FONTNAME you can set
@@ -2246,17 +2173,6 @@ DOT_GRAPH_MAX_NODES    = 50
 
 MAX_DOT_GRAPH_DEPTH    = 0
 
-# Set the DOT_TRANSPARENT tag to YES to generate images with a transparent
-# background. This is disabled by default, because dot on Windows does not seem
-# to support this out of the box.
-#
-# Warning: Depending on the platform used, enabling this option may lead to
-# badly anti-aliased labels on the edges of a graph (i.e. they become hard to
-# read).
-# The default value is: NO.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_TRANSPARENT        = NO
 
 # Set the DOT_MULTI_TARGETS tag to YES allow dot to generate multiple output
 # files in one run (i.e. multiple -o and -T options on the command line). This

--- a/doc/cookbook.md
+++ b/doc/cookbook.md
@@ -1,7 +1,4 @@
-/**
-\page cookbook Cookbook
-
-# Cookbook — Practical Recipes for `ysc::matrix`
+# Cookbook — Practical Recipes for ysc::matrix {#cookbook}
 
 Six self-contained recipes for the first things you will want to do with
 `ysc::matrix`. Each one also highlights a property of the library that sets it
@@ -39,8 +36,6 @@ int main()
 > `int m[2][3]`, zero indirection, zero allocation. You only pay for what you
 > use.
 
----
-
 ## 2. Algebra at compile time
 
 Every linear-algebra primitive is `constexpr`. Move invariants from the
@@ -68,8 +63,6 @@ int main()
 > matrix product inside a `static_assert`. Here the whole API is `constexpr`,
 > so unit-test-grade checks run during compilation.
 
----
-
 ## 3. Factory functions
 
 Five constexpr factories cover the matrices you most often need to type
@@ -95,8 +88,6 @@ int main()
 > **Why it matters.** All five live in the same header you already include,
 > all are `constexpr`, and all carry their dimensions in the type. No
 > `Eigen::MatrixXd::Identity(n, n)` runtime sizing surprise.
-
----
 
 ## 4. Map, reduce, transform
 
@@ -134,8 +125,6 @@ int main()
 > `std::ranges::for_each` and `std::ranges::transform`, but they keep the
 > dimensions in the type — so `m.map(f)` produces a `matrix<U, Dims...>`,
 > not a `std::vector`.
-
----
 
 ## 5. Zero-copy views and slicing
 
@@ -190,8 +179,6 @@ auto rc = const_m.row(0);    // matrix_view<const int, contiguous, 4> (read-only
 > `std::array` cannot slice at all. Here a view is a pointer + a compile-time
 > shape, composable, and the const-ness is enforced by the type system.
 
----
-
 ## 6. Linear algebra essentials
 
 `transpose`, `matmul`, and `dot` cover most everyday linear algebra.
@@ -233,5 +220,3 @@ int main()
 > compile when `N != K`. With Eigen's dynamic matrices that mistake is a
 > runtime assertion; with raw arrays it is silent undefined behaviour. Static
 > dimensions catch it at the build.
-
-*/

--- a/doc/mainpage.md
+++ b/doc/mainpage.md
@@ -52,7 +52,8 @@ target_link_libraries(my_target PRIVATE ysc::matrix)
 
 ### Manual
 
-Copy `src/include/matrix.hpp` into your project and add its directory to your include path.
+Download `matrix.hpp` from a [GitHub Release](https://github.com/yscialom/matrix/releases) and
+copy it into your project.
 
 ```cpp
 #include "matrix.hpp"
@@ -91,7 +92,16 @@ checks, and views that carry their shape in the type.
 
 The main entry point is the @ref ysc::matrix class.
 
-Related types and concepts:
-- @ref ysc::matrix_zero_t — tag type for explicit zero-initialization (`ysc::zero`)
-- @ref ysc::integral_coordinates — concept constraining `operator()` and `at()` coordinates
-- @ref ysc::matrix_convertible_from — concept constraining converting constructors and assignments
+The API is organized into the following groups — see the [Topics](topics.html) page for a full listing:
+- @ref ysc_construction — Construction (constructors, assignment, `zeros`, `full`, `ones`, `identity`, `generate`)
+- @ref ysc_access — Element access (`operator()`, `at()`)
+- @ref ysc_iterators — Iterators (`begin`, `end`, `rbegin`, `rend`, and const variants)
+- @ref ysc_capacity — Capacity (`size()`, `empty()`, `data()`, `order`, `dimensions`)
+- @ref ysc_modifiers — Modifiers (`fill`, `swap`, `front`, `back`)
+- @ref ysc_comparison — Comparison (`==`, `<=>`)
+- @ref ysc_arithmetic — Arithmetic operators (element-wise and scalar)
+- @ref ysc_algorithms — Algorithms (`apply`, `map`, `sum`, `min`, `max`, `all`, `any`)
+- @ref ysc_linalg — Linear algebra (`transpose`, `matmul`, `dot`)
+- @ref ysc_views — Views (`matrix_view`, `row`, `col`, `slice`, `rows`, `cols`, `reshape`, `flatten`)
+- @ref ysc_io — I/O (`operator<<`, `std::formatter`)
+- @ref ysc_hash — Hash support (`std::hash` specialization)

--- a/doc/mainpage.md
+++ b/doc/mainpage.md
@@ -90,8 +90,6 @@ checks, and views that carry their shape in the type.
 
 ## API Reference
 
-The main entry point is the @ref ysc::matrix class.
-
 The API is organized into the following groups — see the [Topics](topics.html) page for a full listing:
 - @ref ysc_construction — Construction (constructors, assignment, `zeros`, `full`, `ones`, `identity`, `generate`)
 - @ref ysc_access — Element access (`operator()`, `at()`)
@@ -105,3 +103,8 @@ The API is organized into the following groups — see the [Topics](topics.html)
 - @ref ysc_views — Views (`matrix_view`, `row`, `col`, `slice`, `rows`, `cols`, `reshape`, `flatten`)
 - @ref ysc_io — I/O (`operator<<`, `std::formatter`)
 - @ref ysc_hash — Hash support (`std::hash` specialization)
+
+You can also browse the full documentation for the main library classes:
+- Owning matrix — @ref ysc::matrix
+- Non-owning continuous view — @ref ysc::matrix_view< T, contiguous, Dimensions... >
+- Non-owning strided view — @ref ysc::matrix_view< T, strided, Dimensions... >

--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -12,11 +12,11 @@
 | **F — Arithmétique** | ✅ Terminée | 4/4 | ✅ US-026, ✅ US-027, ✅ US-028, ✅ US-029 |
 | **G — Algorithmes** | ✅ Terminée | 5/5 | ✅ US-030, ✅ US-031, ✅ US-032, ✅ US-033, ✅ US-034 |
 | **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
-| **I — Packaging & préparation v1.0.0** | 🔄 En cours | 1/10 | ✅ US-046, ⬜ US-038, US-040 à US-043, US-045, US-047 à US-049 |
+| **I — Packaging & préparation v1.0.0** | 🔄 En cours | 2/10 | ✅ US-043, ✅ US-046, ⬜ US-038, US-040 à US-042, US-045, US-047 à US-049 |
 | **J — Ergonomie & finition** | ✅ Terminée | 11/11 | ✅ US-039, ✅ US-050 à US-059 |
 | **K — Extensions pre-v1** | ⬜ Non démarrée | 0/10 | ⬜ US-060 à US-069 |
 
-**Total : 44 / 69 US**
+**Total : 45 / 69 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -38,7 +38,7 @@
 | US-040 | Dossier `examples/` enrichi | P1 | ⬜ À faire |
 | US-041 | Gate couverture 100 % | P1 | ⬜ À faire |
 | US-042 | Tag `v1.0.0` | P0 (final) | ⬜ À faire |
-| US-043 | Documentation Doxygen complète | P1 | ⬜ À faire |
+| US-043 | Documentation Doxygen complète | P1 | ✅ Done |
 | US-045 | Packaging CMake : cible `ysc-matrix`, alias, install, find_package | P0 | ⬜ À faire |
 | US-046 | Correctifs docs + `.gitignore` | P0 | ✅ Done |
 | US-047 | README marketing + `mainpage.md` v1 | P0 | ⬜ À faire |
@@ -1108,18 +1108,18 @@ En tant qu'utilisateur de la bibliothèque, je veux que chaque fonction publique
 
 | Groupe | Contenu |
 |--------|---------|
-| `ysc_construction` | Constructeurs, `operator=`, factories |
+| `ysc_construction` | Constructeurs, `operator=`, factories : `zeros`, `full`, `ones`, `identity`, `generate` ; `matrix(std::array)`, `matrix(std::span)` |
 | `ysc_access` | `operator()`, `at()` |
-| `ysc_iterators` | `begin`, `end`, `cbegin`, `cend`, `rbegin`, `rend`, variantes const |
-| `ysc_capacity` | `size`, `max_size`, `empty`, `data` |
-| `ysc_modifiers` | `fill`, `swap` |
+| `ysc_iterators` | `begin`, `end`, `cbegin`, `cend`, `rbegin`, `rend`, `crbegin`, `crend` et variantes const |
+| `ysc_capacity` | `size`, `max_size`, `empty`, `data`, `order`, `dimensions` |
+| `ysc_modifiers` | `fill`, `swap` (membre et friend), `front`, `back` |
 | `ysc_comparison` | `operator==`, `operator<=>` |
 | `ysc_arithmetic` | `operator+`, `-`, `*`, `/`, scalaires, Hadamard, unaires |
 | `ysc_algorithms` | `apply`, `map`, `sum`, `min`, `max`, `all`, `any` |
 | `ysc_linalg` | `transpose`, `matmul`, `dot` |
-| `ysc_views` | `slice`, `row`, `col`, `reshape`, `flatten`, `ysc::all`, `ysc::contiguous`, `ysc::strided` |
-| `ysc_io` | `operator<<`, `std::formatter` |
-| `ysc_hash` | `std::hash` |
+| `ysc_views` | `slice`, `row`, `col`, `rows`, `cols`, `reshape`, `flatten` ; `matrix_view` (classe), `contiguous`, `strided`, `all_t`, `all`, `const_matrix_view` ; vues sur `matrix_view` : `row`, `col`, `fill`, `front`, `back` |
+| `ysc_io` | `operator<<` (matrix + matrix_view contiguous), `std::formatter` (matrix + matrix_view contiguous) |
+| `ysc_hash` | `std::hash<ysc::matrix<T, D...>>` |
 
 **Page principale (`@mainpage`) :**
 - Fichier `doc/mainpage.md`
@@ -1134,12 +1134,12 @@ En tant qu'utilisateur de la bibliothèque, je veux que chaque fonction publique
 - Ou ajouter une étape `doxygen-check` dédiée (sans déploiement)
 
 ### Critères d'acceptation
-- [ ] Chaque fonction publique de `matrix.hpp`, `matrix_view.hpp`, `matrix_detail.hpp` possède `@brief`, `@tparam`/`@param`/`@return`/`@throws` selon applicable, et un exemple `@code`…`@endcode`
-- [ ] Toutes les fonctions sont rattachées à l'un des 12 groupes ci-dessus via `@ingroup`
-- [ ] La page `@mainpage` liste les 12 groupes ; chaque groupe est accessible en 1 clic depuis la page principale
-- [ ] `cmake --build build --target doc` produit zéro avertissement Doxygen
-- [ ] La CI est rouge si un avertissement Doxygen est introduit (`WARN_AS_ERROR = YES`)
-- [ ] `GENERATE_TREEVIEW = YES` et `USE_MATHJAX = YES` actifs dans `Doxyfile.in`
+- [x] Chaque fonction publique de `matrix.hpp`, `matrix_view.hpp`, `matrix_detail.hpp` possède `@brief`, `@tparam`/`@param`/`@return`/`@throws` selon applicable, et un exemple `@code`…`@endcode`
+- [x] Toutes les fonctions sont rattachées à l'un des 12 groupes ci-dessus via `@ingroup`
+- [x] La page `@mainpage` liste les 12 groupes ; chaque groupe est accessible en 1 clic depuis la page principale
+- [x] `cmake --build build --target doc` produit zéro avertissement Doxygen
+- [x] La CI est rouge si un avertissement Doxygen est introduit (`WARN_AS_ERROR = YES`)
+- [x] `GENERATE_TREEVIEW = YES` et `USE_MATHJAX = YES` actifs dans `Doxyfile.in`
 
 ---
 

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -53,6 +53,36 @@ constexpr struct matrix_zero_t {
 } zero;
 
 /**
+ * @defgroup ysc_construction Construction
+ * @brief Constructors, assignment operators, and factory functions.
+ */
+
+/**
+ * @defgroup ysc_iterators Iterators
+ * @brief Range iteration over matrix elements in row-major order.
+ */
+
+/**
+ * @defgroup ysc_capacity Capacity
+ * @brief Size queries and data pointer.
+ */
+
+/**
+ * @defgroup ysc_modifiers Modifiers
+ * @brief In-place mutation: fill, swap, front, back.
+ */
+
+/**
+ * @defgroup ysc_access Element access
+ * @brief Unchecked and checked element access.
+ */
+
+/**
+ * @defgroup ysc_comparison Comparison
+ * @brief Equality and three-way comparison operators.
+ */
+
+/**
  * @brief Multi-dimensional container encapsulating a fixed size matrix.
  * @tparam T          Element type
  * @tparam Dimentions Dimensions of the matrix
@@ -85,10 +115,26 @@ template <class T, std::size_t... Dimensions> class matrix {
     template <class, std::size_t...> friend class matrix;
 
 public:
-    /** @brief Order of the matrix (2D matrix have order 2, 3D order 3, etc.).
+    /**
+     * @brief Order of the matrix (2D matrix have order 2, 3D order 3, etc.).
+     *
+     * @code
+     * static_assert(ysc::matrix<int, 2, 3>::order == 2);
+     * @endcode
+     *
+     * @ingroup ysc_capacity
      */
     static constexpr std::size_t order = sizeof...(Dimensions);
-    /** @brief Dimensions of the matrix. An order-`N` matrix has `N` dimensions.
+
+    /**
+     * @brief Dimensions of the matrix. An order-`N` matrix has `N` dimensions.
+     *
+     * @code
+     * static_assert(ysc::matrix<int, 2, 3>::dimensions[0] == 2);
+     * static_assert(ysc::matrix<int, 2, 3>::dimensions[1] == 3);
+     * @endcode
+     *
+     * @ingroup ysc_capacity
      */
     static constexpr std::array dimensions = {Dimensions...};
 
@@ -121,64 +167,186 @@ public:
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
     // iterators
+
+    /**
+     * @brief Returns an iterator to the first element in row-major order.
+     * @return Iterator to the first element
+     *
+     * @code
+     * ysc::matrix<int, 3> m{1, 2, 3};
+     * for (int v : m) { } // visits 1, then 2, then 3
+     * @endcode
+     *
+     * @ingroup ysc_iterators
+     */
     constexpr iterator begin() noexcept { return _data.begin(); }
+
+    /**
+     * @brief Returns a const iterator to the first element in row-major order.
+     * @return Const iterator to the first element
+     * @see begin()
+     * @ingroup ysc_iterators
+     */
     [[nodiscard]] constexpr const_iterator begin() const noexcept { return _data.begin(); }
+
+    /**
+     * @brief Returns a const iterator to the first element in row-major order.
+     * @return Const iterator to the first element
+     * @see begin()
+     * @ingroup ysc_iterators
+     */
     [[nodiscard]] constexpr const_iterator cbegin() const noexcept { return _data.cbegin(); }
+
+    /**
+     * @brief Returns an iterator past the last element.
+     * @return Iterator past the last element
+     * @see begin()
+     * @ingroup ysc_iterators
+     */
     constexpr iterator end() noexcept { return _data.end(); }
+
+    /**
+     * @brief Returns a const iterator past the last element.
+     * @return Const iterator past the last element
+     * @see begin()
+     * @ingroup ysc_iterators
+     */
     [[nodiscard]] constexpr const_iterator end() const noexcept { return _data.end(); }
+
+    /**
+     * @brief Returns a const iterator past the last element.
+     * @return Const iterator past the last element
+     * @see begin()
+     * @ingroup ysc_iterators
+     */
     [[nodiscard]] constexpr const_iterator cend() const noexcept { return _data.cend(); }
+
+    /**
+     * @brief Returns a reverse iterator to the last element.
+     * @return Reverse iterator to the last element
+     * @see begin()
+     * @ingroup ysc_iterators
+     */
     constexpr reverse_iterator rbegin() noexcept { return _data.rbegin(); }
+
+    /**
+     * @brief Returns a const reverse iterator to the last element.
+     * @return Const reverse iterator to the last element
+     * @see begin()
+     * @ingroup ysc_iterators
+     */
     [[nodiscard]] constexpr const_reverse_iterator rbegin() const noexcept {
         return _data.rbegin();
     }
+
+    /**
+     * @brief Returns a const reverse iterator to the last element.
+     * @return Const reverse iterator to the last element
+     * @see begin()
+     * @ingroup ysc_iterators
+     */
     [[nodiscard]] constexpr const_reverse_iterator crbegin() const noexcept {
         return _data.crbegin();
     }
+
+    /**
+     * @brief Returns a reverse iterator past the first element.
+     * @return Reverse iterator past the first element
+     * @see begin()
+     * @ingroup ysc_iterators
+     */
     constexpr reverse_iterator rend() noexcept { return _data.rend(); }
+
+    /**
+     * @brief Returns a const reverse iterator past the first element.
+     * @return Const reverse iterator past the first element
+     * @see begin()
+     * @ingroup ysc_iterators
+     */
     [[nodiscard]] constexpr const_reverse_iterator rend() const noexcept { return _data.rend(); }
+
+    /**
+     * @brief Returns a const reverse iterator past the first element.
+     * @return Const reverse iterator past the first element
+     * @see begin()
+     * @ingroup ysc_iterators
+     */
     [[nodiscard]] constexpr const_reverse_iterator crend() const noexcept { return _data.crend(); }
 
     // capacity
     /**
-     * @brief Returns the number of elements in the matrix (product of all
-     * dimensions).
+     * @brief Returns the number of elements in the matrix (product of all dimensions).
+     * @return Number of elements
      *
-     * @note This function is @c static because the size is a compile-time
-     * constant.
+     * @note This function is @c static because the size is a compile-time constant.
+     *
+     * @code
+     * static_assert(ysc::matrix<int, 2, 3>::size() == 6);
+     * @endcode
+     *
+     * @ingroup ysc_capacity
      */
     static constexpr size_type size() noexcept { return linear_size; }
 
     /**
      * @brief Returns the maximum number of elements the matrix can hold.
+     * @return Maximum number of elements (always equal to @c size())
      *
      * Always equal to @c size() for this fixed-size container.
      *
-     * @note This function is @c static because the value is a compile-time
-     * constant.
+     * @note This function is @c static because the value is a compile-time constant.
+     *
+     * @code
+     * static_assert(ysc::matrix<int, 2, 3>::max_size() == 6);
+     * @endcode
+     *
+     * @ingroup ysc_capacity
      */
     static constexpr size_type max_size() noexcept { return linear_size; }
 
     /**
      * @brief Returns whether the matrix has no elements.
+     * @return @c true if @c linear_size == 0
      *
-     * @note This function is @c static because the value is a compile-time
-     * constant.
+     * @note This function is @c static because the value is a compile-time constant.
+     *
+     * @code
+     * static_assert(!ysc::matrix<int, 2, 3>::empty());
+     * @endcode
+     *
+     * @ingroup ysc_capacity
      */
     static constexpr bool empty() noexcept { return linear_size == 0; }
 
     /**
      * @brief Returns a pointer to the underlying element storage.
+     * @return Pointer to the first element
      *
-     * Elements are stored in row-major order (rightmost dimension is
-     * contiguous).
+     * Elements are stored in row-major order (rightmost dimension is contiguous).
+     *
+     * @code
+     * ysc::matrix<int, 3> m{1, 2, 3};
+     * int* p = m.data();
+     * assert(p[1] == 2);
+     * @endcode
+     *
+     * @ingroup ysc_capacity
      */
     constexpr pointer data() noexcept { return _data.data(); }
 
     /**
-     * @brief Returns a pointer to the underlying element storage.
+     * @brief Returns a const pointer to the underlying element storage.
+     * @return Const pointer to the first element
      *
-     * Elements are stored in row-major order (rightmost dimension is
-     * contiguous).
+     * Elements are stored in row-major order (rightmost dimension is contiguous).
+     *
+     * @code
+     * const ysc::matrix<int, 3> m{1, 2, 3};
+     * const int* p = m.data();
+     * assert(p[0] == 1);
+     * @endcode
+     *
+     * @ingroup ysc_capacity
      */
     [[nodiscard]] constexpr const_pointer data() const noexcept { return _data.data(); }
 
@@ -195,6 +363,8 @@ public:
      ++rhs_it) { swap(*lhs_it, *rhs_it);
      }
      @endcode
+     *
+     * @ingroup ysc_modifiers
      */
     friend void swap(matrix& lhs, matrix& rhs) noexcept(std::is_nothrow_swappable_v<T>) {
         using std::swap;
@@ -205,8 +375,14 @@ public:
     /**
      * @brief Initializes the matrix.
      *
-     * @note If `T` is a trivial type, initialization may result in
-     * indeterminate values.
+     * @note If `T` is a trivial type, initialization may result in indeterminate values.
+     * Use `matrix(matrix_zero_t)` to guarantee zero-initialization.
+     *
+     * @code
+     * ysc::matrix<int, 3> m;  // elements may be indeterminate for trivial T
+     * @endcode
+     *
+     * @ingroup ysc_construction
      */
     // Intentional: _data is deliberately left uninitialized for trivial T to
     // avoid the cost of zero-initialization on the hot path. Use
@@ -215,25 +391,36 @@ public:
     matrix() = default;
 
     /**
-     * @brief Initializes the matrix following the rules of default
-     * initialization.
+     * @brief Initializes the matrix with all elements zero-initialized.
      *
      * @note If `T` is a trivial type, the matrix is zero-initialized; otherwise
      * the default constructors of its elements are called.
+     *
+     * @code
+     * ysc::matrix<int, 2, 3> m{ysc::zero};  // all elements == 0
+     * @endcode
+     *
+     * @ingroup ysc_construction
      */
     constexpr matrix(matrix_zero_t /*zero*/) : _data({}) {}
 
     // aggregate constructors
     /**
-     * @brief Initializes the matrix following the rules of aggregate
-     * initialization.
-     * @tparam Args... Source types (must all be convertible to @c T)
-     * @param args...  Source values (must be exactly @c linear_size values)
+     * @brief Initializes the matrix from exactly @c linear_size values,
+     * following the rules of aggregate initialization.
+     * @tparam Args Source types (must all be convertible to @c T)
      *
-     * `matrix<long, 2, 2> m{true, '\x02', 3, 4L}` initializes an order-2 matrix
-     * from the values `true`, `'\x02'`, `3` and `4L` converted to `long`.
+     * `matrix<long, 2, 2> m{true, 'x', 3, 4L}` initializes an order-2 matrix
+     * from the values `true`, `'x'`, `3` and `4L` converted to `long`.
      * Partial initialization (fewer than `linear_size` values) is not
      * supported; use `matrix(matrix_zero_t)` to zero-initialize.
+     *
+     * @code
+     * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+     * assert(m(1, 2) == 6);
+     * @endcode
+     *
+     * @ingroup ysc_construction
      */
     template <class... Args>
         requires(sizeof...(Args) == linear_size) && (std::convertible_to<Args, T> && ...) &&
@@ -256,6 +443,8 @@ public:
      * ysc::matrix<int, 2, 3> m{{1, 2, 3}, {4, 5, 6}};
      * assert(m(1, 2) == 6);
      * @endcode
+     *
+     * @ingroup ysc_construction
      */
     template <std::size_t D1 = order>
         requires(D1 == 2)
@@ -278,6 +467,13 @@ public:
     /**
      * @brief Initializes the matrix as a copy of another.
      * @param other Source matrix
+     *
+     * @code
+     * ysc::matrix<int, 3> a{1, 2, 3};
+     * ysc::matrix<int, 3> b = a;
+     * @endcode
+     *
+     * @ingroup ysc_construction
      */
     matrix(matrix const& other) = default;
 
@@ -288,6 +484,13 @@ public:
      *
      * Elements of the matrix are copy-initialized from the elements of the
      * source matrix.
+     *
+     * @code
+     * ysc::matrix<int, 3>  a{1, 2, 3};
+     * ysc::matrix<long, 3> b = a;  // converting copy
+     * @endcode
+     *
+     * @ingroup ysc_construction
      */
     template <class U>
         requires matrix_convertible_from<T, U>
@@ -302,6 +505,13 @@ public:
      *
      * Elements of the matrix are move-initialized from the elements of the
      * source matrix. `other` is left in a valid but unspecified state.
+     *
+     * @code
+     * ysc::matrix<int, 3> a{1, 2, 3};
+     * ysc::matrix<int, 3> b = std::move(a);
+     * @endcode
+     *
+     * @ingroup ysc_construction
      */
     matrix(matrix&& other) = default;
 
@@ -312,6 +522,13 @@ public:
      *
      * Elements of the matrix are move-initialized from the elements of the
      * source matrix. `other` is left in a valid but unspecified state.
+     *
+     * @code
+     * ysc::matrix<int, 3>  a{1, 2, 3};
+     * ysc::matrix<long, 3> b = std::move(a);  // converting move
+     * @endcode
+     *
+     * @ingroup ysc_construction
      */
     template <class U>
         requires matrix_convertible_from<T, U>
@@ -338,7 +555,7 @@ public:
      * m2(0) = 99;                              // does not affect m
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     explicit matrix(const matrix_view<T, contiguous, Dimensions...>& v) {
         std::copy(v.begin(), v.end(), _data.begin());
@@ -361,7 +578,7 @@ public:
      * m2(0) = 99;                              // does not affect m
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     explicit matrix(const matrix_view<T, strided, Dimensions...>& v) {
         if constexpr (sizeof...(Dimensions) == 1) {
@@ -385,7 +602,7 @@ public:
      * assert(m(0) == 1);
      * @endcode
      *
-     * @ingroup ysc_matrix
+     * @ingroup ysc_construction
      */
     explicit matrix(std::array<T, linear_size> data) noexcept(
         std::is_nothrow_move_constructible_v<T>)
@@ -401,7 +618,7 @@ public:
      * assert(m(0) == 4);
      * @endcode
      *
-     * @ingroup ysc_matrix
+     * @ingroup ysc_construction
      */
     explicit matrix(std::span<const T, linear_size> data) {
         std::copy(data.begin(), data.end(), _data.begin());
@@ -411,13 +628,28 @@ public:
     /**
      * @brief Assigns values to a matrix.
      * @param other Source matrix
+     *
+     * @code
+     * ysc::matrix<int, 3> a{1, 2, 3}, b{4, 5, 6};
+     * a = b;
+     * @endcode
+     *
+     * @ingroup ysc_construction
      */
     matrix& operator=(matrix const& other) = default;
 
     /**
-     * @brief Assigns values to a matrix.
+     * @brief Assigns values to a matrix with element type conversion.
      * @tparam U     Element type of the source matrix
      * @param  other Source matrix
+     *
+     * @code
+     * ysc::matrix<long, 3> a;
+     * ysc::matrix<int, 3>  b{1, 2, 3};
+     * a = b;  // converting assignment
+     * @endcode
+     *
+     * @ingroup ysc_construction
      */
     template <class U>
         requires matrix_convertible_from<T, U>
@@ -428,15 +660,30 @@ public:
 
     // assignment operators (move)
     /**
-     * @brief Replace the element with those of another matrix.
-     * @param other Source matrix
+     * @brief Replaces the elements with those of another matrix (move).
+     * @param other Source matrix — left in a valid but unspecified state
+     *
+     * @code
+     * ysc::matrix<int, 3> a{1, 2, 3}, b;
+     * b = std::move(a);
+     * @endcode
+     *
+     * @ingroup ysc_construction
      */
     matrix& operator=(matrix&& other) = default;
 
     /**
-     * @brief Replaces the element with those of another matrix.
+     * @brief Replaces the elements with those of another matrix (converting move).
      * @tparam U     Element type of the source matrix
-     * @param  other Source matrix
+     * @param  other Source matrix — left in a valid but unspecified state
+     *
+     * @code
+     * ysc::matrix<long, 3> a;
+     * ysc::matrix<int, 3>  b{1, 2, 3};
+     * a = std::move(b);
+     * @endcode
+     *
+     * @ingroup ysc_construction
      */
     template <class U>
         requires matrix_convertible_from<T, U>
@@ -452,12 +699,35 @@ public:
     ~matrix() = default;
 
     // comparison operators
-    /** @brief Equality comparison — lexicographic on the flat row-major
-     * storage.
+
+    /**
+     * @brief Equality comparison — lexicographic on the flat row-major storage.
+     * @param lhs Left-hand matrix
+     * @param rhs Right-hand matrix
+     * @return @c true if all elements are equal in row-major order
+     *
+     * @code
+     * ysc::matrix<int, 2> a{1, 2}, b{1, 2}, c{1, 3};
+     * assert(a == b);
+     * assert(a != c);
+     * @endcode
+     *
+     * @ingroup ysc_comparison
      */
     friend bool operator==(const matrix& lhs, const matrix& rhs) = default;
-    /** @brief Three-way comparison — lexicographic on the flat row-major
-     * storage.
+
+    /**
+     * @brief Three-way comparison — lexicographic on the flat row-major storage.
+     * @param lhs Left-hand matrix
+     * @param rhs Right-hand matrix
+     * @return Ordering result (strong, weak, or partial — inherits from @c T)
+     *
+     * @code
+     * ysc::matrix<int, 2> a{1, 2}, b{1, 3};
+     * assert((a <=> b) < 0);
+     * @endcode
+     *
+     * @ingroup ysc_comparison
      */
     friend auto operator<=>(const matrix& lhs, const matrix& rhs) = default;
 
@@ -1034,6 +1304,14 @@ public:
     /**
      * @brief Assigns the given value to all elements of the matrix.
      * @param value Value to assign
+     *
+     * @code
+     * ysc::matrix<int, 3> m{1, 2, 3};
+     * m.fill(0);
+     * assert(m(0) == 0 && m(2) == 0);
+     * @endcode
+     *
+     * @ingroup ysc_modifiers
      */
     constexpr void fill(const T& value) noexcept(std::is_nothrow_copy_assignable_v<T>) {
         _data.fill(value);
@@ -1042,48 +1320,86 @@ public:
     /**
      * @brief Exchanges the contents of this matrix with another.
      * @param other Matrix to swap with
+     *
+     * @code
+     * ysc::matrix<int, 2> a{1, 2}, b{3, 4};
+     * a.swap(b);
+     * assert(a(0) == 3 && b(0) == 1);
+     * @endcode
+     *
+     * @ingroup ysc_modifiers
      */
     void swap(matrix& other) noexcept(std::is_nothrow_swappable_v<T>) { _data.swap(other._data); }
 
     // element access
     /**
-     * @brief Returns a reference to the first element in the matrix (row-major
-     * order).
+     * @brief Returns a reference to the first element in the matrix (row-major order).
+     * @return Reference to the first element
      *
      * Calling @c front() on an empty matrix is undefined behavior.
+     *
+     * @code
+     * ysc::matrix<int, 3> m{1, 2, 3};
+     * assert(m.front() == 1);
+     * m.front() = 99;
+     * @endcode
+     *
+     * @ingroup ysc_modifiers
      */
     constexpr reference front() noexcept { return _data.front(); }
 
     /**
-     * @brief Returns a const reference to the first element in the matrix
-     * (row-major order).
+     * @brief Returns a const reference to the first element in the matrix (row-major order).
+     * @return Const reference to the first element
      *
      * Calling @c front() on an empty matrix is undefined behavior.
+     *
+     * @see front()
+     * @ingroup ysc_modifiers
      */
     [[nodiscard]] constexpr const_reference front() const noexcept { return _data.front(); }
 
     /**
-     * @brief Returns a reference to the last element in the matrix (row-major
-     * order).
+     * @brief Returns a reference to the last element in the matrix (row-major order).
+     * @return Reference to the last element
      *
      * Calling @c back() on an empty matrix is undefined behavior.
+     *
+     * @code
+     * ysc::matrix<int, 3> m{1, 2, 3};
+     * assert(m.back() == 3);
+     * m.back() = 99;
+     * @endcode
+     *
+     * @ingroup ysc_modifiers
      */
     constexpr reference back() noexcept { return _data.back(); }
 
     /**
-     * @brief Returns a const reference to the last element in the matrix
-     * (row-major order).
+     * @brief Returns a const reference to the last element in the matrix (row-major order).
+     * @return Const reference to the last element
      *
      * Calling @c back() on an empty matrix is undefined behavior.
+     *
+     * @see back()
+     * @ingroup ysc_modifiers
      */
     [[nodiscard]] constexpr const_reference back() const noexcept { return _data.back(); }
 
     /**
-     * @brief Returns a reference to the element at coordinates.
+     * @brief Returns a const reference to the element at the given coordinates (unchecked).
      * @param coordinates Coordinates of the element to return
+     * @return Const reference to the element
      *
-     * No bounds checking is performed; if @c coordinates are outside od
+     * No bounds checking is performed; if @c coordinates are outside of
      * the matrix dimensions, the behavior is undefined.
+     *
+     * @code
+     * const ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+     * assert(m(1, 2) == 6);
+     * @endcode
+     *
+     * @ingroup ysc_access
      */
     template <class... Coords>
         requires integral_coordinates<Coords...>
@@ -1094,11 +1410,19 @@ public:
     }
 
     /**
-     * @brief Returns a reference to the element at coordinates.
+     * @brief Returns a reference to the element at the given coordinates (unchecked).
      * @param coordinates Coordinates of the element to return
+     * @return Reference to the element
      *
-     * No bounds checking is performed; if @c coordinates are outside od
+     * No bounds checking is performed; if @c coordinates are outside of
      * the matrix dimensions, the behavior is undefined.
+     *
+     * @code
+     * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+     * m(1, 2) = 99;
+     * @endcode
+     *
+     * @ingroup ysc_access
      */
     template <class... Coords>
         requires integral_coordinates<Coords...>
@@ -1109,19 +1433,18 @@ public:
     }
 
     /**
-     * @brief Returns a reference to the element at coordinates.
+     * @brief Returns a const reference to the element at coordinates (bounds-checked).
      * @param coordinates Coordinates of the element to return
+     * @return Const reference to the element
      *
-     * If @a coordinates is not within the range of the container, an exception
-     * of type @c std::out_of_range is thrown with a message of the form:
+     * @throws std::out_of_range if any coordinate is negative or exceeds the dimension size
+     *
      * @code
-     * "matrix::at: coordinate <c> is out of bounds for dimension <i> (size=<s>)"
+     * const ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+     * assert(m.at(0, 2) == 3);
      * @endcode
-     * where @c c is the offending coordinate value, @c i is the dimension index,
-     * and @c s is the size of that dimension.
      *
-     * @throws std::out_of_range if any coordinate is negative or exceeds the
-     * dimension size
+     * @ingroup ysc_access
      */
     template <class... Coords>
         requires integral_coordinates<Coords...>
@@ -1143,19 +1466,18 @@ public:
     }
 
     /**
-     * @brief Returns a reference to the element at coordinates.
+     * @brief Returns a reference to the element at coordinates (bounds-checked).
      * @param coordinates Coordinates of the element to return
+     * @return Reference to the element
      *
-     * If @a coordinates is not within the range of the container, an exception
-     * of type @c std::out_of_range is thrown with a message of the form:
+     * @throws std::out_of_range if any coordinate is negative or exceeds the dimension size
+     *
      * @code
-     * "matrix::at: coordinate <c> is out of bounds for dimension <i> (size=<s>)"
+     * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+     * m.at(1, 0) = 42;
      * @endcode
-     * where @c c is the offending coordinate value, @c i is the dimension index,
-     * and @c s is the size of that dimension.
      *
-     * @throws std::out_of_range if any coordinate is negative or exceeds the
-     * dimension size
+     * @ingroup ysc_access
      */
     template <class... Coords>
         requires integral_coordinates<Coords...>
@@ -1198,7 +1520,7 @@ public:
      * whole matrix
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     template <typename... Specs>
         requires(sizeof...(Specs) <= order) &&
@@ -1253,7 +1575,7 @@ public:
      * auto v = m.slice(1);  // const view of row 1
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     template <typename... Specs>
         requires(sizeof...(Specs) <= order) &&
@@ -1307,7 +1629,7 @@ public:
      * r(2) = 99;          // writes m(1, 2)
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     template <std::size_t D = order>
         requires(D == 2)
@@ -1333,7 +1655,7 @@ public:
      * assert(r(0) == m(1, 0));
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     template <std::size_t D = order>
         requires(D == 2)
@@ -1360,7 +1682,7 @@ public:
      * c(1) = 99;          // writes m(1, 2)
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     template <std::size_t D = order>
         requires(D == 2)
@@ -1386,7 +1708,7 @@ public:
      * assert(c(1) == m(1, 2));
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     template <std::size_t D = order>
         requires(D == 2)
@@ -1411,7 +1733,7 @@ public:
      * }
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     template <std::size_t D = order>
         requires(D == 2)
@@ -1434,7 +1756,7 @@ public:
      * }
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     template <std::size_t D = order>
         requires(D == 2)
@@ -1457,7 +1779,7 @@ public:
      * }
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     template <std::size_t D = order>
         requires(D == 2)
@@ -1480,7 +1802,7 @@ public:
      * }
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     template <std::size_t D = order>
         requires(D == 2)
@@ -1504,7 +1826,7 @@ public:
      * v(0, 0) = 99;               // also sets m(0, 0)
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     template <std::size_t... NewD>
     [[nodiscard]] constexpr matrix_view<T, contiguous, NewD...> reshape() & noexcept {
@@ -1523,7 +1845,7 @@ public:
      * auto v = m.reshape<6>();  // matrix_view<const int, contiguous, 6>
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     template <std::size_t... NewD>
     [[nodiscard]] constexpr matrix_view<const T, contiguous, NewD...> reshape() const& noexcept {
@@ -1544,7 +1866,7 @@ public:
      * assert(v(3) == m(1, 0));
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] constexpr matrix_view<T, contiguous, linear_size> flatten() & noexcept {
         return matrix_view<T, contiguous, linear_size>{_data.data()};
@@ -1559,7 +1881,7 @@ public:
      * auto v = m.flatten();  // matrix_view<const int, contiguous, 6>
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] constexpr matrix_view<const T, contiguous, linear_size>
     flatten() const& noexcept {
@@ -1571,6 +1893,13 @@ public:
  * @brief Returns a matrix with all elements zero-initialized.
  * @tparam T  Element type
  * @tparam D  Dimensions
+ *
+ * @code
+ * auto m = ysc::zeros<int, 2, 3>();
+ * assert(m(0, 0) == 0 && m(1, 2) == 0);
+ * @endcode
+ *
+ * @ingroup ysc_construction
  */
 template <class T, std::size_t... D> constexpr matrix<T, D...> zeros() noexcept {
     return matrix<T, D...>(zero);
@@ -1581,6 +1910,13 @@ template <class T, std::size_t... D> constexpr matrix<T, D...> zeros() noexcept 
  * @tparam T  Element type
  * @tparam D  Dimensions
  * @param  v  Value to fill
+ *
+ * @code
+ * auto m = ysc::full<int, 2, 3>(7);
+ * assert(m(0, 0) == 7 && m(1, 2) == 7);
+ * @endcode
+ *
+ * @ingroup ysc_construction
  */
 template <class T, std::size_t... D> constexpr matrix<T, D...> full(const T& v) {
     auto m = zeros<T, D...>();
@@ -1592,6 +1928,13 @@ template <class T, std::size_t... D> constexpr matrix<T, D...> full(const T& v) 
  * @brief Returns a matrix with all elements set to @c T{1}.
  * @tparam T  Element type — must support construction from integer literal @c 1
  * @tparam D  Dimensions
+ *
+ * @code
+ * auto m = ysc::ones<double, 3>();
+ * assert(m(0) == 1.0 && m(2) == 1.0);
+ * @endcode
+ *
+ * @ingroup ysc_construction
  */
 template <class T, std::size_t... D>
     requires requires { T{1}; }
@@ -1603,6 +1946,13 @@ constexpr matrix<T, D...> ones() {
  * @brief Returns the N×N identity matrix (diagonal = 1, rest = 0).
  * @tparam T  Element type — must support construction from integer literal @c 1
  * @tparam N  Dimension
+ *
+ * @code
+ * auto m = ysc::identity<double, 3>();
+ * assert(m(0, 0) == 1.0 && m(0, 1) == 0.0);
+ * @endcode
+ *
+ * @ingroup ysc_construction
  */
 template <class T, std::size_t N>
     requires requires { T{1}; }
@@ -1627,7 +1977,7 @@ constexpr matrix<T, N, N> identity() {
  * // m == ysc::matrix<int, 3>{0, 2, 4}
  * @endcode
  *
- * @ingroup ysc_matrix
+ * @ingroup ysc_construction
  */
 template <class T, std::size_t... Dims, std::invocable<std::size_t> F>
 [[nodiscard]] constexpr matrix<T, Dims...> generate(F f) {

--- a/src/include/matrix_detail.hpp
+++ b/src/include/matrix_detail.hpp
@@ -22,16 +22,16 @@ namespace ysc {
 
 // ─── storage tags ────────────────────────────────────────────────────────────
 
-/** @brief Storage tag: view elements are contiguous in memory. @ingroup ysc_view */
+/** @brief Storage tag: view elements are contiguous in memory. @ingroup ysc_views */
 struct contiguous {};
-/** @brief Storage tag: view elements are non-contiguous (strided) in memory. @ingroup ysc_view */
+/** @brief Storage tag: view elements are non-contiguous (strided) in memory. @ingroup ysc_views */
 struct strided {};
 
 // ─── slice sentinel ──────────────────────────────────────────────────────────
 
 /**
  * @brief Sentinel type used in slice() to indicate "keep this dimension".
- * @ingroup ysc_view
+ * @ingroup ysc_views
  */
 struct all_t {};
 
@@ -43,7 +43,7 @@ struct all_t {};
  * auto v = m.slice(ysc::all, 2);  // keeps dims 0 and 2, fixes dim 1 at index 2
  * @endcode
  *
- * @ingroup ysc_view
+ * @ingroup ysc_views
  */
 inline constexpr all_t all{};
 
@@ -58,6 +58,7 @@ template <class T, class Storage, std::size_t... Dims> class matrix_view;
 /**
  * @brief Satisfied when all types in @c Coords are integral (ignoring cv-ref).
  * Used to constrain @c operator() and @c at() on matrix and matrix_view.
+ * @ingroup ysc_access
  */
 template <class... Coords>
 concept integral_coordinates = (std::integral<std::remove_cvref_t<Coords>> && ...);
@@ -272,7 +273,7 @@ template <class... PaddedSpecs> struct slice_helper<std::tuple<PaddedSpecs...>> 
  * assert(v(0, 0) == 1);
  * @endcode
  *
- * @ingroup ysc_view
+ * @ingroup ysc_views
  */
 template <class T, std::size_t... Dims>
 using const_matrix_view = matrix_view<const T, contiguous, Dims...>;

--- a/src/include/matrix_view.hpp
+++ b/src/include/matrix_view.hpp
@@ -33,7 +33,7 @@
 namespace ysc {
 
 /**
- * @defgroup ysc_view Views
+ * @defgroup ysc_views Views
  * @brief Non-owning read/write views over @c ysc::matrix storage.
  */
 
@@ -50,7 +50,7 @@ namespace ysc {
  * @tparam Storage Storage tag: @c ysc::contiguous or @c ysc::strided
  * @tparam Dims    Dimensions of the view
  *
- * @ingroup ysc_view
+ * @ingroup ysc_views
  */
 template <class T, class Storage, std::size_t... Dims> class matrix_view;
 
@@ -80,7 +80,7 @@ template <class T, class Storage, std::size_t... Dims> class matrix_view;
  * assert(m(0, 0) == 99);
  * @endcode
  *
- * @ingroup ysc_view
+ * @ingroup ysc_views
  */
 template <class T, std::size_t... Dimensions> class matrix_view<T, contiguous, Dimensions...> {
 public:
@@ -139,7 +139,7 @@ public:
      * ysc::matrix_view<int, ysc::contiguous, 3> v = m;
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
     constexpr matrix_view(matrix<T, Dimensions...>& m) noexcept : _ptr{m.data()} {}
@@ -158,7 +158,7 @@ public:
      * ysc::matrix_view<const int, ysc::contiguous, 3> v{m};
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     template <class U>
         requires std::same_as<T, const U>
@@ -177,7 +177,7 @@ public:
      * ysc::matrix_view<int, ysc::contiguous, 2, 3> v{buf};
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     constexpr explicit matrix_view(T* ptr) noexcept : _ptr{ptr} {}
 
@@ -205,7 +205,7 @@ public:
      * ysc::matrix_view<int, ysc::strided,    2, 3> sv = cv;  // implicit conversion
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
     operator matrix_view<T, strided, Dimensions...>() const noexcept;
@@ -215,56 +215,56 @@ public:
     /**
      * @brief Returns an iterator to the first element (row-major order).
      * @return Iterator to the first element
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     constexpr iterator begin() noexcept { return _ptr; }
 
     /**
      * @brief Returns a const iterator to the first element (row-major order).
      * @return Const iterator to the first element
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] constexpr const_iterator begin() const noexcept { return _ptr; }
 
     /**
      * @brief Returns a const iterator to the first element (row-major order).
      * @return Const iterator to the first element
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] constexpr const_iterator cbegin() const noexcept { return _ptr; }
 
     /**
      * @brief Returns an iterator past the last element.
      * @return Iterator past the last element
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     constexpr iterator end() noexcept { return end_ptr(); }
 
     /**
      * @brief Returns a const iterator past the last element.
      * @return Const iterator past the last element
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] constexpr const_iterator end() const noexcept { return end_ptr(); }
 
     /**
      * @brief Returns a const iterator past the last element.
      * @return Const iterator past the last element
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] constexpr const_iterator cend() const noexcept { return end_ptr(); }
 
     /**
      * @brief Returns a reverse iterator to the last element.
      * @return Reverse iterator to the last element
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     constexpr reverse_iterator rbegin() noexcept { return reverse_iterator{end_ptr()}; }
 
     /**
      * @brief Returns a const reverse iterator to the last element.
      * @return Const reverse iterator to the last element
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] constexpr const_reverse_iterator rbegin() const noexcept {
         return const_reverse_iterator{end_ptr()};
@@ -273,7 +273,7 @@ public:
     /**
      * @brief Returns a const reverse iterator to the last element.
      * @return Const reverse iterator to the last element
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] constexpr const_reverse_iterator crbegin() const noexcept {
         return const_reverse_iterator{end_ptr()};
@@ -282,14 +282,14 @@ public:
     /**
      * @brief Returns a reverse iterator past the first element.
      * @return Reverse iterator past the first element
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     constexpr reverse_iterator rend() noexcept { return reverse_iterator{_ptr}; }
 
     /**
      * @brief Returns a const reverse iterator past the first element.
      * @return Const reverse iterator past the first element
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] constexpr const_reverse_iterator rend() const noexcept {
         return const_reverse_iterator{_ptr};
@@ -298,7 +298,7 @@ public:
     /**
      * @brief Returns a const reverse iterator past the first element.
      * @return Const reverse iterator past the first element
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] constexpr const_reverse_iterator crend() const noexcept {
         return const_reverse_iterator{_ptr};
@@ -316,7 +316,7 @@ public:
      * static_assert(ysc::matrix_view<int, ysc::contiguous, 2, 3>::size() == 6);
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] static constexpr size_type size() noexcept { return linear_size; }
 
@@ -326,7 +326,7 @@ public:
      *
      * @note This function is @c static because the value is a compile-time constant.
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] static constexpr size_type max_size() noexcept { return linear_size; }
 
@@ -336,7 +336,7 @@ public:
      *
      * @note This function is @c static because the value is a compile-time constant.
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] static constexpr bool empty() noexcept { return linear_size == 0; }
 
@@ -346,7 +346,7 @@ public:
      *
      * Elements are stored in row-major order (rightmost dimension is contiguous).
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] constexpr pointer data() noexcept { return _ptr; }
 
@@ -356,7 +356,7 @@ public:
      *
      * Elements are stored in row-major order (rightmost dimension is contiguous).
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] constexpr const_pointer data() const noexcept { return _ptr; }
 
@@ -367,7 +367,7 @@ public:
      *
      * Calling @c front() on an empty view is undefined behavior.
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     constexpr reference front() noexcept { return *_ptr; }
 
@@ -376,7 +376,7 @@ public:
      *
      * Calling @c front() on an empty view is undefined behavior.
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] constexpr const_reference front() const noexcept { return *_ptr; }
 
@@ -385,7 +385,7 @@ public:
      *
      * Calling @c back() on an empty view is undefined behavior.
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     constexpr reference back() noexcept { return *(end_ptr() - 1); }
@@ -395,7 +395,7 @@ public:
      *
      * Calling @c back() on an empty view is undefined behavior.
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     [[nodiscard]] constexpr const_reference back() const noexcept { return *(end_ptr() - 1); }
@@ -414,7 +414,7 @@ public:
      * assert(v(1, 2) == 6);
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     template <class... Coords>
         requires integral_coordinates<Coords...>
@@ -439,7 +439,7 @@ public:
      * assert(m(0, 0) == 99);
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     template <class... Coords>
         requires integral_coordinates<Coords...>
@@ -467,7 +467,7 @@ public:
      * assert(v.at(1, 2) == 6);
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     template <class... Coords>
         requires integral_coordinates<Coords...>
@@ -507,7 +507,7 @@ public:
      * assert(m(0, 0) == 99);
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     template <class... Coords>
         requires integral_coordinates<Coords...>
@@ -543,7 +543,7 @@ public:
      * assert(m(0) == 0 && m(2) == 0);
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     constexpr void fill(const T& value) noexcept(std::is_nothrow_copy_assignable_v<T>) {
         std::fill(begin(), end(), value);
@@ -565,7 +565,7 @@ public:
      * auto sub = row0.slice(2);    // matrix_view<int, contiguous, 2> — last 2 elements
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     template <typename... Specs>
         requires(sizeof...(Specs) <= order) &&
@@ -617,7 +617,7 @@ public:
      * auto r   = v2d.row(1);  // contiguous view of row 1 — 4 elements
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     template <std::size_t D = order>
         requires(D == 2)
@@ -642,7 +642,7 @@ public:
      * auto c   = v2d.col(2);  // strided view of column 2 — 3 elements, stride 4
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     template <std::size_t D = order>
         requires(D == 2)
@@ -684,7 +684,7 @@ public:
  * assert(m(1, 2) == 99);
  * @endcode
  *
- * @ingroup ysc_view
+ * @ingroup ysc_views
  */
 template <class T, std::size_t... Dimensions> class matrix_view<T, strided, Dimensions...> {
 public:
@@ -724,7 +724,7 @@ public:
      * Advances by @c _stride elements per step.  Satisfies
      * `std::random_access_iterator` (but not `std::contiguous_iterator`).
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     struct iterator {
         /** @brief Iterator category: random-access (not contiguous). */
@@ -818,7 +818,7 @@ public:
 
     /**
      * @brief Const random-access iterator over a 1-D strided view.
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     struct const_iterator {
         /** @brief Iterator category: random-access (not contiguous). */
@@ -932,7 +932,7 @@ public:
      * assert(v(0) == 1 && v(1) == 3 && v(2) == 5);
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     constexpr explicit matrix_view(T* ptr,
                                    std::array<std::size_t, sizeof...(Dimensions)> strides) noexcept
@@ -961,21 +961,21 @@ public:
      * static_assert(ysc::matrix_view<int, ysc::strided, 3, 4>::size() == 12);
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] static constexpr size_type size() noexcept { return linear_size; }
 
     /**
      * @brief Returns the maximum number of elements the view can address.
      * @return Maximum number of elements (always equal to @c size())
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] static constexpr size_type max_size() noexcept { return linear_size; }
 
     /**
      * @brief Returns whether the view has no elements.
      * @return @c true if @c linear_size == 0
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] static constexpr bool empty() noexcept { return linear_size == 0; }
 
@@ -993,7 +993,7 @@ public:
      * int sum = std::accumulate(col.begin(), col.end(), 0);
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     iterator begin() noexcept
         requires(order == 1)
@@ -1005,7 +1005,7 @@ public:
     /**
      * @brief Returns a const iterator to the first element of a 1-D strided view.
      * @return Const iterator to the first element
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] const_iterator begin() const noexcept
         requires(order == 1)
@@ -1017,7 +1017,7 @@ public:
     /**
      * @brief Returns a const iterator to the first element of a 1-D strided view.
      * @return Const iterator to the first element
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] const_iterator cbegin() const noexcept
         requires(order == 1)
@@ -1029,7 +1029,7 @@ public:
     /**
      * @brief Returns an iterator past the last element of a 1-D strided view.
      * @return Iterator past the last element
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     iterator end() noexcept
         requires(order == 1)
@@ -1041,7 +1041,7 @@ public:
     /**
      * @brief Returns a const iterator past the last element of a 1-D strided view.
      * @return Const iterator past the last element
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] const_iterator end() const noexcept
         requires(order == 1)
@@ -1053,7 +1053,7 @@ public:
     /**
      * @brief Returns a const iterator past the last element of a 1-D strided view.
      * @return Const iterator past the last element
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] const_iterator cend() const noexcept
         requires(order == 1)
@@ -1079,7 +1079,7 @@ public:
      * assert(col(1) == m(1, 2));
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     template <class... Coords>
         requires integral_coordinates<Coords...> && (sizeof...(Coords) == sizeof...(Dimensions))
@@ -1111,7 +1111,7 @@ public:
      * assert(m(1, 2) == 99);
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     template <class... Coords>
         requires integral_coordinates<Coords...> && (sizeof...(Coords) == sizeof...(Dimensions))
@@ -1145,7 +1145,7 @@ public:
      * assert(col.at(0) == m(0, 2));
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     template <class... Coords>
         requires integral_coordinates<Coords...> && (sizeof...(Coords) == sizeof...(Dimensions))
@@ -1185,7 +1185,7 @@ public:
      * assert(m(1, 2) == 99);
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     template <class... Coords>
         requires integral_coordinates<Coords...> && (sizeof...(Coords) == sizeof...(Dimensions))
@@ -1219,7 +1219,7 @@ public:
      * assert(col.front() == m(0, 1));
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     constexpr reference front() noexcept { return (*this)(((void)Dimensions, std::size_t{0})...); }
 
@@ -1228,7 +1228,7 @@ public:
      *
      * Calling @c front() on an empty view is undefined behavior.
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] constexpr const_reference front() const noexcept {
         return (*this)(((void)Dimensions, std::size_t{0})...);
@@ -1245,7 +1245,7 @@ public:
      * assert(col.back() == m(2, 1));
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     constexpr reference back() noexcept { return (*this)((Dimensions - 1)...); }
 
@@ -1254,7 +1254,7 @@ public:
      *
      * Calling @c back() on an empty view is undefined behavior.
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     [[nodiscard]] constexpr const_reference back() const noexcept {
         return (*this)((Dimensions - 1)...);
@@ -1275,7 +1275,7 @@ public:
      * assert(m(1, 2) == 7);
      * @endcode
      *
-     * @ingroup ysc_view
+     * @ingroup ysc_views
      */
     constexpr void fill(const T& value) noexcept(std::is_nothrow_copy_assignable_v<T>) {
         for (std::size_t k = 0; k < linear_size; ++k) {
@@ -1294,7 +1294,7 @@ public:
  * The natural strides of a row-major contiguous view are computed at compile time.
  * Stride at dimension @c i = product of all dimensions after @c i.
  *
- * @ingroup ysc_view
+ * @ingroup ysc_views
  */
 template <class T, std::size_t... Dimensions>
 matrix_view<T, contiguous, Dimensions...>::operator matrix_view<T, strided, Dimensions...>()


### PR DESCRIPTION
## Résumé

Cette PR implémente **US-043** et couvre deux aspects complémentaires :

1. **doxygen-awesome-css v2.3.4** intégré via CMake `FetchContent` (pas de sous-module git) : thème moderne avec toggle dark/light, bouton de copie de fragments, liens de paragraphes, et table des matières interactive. La variante *default* (barre de titre en haut) est utilisée, non la variante sidebar-only.

2. **Documentation exhaustive de l'API publique** : chaque fonction publique de `matrix.hpp`, `matrix_view.hpp` et `matrix_detail.hpp` possède désormais `@brief`, `@ingroup`, et un exemple `@code`…`@endcode`. Les 12 groupes `@defgroup` sont définis et listés sur la `@mainpage`.

`WARN_AS_ERROR = YES` est activé dans `Doxyfile.in` : tout avertissement Doxygen fait échouer le build.

## Checklist des critères d'acceptation

- [x] Chaque fonction publique possède `@brief`, `@tparam`/`@param`/`@return`/`@throws` selon applicable, et un exemple `@code`…`@endcode`
- [x] Toutes les fonctions sont rattachées à l'un des 12 groupes via `@ingroup`
- [x] La `@mainpage` liste les 12 groupes ; chaque groupe est accessible en 1 clic
- [x] `cmake --build build --target doc` produit zéro avertissement Doxygen
- [x] `WARN_AS_ERROR = YES` activé — la CI sera rouge si un warning Doxygen est introduit
- [x] `GENERATE_TREEVIEW = YES` et `USE_MATHJAX = YES` actifs dans `Doxyfile.in`

## Décisions d'implémentation

- **Renommage `ysc_view` → `ysc_views`** (pluriel) partout : `matrix.hpp`, `matrix_view.hpp`, `matrix_detail.hpp`.
- **Fusion `ysc_matrix` → `ysc_construction`** : `matrix(array)`, `matrix(span)`, `generate()` intégrés dans `ysc_construction`.
- **`/* ... */` dans les blocs `@code`** interdit à l'intérieur des commentaires Doxygen `/** ... */` (ferme le commentaire) — remplacé par `//` dans l'exemple de `begin()`.
- Le job CI `docs` existant (US-006) hérite automatiquement de `WARN_AS_ERROR = YES` sans modification du workflow.