### PR TITLE
US-045 — Packaging CMake : cible ysc-matrix, alias, install, find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,20 +3,34 @@ cmake_minimum_required(VERSION 3.20)
 ##
 # general configuration
 #
-project(ysc-matrix)
-
 set(VERSION_MAJOR   0   CACHE STRING "Project major version number.")
 set(VERSION_MINOR   7   CACHE STRING "Project minor version number.")
 set(VERSION_PATCH   2   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
+project(ysc-matrix
+    VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}
+    LANGUAGES CXX
+)
+
+
+##
+# top-level detection (auto-disable tests/docs when used via FetchContent)
+#
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    set(YSC_MATRIX_IS_TOP_LEVEL ON)
+else()
+    set(YSC_MATRIX_IS_TOP_LEVEL OFF)
+endif()
+
+option(YSC_MATRIX_BUILD_TESTING       "Build tests"       ${YSC_MATRIX_IS_TOP_LEVEL})
+option(YSC_MATRIX_BUILD_DOCUMENTATION "Build Doxygen doc" ${YSC_MATRIX_IS_TOP_LEVEL})
+option(YSC_MATRIX_BUILD_EXAMPLES      "Build examples"    OFF)
+
 
 ##
 # source configuration
 #
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 add_subdirectory(src)
 
@@ -24,9 +38,8 @@ add_subdirectory(src)
 ##
 # test configuration
 #
-include(cmake/ClangFormat.cmake)
-option(BUILD_TESTING "Build the test suite" ON)
-if(BUILD_TESTING)
+if(YSC_MATRIX_BUILD_TESTING)
+    include(cmake/ClangFormat.cmake)
     enable_testing()
     add_subdirectory(test)
     include(cmake/Coverage.cmake)
@@ -50,13 +63,8 @@ endif()
 ##
 # doc generation
 #
-find_package(Doxygen)
-option(BUILD_DOCUMENTATION "Create and install the HTML based API documentation (requires Doxygen)" ${DOXYGEN_FOUND})
-
-if(BUILD_DOCUMENTATION)
-    if(NOT DOXYGEN_FOUND)
-        message(FATAL_ERROR "Doxygen is needed to build the documentation.")
-    endif()
+if(YSC_MATRIX_BUILD_DOCUMENTATION)
+    find_package(Doxygen REQUIRED)
 
     include(cmake/DoxygenAwesome.cmake)
 
@@ -72,5 +80,5 @@ if(BUILD_DOCUMENTATION)
         COMMENT "Generating API documentation with Doxygen"
         VERBATIM)
 
-    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html DESTINATION share/doc)
+    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html DESTINATION share/doc OPTIONAL)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,14 @@ else()
     set(YSC_MATRIX_IS_TOP_LEVEL OFF)
 endif()
 
-option(YSC_MATRIX_BUILD_TESTING       "Build tests"       ${YSC_MATRIX_IS_TOP_LEVEL})
-option(YSC_MATRIX_BUILD_DOCUMENTATION "Build Doxygen doc" ${YSC_MATRIX_IS_TOP_LEVEL})
-option(YSC_MATRIX_BUILD_EXAMPLES      "Build examples"    OFF)
+option(YSC_MATRIX_BUILD_TESTING  "Build tests"    ${YSC_MATRIX_IS_TOP_LEVEL})
+option(YSC_MATRIX_BUILD_EXAMPLES "Build examples" OFF)
+
+find_package(Doxygen)
+option(YSC_MATRIX_BUILD_DOCUMENTATION
+    "Build Doxygen doc (requires Doxygen)"
+    ${DOXYGEN_FOUND}
+)
 
 
 ##
@@ -64,7 +69,9 @@ endif()
 # doc generation
 #
 if(YSC_MATRIX_BUILD_DOCUMENTATION)
