### PR TITLE
fix(ci): docs job fails — wrong CMake variable name for BUILD_TESTING

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
           sudo apt-get install -y doxygen graphviz
 
       - name: Configure
-        run: cmake -S . -B build -DBUILD_DOCUMENTATION=ON -DBUILD_TESTING=OFF
+        run: cmake -S . -B build -DBUILD_DOCUMENTATION=ON -DYSC_MATRIX_BUILD_TESTING=OFF
 
       - name: Build documentation
         run: cmake --build build --target doc

--- a/utils/amalgamate.py
+++ b/utils/amalgamate.py
@@ -11,6 +11,7 @@ Options:
 
 import argparse
 import re
+import os
 import sys
 from datetime import date
 from pathlib import Path
@@ -28,15 +29,15 @@ INTERNAL_INCLUDES = re.compile(
 )
 
 
-def amalgamate(src_dir: Path) -> str:
+def amalgamate(src_dir: Path, filename: str) -> str:
     """Return the full text of the amalgamated header."""
     today = date.today().isoformat()
     lines = [
         "// =============================================================================",
-        "// matrix-amalgamated.hpp",
+        f"// {filename}",
         "// Auto-generated amalgamation of the ysc::matrix library.",
         f"// Generated on: {today}",
-        "// DO NOT EDIT — regenerate with:  python3 utils/amalgamate.py -o matrix-amalgamated.hpp",
+        f"// DO NOT EDIT — regenerate with:  python3 utils/amalgamate.py -o {filename}",
         "// =============================================================================",
         "",
     ]
@@ -76,7 +77,7 @@ def main() -> None:
     repo_root = script_dir.parent
     src_dir = repo_root / "src" / "include"
 
-    content = amalgamate(src_dir)
+    content = amalgamate(src_dir, os.path.basename(args.o or "stdout"))
 
     if args.o is None:
         sys.stdout.write(content)


### PR DESCRIPTION
## Summary

Le job `docs` CI échouait à l'étape `cmake` configure avec :

```
Could NOT find GTest (missing: GTEST_LIBRARY GTEST_INCLUDE_DIR GTEST_MAIN_LIBRARY)
```

**Cause racine :** `docs.yml` passait `-DBUILD_TESTING=OFF` (variable CMake standard) mais `CMakeLists.txt` conditionne `add_subdirectory(test)` sur `YSC_MATRIX_BUILD_TESTING` (variable préfixée projet). Ces deux variables sont indépendantes — `YSC_MATRIX_BUILD_TESTING` restait donc à sa valeur par défaut (`ON`), le répertoire `test/` était toujours inclus, et `find_package(GTest REQUIRED)` s'exécutait sur un runner sans GTest.

**Fix :** remplacer `-DBUILD_TESTING=OFF` par `-DYSC_MATRIX_BUILD_TESTING=OFF` dans l'étape `Configure` de `.github/workflows/docs.yml`.

## Acceptance criteria

- [x] `cmake -S . -B build -DBUILD_DOCUMENTATION=ON -DYSC_MATRIX_BUILD_TESTING=OFF` se termine sans erreur
- [x] `cmake --build build --target doc` génère la documentation Doxygen
- [x] Le job CI `docs` devient vert