### PR TITLE
US-060 — Réductions par axe (sum/min/max<Axis>())

### DIFF
--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -14,9 +14,9 @@
 | **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
 | **I — Packaging & préparation v1.0.0** | 🔄 En cours | 7/10 | ✅ US-038, ✅ US-041, ✅ US-043, ✅ US-045, ✅ US-046, ✅ US-047, ✅ US-049, ⬜ US-040, US-042, US-048 |
 | **J — Ergonomie & finition** | ✅ Terminée | 11/11 | ✅ US-039, ✅ US-050 à US-059 |
-| **K — Extensions pre-v1** | ⬜ Non démarrée | 0/10 | ⬜ US-060 à US-069 |
+| **K — Extensions pre-v1** | 🔄 En cours | 1/10 | ✅ US-060, ⬜ US-061 à US-069 |
 
-**Total : 49 / 69 US**
+**Total : 50 / 69 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -65,7 +65,7 @@
 
 | US | Titre | Priorité | Statut |
 |----|-------|----------|--------|
-| US-060 | Réductions par axe (`sum<Axis>()`, etc.) | P2 | ⬜ À faire |
+| US-060 | Réductions par axe (`sum<Axis>()`, etc.) | P2 | ✅ Done |
 | US-061 | `submatrix` : extraction d'un sous-bloc N-D | P2 | ⬜ À faire |
 | US-062 | `enumerate()` : itérateur de coordonnées | P2 | ⬜ À faire |
 | US-063 | Opérateurs bit-à-bit pour types entiers | P2 | ⬜ À faire |
@@ -1615,10 +1615,10 @@ En tant qu'utilisateur, je veux calculer la somme, le min, le max d'une matrice 
 - Contrainte : `static_assert(Axis < order)`
 
 ### Critères d'acceptation
-- [ ] `matrix<int,2,3>{{1,2,3},{4,5,6}}.sum<0>()` == `matrix<int,3>{5,7,9}` (somme par colonnes)
-- [ ] `matrix<int,2,3>{{1,2,3},{4,5,6}}.sum<1>()` == `matrix<int,2>{6,15}` (somme par lignes)
-- [ ] Erreur de compilation si `Axis >= order`
-- [ ] Tests dans `test/src/reductions_axis.cpp`
+- [x] `matrix<int,2,3>{{1,2,3},{4,5,6}}.sum<0>()` == `matrix<int,3>{5,7,9}` (somme par colonnes)
+- [x] `matrix<int,2,3>{{1,2,3},{4,5,6}}.sum<1>()` == `matrix<int,2>{6,15}` (somme par lignes)
+- [x] Erreur de compilation si `Axis >= order` (contrainte `requires(Axis < order)`)
+- [x] Tests dans `test/src/reductions_axis.cpp`
 
 ---
 

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -1298,6 +1298,146 @@ public:
         return std::ranges::any_of(_data, [](const T& v) { return static_cast<bool>(v); });
     }
 
