### PR TITLE
US-038 — Cas particulier dimension 0

### DIFF
--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -12,11 +12,11 @@
 | **F — Arithmétique** | ✅ Terminée | 4/4 | ✅ US-026, ✅ US-027, ✅ US-028, ✅ US-029 |
 | **G — Algorithmes** | ✅ Terminée | 5/5 | ✅ US-030, ✅ US-031, ✅ US-032, ✅ US-033, ✅ US-034 |
 | **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
-| **I — Packaging & préparation v1.0.0** | 🔄 En cours | 6/10 | ✅ US-041, ✅ US-043, ✅ US-045, ✅ US-046, ✅ US-047, ✅ US-049, ⬜ US-038, US-040, US-042, US-048 |
+| **I — Packaging & préparation v1.0.0** | 🔄 En cours | 7/10 | ✅ US-038, ✅ US-041, ✅ US-043, ✅ US-045, ✅ US-046, ✅ US-047, ✅ US-049, ⬜ US-040, US-042, US-048 |
 | **J — Ergonomie & finition** | ✅ Terminée | 11/11 | ✅ US-039, ✅ US-050 à US-059 |
 | **K — Extensions pre-v1** | ⬜ Non démarrée | 0/10 | ⬜ US-060 à US-069 |
 
-**Total : 48 / 69 US**
+**Total : 49 / 69 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -34,7 +34,7 @@
 
 | US | Titre | Priorité | Statut |
 |----|-------|----------|--------|
-| US-038 | Cas particulier dimension 0 | P2 | ⬜ À faire |
+| US-038 | Cas particulier dimension 0 | P2 | ✅ Done |
 | US-040 | Dossier `examples/` enrichi | P1 | ⬜ À faire |
 | US-041 | Gate couverture 100 % | P1 | ✅ Done |
 | US-042 | Tag `v1.0.0` | P0 (final) | ⬜ À faire |

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -103,8 +103,6 @@ constexpr struct matrix_zero_t {
  *
  * @todo Requirements (Container, etc.)
  *
- * @todo Special case when one dimension is 0.
- *
  * ### Iterator invalidation
  * As a rule, iterators to aa matrix are never invalidated throughout the
  * lifetime of the matrix. One should take note, however, that during swap, the

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,7 @@ include_directories(include)
 #
 set(TARGET_NAME matrix-test)
 add_executable(${TARGET_NAME}
+    src/empty_matrix.cpp
     src/access.cpp
     src/accessors.cpp
     src/algorithms.cpp

--- a/test/src/empty_matrix.cpp
+++ b/test/src/empty_matrix.cpp
@@ -1,0 +1,100 @@
+#include "matrix.hpp"
+#include <gtest/gtest.h>
+#include <stdexcept>
+
+// --- static checks ---
+
+static_assert(ysc::matrix<int, 0>::size() == 0);
+static_assert(ysc::matrix<int, 0>::empty());
+
+static_assert(ysc::matrix<int, 2, 0, 3>::size() == 0);
+static_assert(ysc::matrix<int, 2, 0, 3>::empty());
+
+// --- order-1 empty matrix ---
+
+TEST(EmptyMatrix, DefaultConstruct) {
+    ysc::matrix<int, 0> m;
+    EXPECT_TRUE(m.empty());
+    EXPECT_EQ(m.size(), 0U);
+}
+
+TEST(EmptyMatrix, ZeroConstruct) {
+    ysc::matrix<int, 0> m{ysc::zero};
+    EXPECT_TRUE(m.empty());
+}
+
+TEST(EmptyMatrix, CopyConstruct) {
+    ysc::matrix<int, 0> a;
+    ysc::matrix<int, 0> b = a; // NOLINT(performance-unnecessary-copy-initialization)
+    EXPECT_EQ(a, b);
+}
+
+TEST(EmptyMatrix, FillIsNoop) {
+    ysc::matrix<int, 0> m;
+    m.fill(42);
+    EXPECT_TRUE(m.empty());
+}
+
+TEST(EmptyMatrix, BeginEqualsEnd) {
+    ysc::matrix<int, 0> m;
+    EXPECT_EQ(m.begin(), m.end());
+    EXPECT_EQ(m.cbegin(), m.cend());
+}
+
+TEST(EmptyMatrix, AtThrows) {
+    ysc::matrix<int, 0> m;
+    EXPECT_THROW(m.at(0), std::out_of_range);
+}
+
+TEST(EmptyMatrix, SumIsZero) {
+    ysc::matrix<int, 0> m;
+    EXPECT_EQ(m.sum(), 0);
+}
+
+TEST(EmptyMatrix, AllVacuouslyTrue) {
+    ysc::matrix<int, 0> m;
+    EXPECT_TRUE(m.all());
+}
+
+TEST(EmptyMatrix, AnyVacuouslyFalse) {
+    ysc::matrix<int, 0> m;
+    EXPECT_FALSE(m.any());
+}
+
+TEST(EmptyMatrix, ApplyIsNoop) {
+    ysc::matrix<int, 0> m;
+    m.apply([](int& v) { v = 99; });
+    EXPECT_TRUE(m.empty());
+}
+
+TEST(EmptyMatrix, MapReturnsEmpty) {
+    ysc::matrix<int, 0> m;
+    auto result = m.map([](int v) { return v * 2; });
+    EXPECT_TRUE(result.empty());
+}
+
+TEST(EmptyMatrix, EqualityHolds) {
+    ysc::matrix<int, 0> a;
+    ysc::matrix<int, 0> b;
+    EXPECT_EQ(a, b);
+}
+
+// --- order-3 empty matrix (one zero dimension) ---
+
+TEST(EmptyMatrix, MultiDimDefaultConstruct) {
+    ysc::matrix<int, 2, 0, 3> m;
+    EXPECT_TRUE(m.empty());
+    EXPECT_EQ(m.size(), 0U);
+}
+
+TEST(EmptyMatrix, MultiDimBeginEqualsEnd) {
+    ysc::matrix<int, 2, 0, 3> m;
+    EXPECT_EQ(m.begin(), m.end());
+    EXPECT_EQ(m.cbegin(), m.cend());
+}
+
+TEST(EmptyMatrix, MultiDimAtThrows) {
+    ysc::matrix<int, 2, 0, 3> m;
+    EXPECT_THROW(m.at(0, 0, 0), std::out_of_range);
+    EXPECT_THROW(m.at(1, 0, 2), std::out_of_range);
+}


### PR DESCRIPTION
## Résumé

Cette PR ferme US-038 : les matrices avec une dimension nulle (`matrix<T, 0>`,
`matrix<T, 2, 0, 3>`) compilent sans warning et sont couvertes par des tests dédiés.

L'implémentation s'appuie sur le comportement naturel de `std::array<T, 0>` (légal
depuis C++11). Le seul changement dans le code de la bibliothèque est la suppression
du `@todo` documentant ce cas comme non géré.

## Critères d'acceptation

- [x] `matrix<int, 0>` et `matrix<int, 2, 0, 3>` compilent sans warning
- [x] Tests dédiés `test/src/empty_matrix.cpp` (15 tests + 4 `static_assert`)

## Décisions d'implémentation

- `front()` / `back()` restent UB sur matrice vide — conformes à `std::array`, déjà documentés.
- `min()` / `max()` sont déjà contraints par `requires(linear_size > 0)` — non-callable sur matrice vide, comportement correct.
- `sum()` retourne `T{}` sur matrice vide (valeur neutre de `std::accumulate`).
- `all()` retourne `true` et `any()` retourne `false` par vacuité — conforme à la sémantique des algorithmes standard.