### PR TITLE
US-048 — Job CI consumer test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,7 +280,7 @@ jobs:
           include(FetchContent)
           FetchContent_Declare(ysc-matrix
               GIT_REPOSITORY https://github.com/yscialom/matrix.git
-              GIT_TAG        ${{ github.sha }}
+              GIT_TAG        ${{ github.event.pull_request.head.sha || github.sha }}
           )
           FetchContent_MakeAvailable(ysc-matrix)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,3 +257,65 @@ jobs:
 
       - name: Run clang-tidy
         run: run-clang-tidy -p build
+
+  consumer-test:
+    name: Consumer Test (Ubuntu / GCC-13)
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install GCC-13
+        uses: eclipse-score/apt-install@main
+        with:
+          packages: g++-13
+
+      - name: Create consumer project
+        run: |
+          mkdir consumer_test
+          cat > consumer_test/CMakeLists.txt << 'EOF'
+          cmake_minimum_required(VERSION 3.20)
+          project(consumer-test CXX)
+
+          include(FetchContent)
+          FetchContent_Declare(ysc-matrix
+              GIT_REPOSITORY https://github.com/yscialom/matrix.git
+              GIT_TAG        ${{ github.sha }}
+          )
+          FetchContent_MakeAvailable(ysc-matrix)
+
+          add_executable(consumer main.cpp)
+          target_link_libraries(consumer PRIVATE ysc::matrix)
+
+          enable_testing()
+          add_test(NAME consumer-run COMMAND consumer)
+          EOF
+          cat > consumer_test/main.cpp << 'EOF'
+          #include <concepts>
+          #include <matrix.hpp>
+
+          template <typename T>
+          concept sized_container = requires(T t) {
+              { t.size() } -> std::convertible_to<std::size_t>;
+          };
+
+          static_assert(sized_container<ysc::matrix<int, 2, 3>>);
+
+          int main() {
+              ysc::matrix<int, 2, 3> m;
+              m(0, 0) = 42;
+              return m(0, 0) == 42 ? 0 : 1;
+          }
+          EOF
+
+      - name: Configure consumer project
+        env:
+          CC: gcc-13
+          CXX: g++-13
+        run: cmake -S consumer_test -B consumer_test/build
+
+      - name: Build consumer project
+        run: cmake --build consumer_test/build --parallel
+
+      - name: Run consumer test
+        run: ctest --test-dir consumer_test/build --output-on-failure

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Building
 _cmake
 /build*/
+/consumer_test/
 
 # Editing
 *.orig

--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -12,11 +12,11 @@
 | **F — Arithmétique** | ✅ Terminée | 4/4 | ✅ US-026, ✅ US-027, ✅ US-028, ✅ US-029 |
 | **G — Algorithmes** | ✅ Terminée | 5/5 | ✅ US-030, ✅ US-031, ✅ US-032, ✅ US-033, ✅ US-034 |
 | **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
-| **I — Packaging & préparation v1.0.0** | 🔄 En cours | 7/10 | ✅ US-038, ✅ US-041, ✅ US-043, ✅ US-045, ✅ US-046, ✅ US-047, ✅ US-049, ⬜ US-040, US-042, US-048 |
+| **I — Packaging & préparation v1.0.0** | 🔄 En cours | 8/10 | ✅ US-038, ✅ US-041, ✅ US-043, ✅ US-045, ✅ US-046, ✅ US-047, ✅ US-048, ✅ US-049, ⬜ US-040, US-042 |
 | **J — Ergonomie & finition** | ✅ Terminée | 11/11 | ✅ US-039, ✅ US-050 à US-059 |
 | **K — Extensions pre-v1** | 🔄 En cours | 1/10 | ✅ US-060, ⬜ US-061 à US-069 |
 
-**Total : 50 / 69 US**
+**Total : 51 / 69 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -42,7 +42,7 @@
 | US-045 | Packaging CMake : cible `ysc-matrix`, alias, install, find_package | P0 | ✅ Done |
 | US-046 | Correctifs docs + `.gitignore` | P0 | ✅ Done |
 | US-047 | README marketing + `mainpage.md` v1 | P0 | ✅ Done |
-| US-048 | Job CI consumer test | P0 | ⬜ À faire |
+| US-048 | Job CI consumer test | P0 | ✅ Done |
 | US-049 | Amalgamation auto-générée par CI | P0 | ✅ Done |
 
 ## EPIC J — Ergonomie & finition


### PR DESCRIPTION
## Résumé

Ajoute un job `consumer-test` dans `.github/workflows/ci.yml` qui crée un projet CMake externe minimal, consomme `ysc::matrix` via `FetchContent` avec le SHA du commit courant (`github.sha`), et vérifie que la bibliothèque est correctement packagée pour les utilisateurs externes. Le consumer utilise un concept C++20 sans déclarer lui-même `cxx_std_20`, ce qui valide que la feature est bien propagée via l'interface de la cible CMake.

## Critères d'acceptation

- [x] Job `consumer-test` vert sur `develop`
- [x] Le job échoue si l'alias `ysc::matrix` est absent ou mal configuré (`target_link_libraries(consumer PRIVATE ysc::matrix)` échoue)
- [x] Le job échoue si `cxx_std_20` n'est pas propagé (le consumer déclare un concept C++20 sans `target_compile_features`)

## Décisions d'implémentation

- Les fichiers `consumer_test/CMakeLists.txt` et `consumer_test/main.cpp` sont générés dynamiquement dans le job CI par des heredocs shell — pas versionnés dans le repo.
- `/consumer_test/` ajouté au `.gitignore` pour protéger les développeurs qui exécuteraient le script localement.
- `FetchContent` avec `GIT_TAG ${{ github.sha }}` teste la véritable consommation depuis GitHub (clone full, pas shallow).
- Le concept `sized_container` dans `main.cpp` est suffisant pour forcer l'activation de C++20 ; inclure `<matrix.hpp>` seul suffirait aussi (utilise des concepts en interne), mais la déclaration explicite rend l'intention de test lisible.