+    /**
+     * @brief Returns the sum of all elements along a given axis.
+     * @tparam Axis Axis to reduce along; must satisfy `Axis < order`
+     * @return A matrix with @c order-1 dimensions containing per-slice sums
+     *
+     * @code
+     * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+     * auto col_sums = m.sum<0>();  // matrix<int, 3>{5, 7, 9}
+     * auto row_sums = m.sum<1>();  // matrix<int, 2>{6, 15}
+     * @endcode
+     *
+     * @ingroup ysc_algorithms
+     */
+    template <std::size_t Axis>
+        requires(Axis < order)
+    [[nodiscard]] constexpr auto sum() const
+        requires std::default_initializable<T> && requires(T a, const T& b) { a += b; }
+    {
+        using result_type = detail::make_matrix_t<T, detail::drop_dim_t<Axis, Dimensions...>>;
+        result_type result(zero);
+        constexpr std::size_t axis_size = dimensions[Axis];
+        constexpr std::size_t suffix = []() constexpr -> std::size_t {
+            std::size_t s = 1;
+            for (std::size_t i = Axis + 1; i < order; ++i) {
+                s *= dimensions[i];
+            }
+            return s;
+        }();
+        constexpr std::size_t prefix = []() constexpr -> std::size_t {
+            std::size_t p = 1;
+            for (std::size_t i = 0; i < Axis; ++i) {
+                p *= dimensions[i];
+            }
+            return p;
+        }();
+        for (std::size_t p = 0; p < prefix; ++p) {
+            for (std::size_t k = 0; k < axis_size; ++k) {
+                for (std::size_t s = 0; s < suffix; ++s) {
+                    result._data[(p * suffix) + s] +=
+                        _data[(p * axis_size * suffix) + (k * suffix) + s];
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * @brief Returns the minimum of all elements along a given axis.
+     * @tparam Axis Axis to reduce along; must satisfy `Axis < order` and `dimensions[Axis] > 0`
+     * @return A matrix with @c order-1 dimensions containing per-slice minima
+     *
+     * @code
+     * ysc::matrix<int, 2, 3> m{3, 1, 4, 1, 5, 9};
+     * auto col_min = m.min<0>();  // matrix<int, 3>{1, 1, 4}
+     * auto row_min = m.min<1>();  // matrix<int, 2>{1, 1}
+     * @endcode
+     *
+     * @ingroup ysc_algorithms
+     */
+    template <std::size_t Axis>
+        requires(Axis < order && dimensions[Axis] > 0)
+    [[nodiscard]] constexpr auto min() const
+        requires std::totally_ordered<T>
+    {
+        using result_type = detail::make_matrix_t<T, detail::drop_dim_t<Axis, Dimensions...>>;
+        result_type result;
+        constexpr std::size_t axis_size = dimensions[Axis];
+        constexpr std::size_t suffix = []() constexpr -> std::size_t {
+            std::size_t s = 1;
+            for (std::size_t i = Axis + 1; i < order; ++i) {
+                s *= dimensions[i];
+            }
+            return s;
+        }();
+        constexpr std::size_t prefix = []() constexpr -> std::size_t {
+            std::size_t p = 1;
+            for (std::size_t i = 0; i < Axis; ++i) {
+                p *= dimensions[i];
+            }
+            return p;
+        }();
+        for (std::size_t p = 0; p < prefix; ++p) {
+            for (std::size_t s = 0; s < suffix; ++s) {
+                T val = _data[(p * axis_size * suffix) + s];
+                for (std::size_t k = 1; k < axis_size; ++k) {
+                    val = std::min(val, _data[(p * axis_size * suffix) + (k * suffix) + s]);
+                }
+                result._data[(p * suffix) + s] = val;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * @brief Returns the maximum of all elements along a given axis.
+     * @tparam Axis Axis to reduce along; must satisfy `Axis < order` and `dimensions[Axis] > 0`
+     * @return A matrix with @c order-1 dimensions containing per-slice maxima
+     *
+     * @code
+     * ysc::matrix<int, 2, 3> m{3, 1, 4, 1, 5, 9};
+     * auto col_max = m.max<0>();  // matrix<int, 3>{3, 5, 9}
+     * auto row_max = m.max<1>();  // matrix<int, 2>{4, 9}
+     * @endcode
+     *
+     * @ingroup ysc_algorithms
+     */
+    template <std::size_t Axis>
+        requires(Axis < order && dimensions[Axis] > 0)
+    [[nodiscard]] constexpr auto max() const
+        requires std::totally_ordered<T>
+    {
+        using result_type = detail::make_matrix_t<T, detail::drop_dim_t<Axis, Dimensions...>>;
+        result_type result;
+        constexpr std::size_t axis_size = dimensions[Axis];
+        constexpr std::size_t suffix = []() constexpr -> std::size_t {
+            std::size_t s = 1;
+            for (std::size_t i = Axis + 1; i < order; ++i) {
+                s *= dimensions[i];
+            }
+            return s;
+        }();
+        constexpr std::size_t prefix = []() constexpr -> std::size_t {
+            std::size_t p = 1;
+            for (std::size_t i = 0; i < Axis; ++i) {
+                p *= dimensions[i];
+            }
+            return p;
+        }();
+        for (std::size_t p = 0; p < prefix; ++p) {
+            for (std::size_t s = 0; s < suffix; ++s) {
+                T val = _data[(p * axis_size * suffix) + s];
+                for (std::size_t k = 1; k < axis_size; ++k) {
+                    val = std::max(val, _data[(p * axis_size * suffix) + (k * suffix) + s]);
+                }
+                result._data[(p * suffix) + s] = val;
+            }
+        }
+        return result;
+    }
+
     // modifiers
     /**
      * @brief Assigns the given value to all elements of the matrix.

--- a/src/include/matrix_detail.hpp
+++ b/src/include/matrix_detail.hpp
@@ -190,6 +190,30 @@ struct make_matrix_view<T, Storage, size_seq<KeptDims...>> {
 template <class T, class Storage, class KeptSizeSeq>
 using make_matrix_view_t = typename make_matrix_view<T, Storage, KeptSizeSeq>::type;
 
+// ─── axis-reduction metaprogramming ──────────────────────────────────────────
+
+/** @brief Removes the @c Axis-th element from a @c size_seq of dimensions (recursive helper). */
+template <std::size_t Axis, std::size_t Idx, std::size_t... Dims> struct drop_dim_impl {
+    using type = size_seq<>;
+};
+template <std::size_t Axis, std::size_t Idx, std::size_t Head, std::size_t... Tail>
+struct drop_dim_impl<Axis, Idx, Head, Tail...> {
+    using tail_seq = typename drop_dim_impl<Axis, Idx + 1, Tail...>::type;
+    using type =
+        std::conditional_t<Idx == Axis, tail_seq, typename prepend_val<Head, tail_seq>::type>;
+};
+
+/** @brief @c size_seq of @c Dims... with the @c Axis-th dimension removed. */
+template <std::size_t Axis, std::size_t... Dims>
+using drop_dim_t = typename drop_dim_impl<Axis, 0, Dims...>::type;
+
+/** @brief @c matrix<T, Dims...> constructed from a @c size_seq<Dims...>. */
+template <class T, class SizeSeq> struct make_matrix_seq;
+template <class T, std::size_t... Dims> struct make_matrix_seq<T, size_seq<Dims...>> {
+    using type = matrix<T, Dims...>;
+};
+template <class T, class SizeSeq> using make_matrix_t = typename make_matrix_seq<T, SizeSeq>::type;
+
 /**
  * @brief Centralises runtime offset and stride computations for @c slice().
  * @tparam PaddedTuple @c std::tuple of padded spec types (all_t or integral)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(${TARGET_NAME}
     src/slice.cpp
     src/ostream.cpp
     src/reductions.cpp
+    src/reductions_axis.cpp
     src/rows_cols.cpp
     src/transpose.cpp
     src/size_data.cpp

--- a/test/src/reductions_axis.cpp
+++ b/test/src/reductions_axis.cpp
@@ -1,0 +1,103 @@
+#include "matrix.hpp"
+
+#include <gtest/gtest.h>
+
+// clang-format off
+// constexpr static checks
+static_assert(ysc::matrix<int, 2, 3>{1, 2, 3, 4, 5, 6}.sum<0>() == (ysc::matrix<int, 3>{5, 7, 9}));
+static_assert(ysc::matrix<int, 2, 3>{1, 2, 3, 4, 5, 6}.sum<1>() == (ysc::matrix<int, 2>{6, 15}));
+// Axis out of bounds must not compile (verified by requires constraint — not testable at runtime)
+// clang-format on
+
+TEST(reductions_axis, sum_axis0_2d) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    ysc::matrix<int, 3> expected{5, 7, 9};
+    EXPECT_EQ(m.sum<0>(), expected);
+}
+
+TEST(reductions_axis, sum_axis1_2d) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    ysc::matrix<int, 2> expected{6, 15};
+    EXPECT_EQ(m.sum<1>(), expected);
+}
+
+TEST(reductions_axis, sum_axis0_3d) {
+    ysc::matrix<int, 2, 3, 4> m{1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+                                13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24};
+    ysc::matrix<int, 3, 4> expected{14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36};
+    EXPECT_EQ(m.sum<0>(), expected);
+}
+
+TEST(reductions_axis, sum_axis1_3d) {
+    ysc::matrix<int, 2, 3, 4> m{1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+                                13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24};
+    ysc::matrix<int, 2, 4> expected{15, 18, 21, 24, 51, 54, 57, 60};
+    EXPECT_EQ(m.sum<1>(), expected);
+}
+
+TEST(reductions_axis, sum_axis2_3d) {
+    ysc::matrix<int, 2, 3, 4> m{1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+                                13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24};
+    ysc::matrix<int, 2, 3> expected{10, 26, 42, 58, 74, 90};
+    EXPECT_EQ(m.sum<2>(), expected);
+}
+
+TEST(reductions_axis, sum_single_row) {
+    ysc::matrix<int, 1, 4> m{2, 3, 5, 7};
+    ysc::matrix<int, 4> expected{2, 3, 5, 7};
+    EXPECT_EQ(m.sum<0>(), expected);
+}
+
+TEST(reductions_axis, sum_single_col) {
+    ysc::matrix<int, 3, 1> m{10, 20, 30};
+    ysc::matrix<int, 3> expected{10, 20, 30};
+    EXPECT_EQ(m.sum<1>(), expected);
+}
+
+TEST(reductions_axis, min_axis0_2d) {
+    ysc::matrix<int, 2, 3> m{3, 1, 4, 1, 5, 9};
+    ysc::matrix<int, 3> expected{1, 1, 4};
+    EXPECT_EQ(m.min<0>(), expected);
+}
+
+TEST(reductions_axis, min_axis1_2d) {
+    ysc::matrix<int, 2, 3> m{3, 1, 4, 1, 5, 9};
+    ysc::matrix<int, 2> expected{1, 1};
+    EXPECT_EQ(m.min<1>(), expected);
+}
+
+TEST(reductions_axis, max_axis0_2d) {
+    ysc::matrix<int, 2, 3> m{3, 1, 4, 1, 5, 9};
+    ysc::matrix<int, 3> expected{3, 5, 9};
+    EXPECT_EQ(m.max<0>(), expected);
+}
+
+TEST(reductions_axis, max_axis1_2d) {
+    ysc::matrix<int, 2, 3> m{3, 1, 4, 1, 5, 9};
+    ysc::matrix<int, 2> expected{4, 9};
+    EXPECT_EQ(m.max<1>(), expected);
+}
+
+TEST(reductions_axis, min_axis0_3d) {
+    ysc::matrix<int, 2, 2, 2> m{5, 1, 3, 7, 2, 8, 6, 4};
+    ysc::matrix<int, 2, 2> expected{2, 1, 3, 4};
+    EXPECT_EQ(m.min<0>(), expected);
+}
+
+TEST(reductions_axis, max_axis2_3d) {
+    ysc::matrix<int, 2, 2, 2> m{5, 1, 3, 7, 2, 8, 6, 4};
+    ysc::matrix<int, 2, 2> expected{5, 7, 8, 6};
+    EXPECT_EQ(m.max<2>(), expected);
+}
+
+TEST(reductions_axis, sum_zero_dim_not_on_axis) {
+    ysc::matrix<int, 2, 0, 3> m{};
+    ysc::matrix<int, 0, 3> expected{};
+    EXPECT_EQ(m.sum<0>(), expected);
+}
+
+TEST(reductions_axis, sum_float) {
+    ysc::matrix<double, 2, 2> m{1.5, 2.5, 3.5, 4.5};
+    ysc::matrix<double, 2> expected{5.0, 7.0};
+    EXPECT_EQ(m.sum<0>(), expected);
+}


### PR DESCRIPTION
## Résumé

Implémente `sum<Axis>()`, `min<Axis>()` et `max<Axis>()` comme templates membres de `ysc::matrix`, réduisant la matrice le long d'un axe donné au moment de la compilation. Le type résultant (`matrix<T, Dims sans Axis...>`) est déduit par métaprogrammation via deux nouveaux helpers dans `matrix_detail.hpp` : `drop_dim_t<Axis, Dims...>` et `make_matrix_t<T, SizeSeq>`. La contrainte `requires(Axis < order)` produit une erreur de compilation propre si l'axe est hors bornes.

## Critères d'acceptation

- [x] `matrix<int,2,3>{{1,2,3},{4,5,6}}.sum<0>()` == `matrix<int,3>{5,7,9}` (somme par colonnes)
- [x] `matrix<int,2,3>{{1,2,3},{4,5,6}}.sum<1>()` == `matrix<int,2>{6,15}` (somme par lignes)
- [x] Erreur de compilation si `Axis >= order` (contrainte `requires(Axis < order)`)
- [x] Tests dans `test/src/reductions_axis.cpp`

## Décisions d'implémentation

- **Décomposition prefix/axis/suffix** : l'index plat est décomposé en `(p * axis_size * suffix) + (k * suffix) + s`, ce qui est exact en row-major et s'applique aux cas 2D et N-D.
- **`min<Axis>()` / `max<Axis>()`** : contrainte `requires(Axis < order && dimensions[Axis] > 0)` (dans un seul `()` pour éviter un bug de formatage clang-format 18 avec `&&` externe entre deux clauses `requires`).
- **`result._data`** : accès direct au membre privé via la friendship `template <class, std::size_t...> friend class matrix;` — élimine le besoin de `data()` et les avertissements d'arithmétique de pointeur.
- **Parenthèses explicites** : `(p * suffix) + s` et `(p * axis_size * suffix) + (k * suffix) + s` pour satisfaire `readability-math-missing-parentheses` de clang-tidy.