-    find_package(Doxygen REQUIRED)
+    if(NOT DOXYGEN_FOUND)
+        message(FATAL_ERROR "Doxygen is needed to build the documentation.")
+    endif()
 
     include(cmake/DoxygenAwesome.cmake)
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Full API reference: [yscialom.github.io/matrix](https://yscialom.github.io/matri
 
 ### CMake FetchContent (recommended)
 
+Add to your `CMakeLists.txt`:
+
 ```cmake
 include(FetchContent)
 FetchContent_Declare(
@@ -28,6 +30,34 @@ FetchContent_MakeAvailable(ysc-matrix)
 
 target_link_libraries(my_target PRIVATE ysc::matrix)
 ```
+
+Tests and documentation are automatically disabled when the library is consumed this way.
+
+### CMake find_package (system install)
+
+Install the library first:
+
+```bash
+cmake -S path/to/ysc-matrix -B build
+cmake --install build --prefix /usr/local
+```
+
+Then in your project's `CMakeLists.txt`:
+
+```cmake
+find_package(ysc-matrix CONFIG REQUIRED)
+
+target_link_libraries(my_target PRIVATE ysc::matrix)
+```
+
+Version constraints are supported:
+
+```cmake
+find_package(ysc-matrix 0.7 CONFIG REQUIRED)
+```
+
+The headers are installed to `<prefix>/include/ysc/` and the CMake package config to
+`<prefix>/lib/cmake/ysc-matrix/`.
 
 ### Manual
 

--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -12,11 +12,11 @@
 | **F — Arithmétique** | ✅ Terminée | 4/4 | ✅ US-026, ✅ US-027, ✅ US-028, ✅ US-029 |
 | **G — Algorithmes** | ✅ Terminée | 5/5 | ✅ US-030, ✅ US-031, ✅ US-032, ✅ US-033, ✅ US-034 |
 | **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
-| **I — Packaging & préparation v1.0.0** | 🔄 En cours | 4/10 | ✅ US-041, ✅ US-043, ✅ US-046, ✅ US-047, ⬜ US-038, US-040, US-042, US-045, US-048 à US-049 |
+| **I — Packaging & préparation v1.0.0** | 🔄 En cours | 5/10 | ✅ US-041, ✅ US-043, ✅ US-045, ✅ US-046, ✅ US-047, ⬜ US-038, US-040, US-042, US-048 à US-049 |
 | **J — Ergonomie & finition** | ✅ Terminée | 11/11 | ✅ US-039, ✅ US-050 à US-059 |
 | **K — Extensions pre-v1** | ⬜ Non démarrée | 0/10 | ⬜ US-060 à US-069 |
 
-**Total : 46 / 69 US**
+**Total : 47 / 69 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -39,7 +39,7 @@
 | US-041 | Gate couverture 100 % | P1 | ✅ Done |
 | US-042 | Tag `v1.0.0` | P0 (final) | ⬜ À faire |
 | US-043 | Documentation Doxygen complète | P1 | ✅ Done |
-| US-045 | Packaging CMake : cible `ysc-matrix`, alias, install, find_package | P0 | ⬜ À faire |
+| US-045 | Packaging CMake : cible `ysc-matrix`, alias, install, find_package | P0 | ✅ Done |
 | US-046 | Correctifs docs + `.gitignore` | P0 | ✅ Done |
 | US-047 | README marketing + `mainpage.md` v1 | P0 | ✅ Done |
 | US-048 | Job CI consumer test | P0 | ⬜ À faire |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,49 @@
-set(TARGET_NAME matrix)
-add_library(${TARGET_NAME} INTERFACE)
-target_include_directories(${TARGET_NAME} INTERFACE include/)
+add_library(ysc-matrix INTERFACE)
+add_library(ysc::matrix ALIAS ysc-matrix)
+set_target_properties(ysc-matrix PROPERTIES EXPORT_NAME matrix)
+target_include_directories(ysc-matrix INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include/ysc>
+)
+target_compile_features(ysc-matrix INTERFACE cxx_std_20)
+
+##
+# Install
+#
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+install(TARGETS ysc-matrix
+    EXPORT ysc-matrixTargets
+)
+
+install(EXPORT ysc-matrixTargets
+    FILE ysc-matrixTargets.cmake
+    NAMESPACE ysc::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ysc-matrix
+)
+
+install(FILES
+    include/matrix.hpp
+    include/matrix_view.hpp
+    include/matrix_detail.hpp
+    DESTINATION include/ysc
+)
+
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ysc-matrixConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/ysc-matrixConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ysc-matrix
+)
+
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/ysc-matrixConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/ysc-matrixConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/ysc-matrixConfigVersion.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ysc-matrix
+)

--- a/src/cmake/ysc-matrixConfig.cmake.in
+++ b/src/cmake/ysc-matrixConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/ysc-matrixTargets.cmake")
+
+check_required_components(ysc-matrix)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,7 +45,7 @@ add_executable(${TARGET_NAME}
     src/main.cpp
 )
 
-target_link_libraries(${TARGET_NAME} matrix GTest::gtest)
+target_link_libraries(${TARGET_NAME} ysc::matrix GTest::gtest)
 
 
 ##


### PR DESCRIPTION
## Résumé

Cette PR implémente le packaging CMake complet pour `ysc::matrix`. La bibliothèque expose désormais une cible CMake `ysc::matrix` utilisable aussi bien via `FetchContent` (sans installation système) que via `find_package` après installation. Les headers sont installés dans `<prefix>/include/ysc/`, les fichiers de config CMake dans `<prefix>/lib/cmake/ysc-matrix/`. La vérification de contrainte de version (`find_package(ysc-matrix 0.7 CONFIG REQUIRED)`) est supportée via `SameMajorVersion`. Quand la bibliothèque est consommée comme sous-projet via `FetchContent`, les tests et la documentation sont automatiquement désactivés.

## Critères d'acceptation

- [x] `target_link_libraries(my_target PRIVATE ysc::matrix)` fonctionne via `FetchContent`
- [x] `cmake --install build && find_package(ysc-matrix CONFIG REQUIRED)` fonctionne
- [x] `find_package(ysc-matrix 0.7 CONFIG REQUIRED)` vérifie la contrainte de version
- [x] Quand consommé via `FetchContent`, les tests/docs ne se déclenchent PAS dans le projet hôte
- [x] README mis à jour avec les deux méthodes d'intégration

## Décisions d'implémentation

- La cible CMake interne est `ysc-matrix` ; l'alias `ysc::matrix` couvre les consumers FetchContent. La propriété `EXPORT_NAME matrix` combinée à `NAMESPACE ysc::` dans `install(EXPORT ...)` produit `ysc::matrix` pour les consumers `find_package`.
- Le template `ysc-matrixConfig.cmake.in` est placé dans `src/cmake/` pour rester proche de la cible qu'il décrit.
- `install(DIRECTORY html DESTINATION share/doc OPTIONAL)` évite un échec d'install si la doc n'a pas été générée.
- La détection top-level (`CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR`) remplace l'option `BUILD_TESTING` par des options préfixées `YSC_MATRIX_*` pour éviter les collisions avec les projets hôtes.