### PR TITLE
US-063 — Opérateurs bit-à-bit pour types entiers

### DIFF
--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -14,9 +14,9 @@
 | **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
 | **I — Packaging & préparation v1.0.0** | 🔄 En cours | 8/10 | ✅ US-038, ✅ US-041, ✅ US-043, ✅ US-045, ✅ US-046, ✅ US-047, ✅ US-048, ✅ US-049, ⬜ US-040, US-042 |
 | **J — Ergonomie & finition** | ✅ Terminée | 11/11 | ✅ US-039, ✅ US-050 à US-059 |
-| **K — Extensions pre-v1** | 🔄 En cours | 1/10 | ✅ US-060, ⬜ US-061 à US-069 |
+| **K — Extensions pre-v1** | 🔄 En cours | 2/10 | ✅ US-060, ✅ US-063, ⬜ US-061, US-062, US-064 à US-069 |
 
-**Total : 51 / 69 US**
+**Total : 52 / 69 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -68,7 +68,7 @@
 | US-060 | Réductions par axe (`sum<Axis>()`, etc.) | P2 | ✅ Done |
 | US-061 | `submatrix` : extraction d'un sous-bloc N-D | P2 | ⬜ À faire |
 | US-062 | `enumerate()` : itérateur de coordonnées | P2 | ⬜ À faire |
-| US-063 | Opérateurs bit-à-bit pour types entiers | P2 | ⬜ À faire |
+| US-063 | Opérateurs bit-à-bit pour types entiers | P2 | ✅ Done |
 | US-064 | Test ASan : détection de vue dangling | P2 | ⬜ À faire |
 | US-065 | Tests de référence linalg (valeurs pré-calculées) | P2 | ⬜ À faire |
 | US-066 | CI Windows : cache vcpkg | P2 | ⬜ À faire |

--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -16,7 +16,7 @@
 | **J — Ergonomie & finition** | ✅ Terminée | 11/11 | ✅ US-039, ✅ US-050 à US-059 |
 | **K — Extensions pre-v1** | 🔄 En cours | 2/10 | ✅ US-060, ✅ US-063, ⬜ US-061, US-062, US-064 à US-069 |
 
-**Total : 52 / 69 US**
+**Total : 59 / 69 US**
 
 ## EPIC A — Infrastructure & CI/CD
 

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -1140,6 +1140,138 @@ public:
         return map([](const T& v) { return -v; });
     }
 
+    // bitwise
+
+    /**
+     * @brief Bitwise AND assignment (element-wise).
+     * @tparam Other Element type of @a other — must support @c &= with @c T
+     * @param  other Right-hand matrix
+     * @return Reference to @c *this after in-place AND
+     *
+     * @code
+     * ysc::matrix<unsigned, 3> a{0b111, 0b101, 0b010};
+     * ysc::matrix<unsigned, 3> b{0b110, 0b110, 0b110};
+     * a &= b;  // a == ysc::matrix<unsigned, 3>{0b110, 0b100, 0b010}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    template <class Other>
+    matrix& operator&=(const matrix<Other, Dimensions...>& other)
+        requires requires(T a, const Other& b) { a &= b; }
+    {
+        std::transform(_data.begin(), _data.end(), other.cbegin(), _data.begin(),
+                       [](T a, const Other& b) -> T { return a &= b; });
+        return *this;
+    }
+
+    /**
+     * @brief Bitwise OR assignment (element-wise).
+     * @tparam Other Element type of @a other — must support @c |= with @c T
+     * @param  other Right-hand matrix
+     * @return Reference to @c *this after in-place OR
+     *
+     * @code
+     * ysc::matrix<unsigned, 3> a{0b001, 0b010, 0b100};
+     * ysc::matrix<unsigned, 3> b{0b110, 0b101, 0b011};
+     * a |= b;  // a == ysc::matrix<unsigned, 3>{0b111, 0b111, 0b111}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    template <class Other>
+    matrix& operator|=(const matrix<Other, Dimensions...>& other)
+        requires requires(T a, const Other& b) { a |= b; }
+    {
+        std::transform(_data.begin(), _data.end(), other.cbegin(), _data.begin(),
+                       [](T a, const Other& b) -> T { return a |= b; });
+        return *this;
+    }
+
+    /**
+     * @brief Bitwise XOR assignment (element-wise).
+     * @tparam Other Element type of @a other — must support @c ^= with @c T
+     * @param  other Right-hand matrix
+     * @return Reference to @c *this after in-place XOR
+     *
+     * @code
+     * ysc::matrix<unsigned, 3> a{0b111, 0b101, 0b010};
+     * ysc::matrix<unsigned, 3> b{0b110, 0b110, 0b110};
+     * a ^= b;  // a == ysc::matrix<unsigned, 3>{0b001, 0b011, 0b100}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    template <class Other>
+    matrix& operator^=(const matrix<Other, Dimensions...>& other)
+        requires requires(T a, const Other& b) { a ^= b; }
+    {
+        std::transform(_data.begin(), _data.end(), other.cbegin(), _data.begin(),
+                       [](T a, const Other& b) -> T { return a ^= b; });
+        return *this;
+    }
+
+    /**
+     * @brief Left-shift assignment by scalar (element-wise).
+     * @tparam Scalar Type of the shift amount — must support @c <<= with @c T
+     * @param  s      Shift amount applied to every element
+     * @return Reference to @c *this after in-place left shift
+     *
+     * @code
+     * ysc::matrix<unsigned, 3> m{1, 2, 4};
+     * m <<= 1u;  // m == ysc::matrix<unsigned, 3>{2, 4, 8}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    template <class Scalar>
+    matrix& operator<<=(const Scalar& s)
+        requires requires(T a, const Scalar& b) { a <<= b; }
+    {
+        std::transform(_data.begin(), _data.end(), _data.begin(),
+                       [&s](T a) -> T { return a <<= s; });
+        return *this;
+    }
+
+    /**
+     * @brief Right-shift assignment by scalar (element-wise).
+     * @tparam Scalar Type of the shift amount — must support @c >>= with @c T
+     * @param  s      Shift amount applied to every element
+     * @return Reference to @c *this after in-place right shift
+     *
+     * @code
+     * ysc::matrix<unsigned, 3> m{8, 4, 2};
+     * m >>= 1u;  // m == ysc::matrix<unsigned, 3>{4, 2, 1}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    template <class Scalar>
+    matrix& operator>>=(const Scalar& s)
+        requires requires(T a, const Scalar& b) { a >>= b; }
+    {
+        std::transform(_data.begin(), _data.end(), _data.begin(),
+                       [&s](T a) -> T { return a >>= s; });
+        return *this;
+    }
+
+    /**
+     * @brief Bitwise NOT (element-wise).
+     * @return New matrix where each element @c e is replaced by @c ~e
+     *
+     * @code
+     * ysc::matrix<unsigned, 2> m{0u, 0xFFFFFFFFu};
+     * auto r = ~m;  // r == ysc::matrix<unsigned, 2>{~0u, 0u}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    [[nodiscard]] matrix operator~() const
+        requires requires(const T& a) { ~a; }
+    {
+        return map([](const T& v) { return ~v; });
+    }
+
     // algorithms
     /**
      * @defgroup ysc_algorithms Algorithms
@@ -2263,6 +2395,96 @@ template <class Ta, class Tb, std::size_t M, std::size_t N>
             result(i) += mat(i, k) * vec(k);
         }
     }
+    return result;
+}
+
+/**
+ * @brief Bitwise AND of two matrices (element-wise, mixed types).
+ * @tparam Ta   Element type of @a lhs
+ * @tparam Tb   Element type of @a rhs — must support @c & with @c Ta
+ * @tparam Dims Dimensions of both matrices
+ * @param  lhs  Left-hand matrix
+ * @param  rhs  Right-hand matrix
+ * @return New matrix where element @c i is @c lhs[i] & @c rhs[i].
+ *         Element type is `decltype(Ta{} & Tb{})`.
+ *
+ * @code
+ * ysc::matrix<unsigned, 3> a{0b111u, 0b101u, 0b010u};
+ * ysc::matrix<unsigned, 3> b{0b110u, 0b110u, 0b110u};
+ * auto r = a & b;  // r == ysc::matrix<unsigned, 3>{0b110u, 0b100u, 0b010u}
+ * @endcode
+ *
+ * @ingroup ysc_arithmetic
+ */
+template <class Ta, class Tb, std::size_t... Dims>
+    requires requires(const Ta& a, const Tb& b) { a & b; }
+[[nodiscard]] constexpr auto operator&(const matrix<Ta, Dims...>& lhs,
+                                       const matrix<Tb, Dims...>& rhs)
+    -> matrix<decltype(std::declval<const Ta&>() & std::declval<const Tb&>()), Dims...> {
+    using Tc = decltype(std::declval<const Ta&>() & std::declval<const Tb&>());
+    matrix<Tc, Dims...> result;
+    std::transform(lhs.cbegin(), lhs.cend(), rhs.cbegin(), result.begin(),
+                   [](const Ta& a, const Tb& b) -> Tc { return a & b; });
+    return result;
+}
+
+/**
+ * @brief Bitwise OR of two matrices (element-wise, mixed types).
+ * @tparam Ta   Element type of @a lhs
+ * @tparam Tb   Element type of @a rhs — must support @c | with @c Ta
+ * @tparam Dims Dimensions of both matrices
+ * @param  lhs  Left-hand matrix
+ * @param  rhs  Right-hand matrix
+ * @return New matrix where element @c i is @c lhs[i] | @c rhs[i].
+ *         Element type is `decltype(Ta{} | Tb{})`.
+ *
+ * @code
+ * ysc::matrix<unsigned, 3> a{0b001u, 0b010u, 0b100u};
+ * ysc::matrix<unsigned, 3> b{0b110u, 0b101u, 0b011u};
+ * auto r = a | b;  // r == ysc::matrix<unsigned, 3>{0b111u, 0b111u, 0b111u}
+ * @endcode
+ *
+ * @ingroup ysc_arithmetic
+ */
+template <class Ta, class Tb, std::size_t... Dims>
+    requires requires(const Ta& a, const Tb& b) { a | b; }
+[[nodiscard]] constexpr auto operator|(const matrix<Ta, Dims...>& lhs,
+                                       const matrix<Tb, Dims...>& rhs)
+    -> matrix<decltype(std::declval<const Ta&>() | std::declval<const Tb&>()), Dims...> {
+    using Tc = decltype(std::declval<const Ta&>() | std::declval<const Tb&>());
+    matrix<Tc, Dims...> result;
+    std::transform(lhs.cbegin(), lhs.cend(), rhs.cbegin(), result.begin(),
+                   [](const Ta& a, const Tb& b) -> Tc { return a | b; });
+    return result;
+}
+
+/**
+ * @brief Bitwise XOR of two matrices (element-wise, mixed types).
+ * @tparam Ta   Element type of @a lhs
+ * @tparam Tb   Element type of @a rhs — must support @c ^ with @c Ta
+ * @tparam Dims Dimensions of both matrices
+ * @param  lhs  Left-hand matrix
+ * @param  rhs  Right-hand matrix
+ * @return New matrix where element @c i is @c lhs[i] ^ @c rhs[i].
+ *         Element type is `decltype(Ta{} ^ Tb{})`.
+ *
+ * @code
+ * ysc::matrix<unsigned, 3> a{0b111u, 0b101u, 0b010u};
+ * ysc::matrix<unsigned, 3> b{0b110u, 0b110u, 0b110u};
+ * auto r = a ^ b;  // r == ysc::matrix<unsigned, 3>{0b001u, 0b011u, 0b100u}
+ * @endcode
+ *
+ * @ingroup ysc_arithmetic
+ */
+template <class Ta, class Tb, std::size_t... Dims>
+    requires requires(const Ta& a, const Tb& b) { a ^ b; }
+[[nodiscard]] constexpr auto operator^(const matrix<Ta, Dims...>& lhs,
+                                       const matrix<Tb, Dims...>& rhs)
+    -> matrix<decltype(std::declval<const Ta&>() ^ std::declval<const Tb&>()), Dims...> {
+    using Tc = decltype(std::declval<const Ta&>() ^ std::declval<const Tb&>());
+    matrix<Tc, Dims...> result;
+    std::transform(lhs.cbegin(), lhs.cend(), rhs.cbegin(), result.begin(),
+                   [](const Ta& a, const Tb& b) -> Tc { return a ^ b; });
     return result;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(${TARGET_NAME}
     src/access.cpp
     src/accessors.cpp
     src/algorithms.cpp
+    src/arithmetic_bitwise.cpp
     src/arithmetic_elementwise.cpp
     src/arithmetic_hadamard.cpp
     src/arithmetic_scalar.cpp

--- a/test/src/arithmetic_bitwise.cpp
+++ b/test/src/arithmetic_bitwise.cpp
@@ -1,0 +1,258 @@
+#include <matrix.hpp>
+
+#include <cstdint>
+
+#include <gtest/gtest.h>
+
+//
+// --- BITWISE AND ---
+//
+
+TEST(arithmetic_bitwise_and, compound_and_correct_values) {
+    ysc::matrix<unsigned, 3> a{0b111U, 0b101U, 0b010U};
+    const ysc::matrix<unsigned, 3> b{0b110U, 0b110U, 0b110U};
+    a &= b;
+    ASSERT_EQ(a, (ysc::matrix<unsigned, 3>{0b110U, 0b100U, 0b010U}));
+}
+
+TEST(arithmetic_bitwise_and, compound_and_returns_self) {
+    ysc::matrix<unsigned, 2> a{0b11U, 0b10U};
+    const ysc::matrix<unsigned, 2> b{0b10U, 0b10U};
+    ysc::matrix<unsigned, 2>& ref = (a &= b);
+    ASSERT_EQ(&ref, &a);
+}
+
+TEST(arithmetic_bitwise_and, compound_and_does_not_modify_rhs) {
+    ysc::matrix<unsigned, 2> a{0b11U, 0b10U};
+    const ysc::matrix<unsigned, 2> b{0b10U, 0b01U};
+    const ysc::matrix<unsigned, 2> b_copy = b;
+    a &= b;
+    ASSERT_EQ(b, b_copy);
+}
+
+TEST(arithmetic_bitwise_and, binary_and_correct_values) {
+    const ysc::matrix<unsigned, 3> a{0b111U, 0b101U, 0b010U};
+    const ysc::matrix<unsigned, 3> b{0b110U, 0b110U, 0b110U};
+    const auto r = a & b;
+    ASSERT_EQ(r, (ysc::matrix<unsigned, 3>{0b110U, 0b100U, 0b010U}));
+}
+
+TEST(arithmetic_bitwise_and, binary_and_does_not_modify_operands) {
+    const ysc::matrix<unsigned, 2> a{0b11U, 0b10U};
+    const ysc::matrix<unsigned, 2> b{0b01U, 0b11U};
+    const auto r = a & b;
+    ASSERT_EQ(r, (ysc::matrix<unsigned, 2>{0b01U, 0b10U}));
+    ASSERT_EQ(a, (ysc::matrix<unsigned, 2>{0b11U, 0b10U}));
+    ASSERT_EQ(b, (ysc::matrix<unsigned, 2>{0b01U, 0b11U}));
+}
+
+TEST(arithmetic_bitwise_and, binary_and_mixed_types) {
+    const ysc::matrix<uint8_t, 3> a{0xF0U, 0x0FU, 0xFFU};
+    const ysc::matrix<uint16_t, 3> b{0x00FFU, 0x00FFU, 0x00FFU};
+    const auto r = a & b;
+    // uint8_t & uint16_t -> int (or wider integral via usual arithmetic conversions)
+    ASSERT_EQ(r(0), 0xF0U & 0x00FFU);
+    ASSERT_EQ(r(1), 0x0FU & 0x00FFU);
+    ASSERT_EQ(r(2), 0xFFU & 0x00FFU);
+}
+
+TEST(arithmetic_bitwise_and, binary_and_2d_matrix) {
+    const ysc::matrix<unsigned, 2, 2> a{0b1010U, 0b1100U, 0b0011U, 0b0101U};
+    const ysc::matrix<unsigned, 2, 2> b{0b1111U, 0b1111U, 0b1111U, 0b1111U};
+    const auto r = a & b;
+    ASSERT_EQ(r, a);
+}
+
+//
+// --- BITWISE OR ---
+//
+
+TEST(arithmetic_bitwise_or, compound_or_correct_values) {
+    ysc::matrix<unsigned, 3> a{0b001U, 0b010U, 0b100U};
+    const ysc::matrix<unsigned, 3> b{0b110U, 0b101U, 0b011U};
+    a |= b;
+    ASSERT_EQ(a, (ysc::matrix<unsigned, 3>{0b111U, 0b111U, 0b111U}));
+}
+
+TEST(arithmetic_bitwise_or, compound_or_returns_self) {
+    ysc::matrix<unsigned, 2> a{0b00U, 0b01U};
+    const ysc::matrix<unsigned, 2> b{0b10U, 0b10U};
+    ysc::matrix<unsigned, 2>& ref = (a |= b);
+    ASSERT_EQ(&ref, &a);
+}
+
+TEST(arithmetic_bitwise_or, compound_or_does_not_modify_rhs) {
+    ysc::matrix<unsigned, 2> a{0b00U, 0b01U};
+    const ysc::matrix<unsigned, 2> b{0b10U, 0b10U};
+    const ysc::matrix<unsigned, 2> b_copy = b;
+    a |= b;
+    ASSERT_EQ(b, b_copy);
+}
+
+TEST(arithmetic_bitwise_or, binary_or_correct_values) {
+    const ysc::matrix<unsigned, 3> a{0b001U, 0b010U, 0b100U};
+    const ysc::matrix<unsigned, 3> b{0b110U, 0b101U, 0b011U};
+    const auto r = a | b;
+    ASSERT_EQ(r, (ysc::matrix<unsigned, 3>{0b111U, 0b111U, 0b111U}));
+}
+
+TEST(arithmetic_bitwise_or, binary_or_does_not_modify_operands) {
+    const ysc::matrix<unsigned, 2> a{0b01U, 0b10U};
+    const ysc::matrix<unsigned, 2> b{0b10U, 0b01U};
+    const auto r = a | b;
+    ASSERT_EQ(r, (ysc::matrix<unsigned, 2>{0b11U, 0b11U}));
+    ASSERT_EQ(a, (ysc::matrix<unsigned, 2>{0b01U, 0b10U}));
+    ASSERT_EQ(b, (ysc::matrix<unsigned, 2>{0b10U, 0b01U}));
+}
+
+TEST(arithmetic_bitwise_or, binary_or_mixed_types) {
+    const ysc::matrix<uint8_t, 2> a{0x00U, 0xF0U};
+    const ysc::matrix<uint16_t, 2> b{0x000FU, 0x000FU};
+    const auto r = a | b;
+    ASSERT_EQ(r(0), 0x00U | 0x000FU);
+    ASSERT_EQ(r(1), 0xF0U | 0x000FU);
+}
+
+//
+// --- BITWISE XOR ---
+//
+
+TEST(arithmetic_bitwise_xor, compound_xor_correct_values) {
+    ysc::matrix<unsigned, 3> a{0b111U, 0b101U, 0b010U};
+    const ysc::matrix<unsigned, 3> b{0b110U, 0b110U, 0b110U};
+    a ^= b;
+    ASSERT_EQ(a, (ysc::matrix<unsigned, 3>{0b001U, 0b011U, 0b100U}));
+}
+
+TEST(arithmetic_bitwise_xor, compound_xor_returns_self) {
+    ysc::matrix<unsigned, 2> a{0b11U, 0b00U};
+    const ysc::matrix<unsigned, 2> b{0b01U, 0b10U};
+    ysc::matrix<unsigned, 2>& ref = (a ^= b);
+    ASSERT_EQ(&ref, &a);
+}
+
+TEST(arithmetic_bitwise_xor, compound_xor_does_not_modify_rhs) {
+    ysc::matrix<unsigned, 2> a{0b11U, 0b00U};
+    const ysc::matrix<unsigned, 2> b{0b01U, 0b10U};
+    const ysc::matrix<unsigned, 2> b_copy = b;
+    a ^= b;
+    ASSERT_EQ(b, b_copy);
+}
+
+TEST(arithmetic_bitwise_xor, binary_xor_correct_values) {
+    const ysc::matrix<unsigned, 3> a{0b111U, 0b101U, 0b010U};
+    const ysc::matrix<unsigned, 3> b{0b110U, 0b110U, 0b110U};
+    const auto r = a ^ b;
+    ASSERT_EQ(r, (ysc::matrix<unsigned, 3>{0b001U, 0b011U, 0b100U}));
+}
+
+TEST(arithmetic_bitwise_xor, binary_xor_does_not_modify_operands) {
+    const ysc::matrix<unsigned, 2> a{0b11U, 0b01U};
+    const ysc::matrix<unsigned, 2> b{0b10U, 0b10U};
+    const auto r = a ^ b;
+    ASSERT_EQ(r, (ysc::matrix<unsigned, 2>{0b01U, 0b11U}));
+    ASSERT_EQ(a, (ysc::matrix<unsigned, 2>{0b11U, 0b01U}));
+    ASSERT_EQ(b, (ysc::matrix<unsigned, 2>{0b10U, 0b10U}));
+}
+
+TEST(arithmetic_bitwise_xor, xor_self_is_zero) {
+    const ysc::matrix<unsigned, 3> a{1U, 2U, 3U};
+    const auto r = a ^ a;
+    ASSERT_EQ(r, (ysc::matrix<unsigned, 3>{0U, 0U, 0U}));
+}
+
+//
+// --- BITWISE NOT ---
+//
+
+TEST(arithmetic_bitwise_not, bitwise_not_correct_values) {
+    const ysc::matrix<unsigned, 3> m{0U, 0xFFFFFFFFU, 0x0F0F0F0FU};
+    const auto r = ~m;
+    ASSERT_EQ(r(0), ~0U);
+    ASSERT_EQ(r(1), ~0xFFFFFFFFU);
+    ASSERT_EQ(r(2), ~0x0F0F0F0FU);
+}
+
+TEST(arithmetic_bitwise_not, bitwise_not_does_not_modify_operand) {
+    const ysc::matrix<unsigned, 2> m{0U, 0xFFU};
+    const ysc::matrix<unsigned, 2> m_copy = m;
+    const auto r = ~m;
+    (void)r;
+    ASSERT_EQ(m, m_copy);
+}
+
+TEST(arithmetic_bitwise_not, double_not_is_identity) {
+    const ysc::matrix<unsigned, 3> m{1U, 2U, 3U};
+    ASSERT_EQ(~~m, m);
+}
+
+//
+// --- SHIFTS ---
+//
+
+TEST(arithmetic_bitwise_shift, left_shift_correct_values) {
+    ysc::matrix<unsigned, 3> m{1U, 2U, 4U};
+    m <<= 1U;
+    ASSERT_EQ(m, (ysc::matrix<unsigned, 3>{2U, 4U, 8U}));
+}
+
+TEST(arithmetic_bitwise_shift, left_shift_returns_self) {
+    ysc::matrix<unsigned, 2> m{1U, 2U};
+    ysc::matrix<unsigned, 2>& ref = (m <<= 1U);
+    ASSERT_EQ(&ref, &m);
+}
+
+TEST(arithmetic_bitwise_shift, right_shift_correct_values) {
+    ysc::matrix<unsigned, 3> m{8U, 4U, 2U};
+    m >>= 1U;
+    ASSERT_EQ(m, (ysc::matrix<unsigned, 3>{4U, 2U, 1U}));
+}
+
+TEST(arithmetic_bitwise_shift, right_shift_returns_self) {
+    ysc::matrix<unsigned, 2> m{8U, 4U};
+    ysc::matrix<unsigned, 2>& ref = (m >>= 1U);
+    ASSERT_EQ(&ref, &m);
+}
+
+TEST(arithmetic_bitwise_shift, shift_2d_matrix) {
+    ysc::matrix<unsigned, 2, 2> m{1U, 2U, 4U, 8U};
+    m <<= 2U;
+    ASSERT_EQ(m, (ysc::matrix<unsigned, 2, 2>{4U, 8U, 16U, 32U}));
+}
+
+//
+// --- COMPILE-TIME CONSTRAINTS ---
+//
+
+struct no_bitwise {
+    unsigned val;
+    bool operator==(const no_bitwise&) const = default;
+};
+
+// Helper concepts — GCC does not support bare requires-expressions in static_assert
+// when all candidates are constrained out (same workaround as in concepts.cpp).
+template <class M>
+concept matrix_and_assignable = requires(M& a, const M& b) { a &= b; };
+template <class M>
+concept matrix_or_assignable = requires(M& a, const M& b) { a |= b; };
+template <class M>
+concept matrix_xor_assignable = requires(M& a, const M& b) { a ^= b; };
+template <class M>
+concept matrix_bitnot_available = requires(const M& a) { ~a; };
+
+static_assert(!matrix_and_assignable<ysc::matrix<no_bitwise, 2>>);
+static_assert(!matrix_or_assignable<ysc::matrix<no_bitwise, 2>>);
+static_assert(!matrix_xor_assignable<ysc::matrix<no_bitwise, 2>>);
+static_assert(!matrix_bitnot_available<ysc::matrix<no_bitwise, 2>>);
+static_assert(!matrix_and_assignable<ysc::matrix<double, 2>>);
+
+static_assert(matrix_and_assignable<ysc::matrix<unsigned, 2>>);
+static_assert(matrix_or_assignable<ysc::matrix<unsigned, 2>>);
+static_assert(matrix_xor_assignable<ysc::matrix<unsigned, 2>>);
+static_assert(matrix_bitnot_available<ysc::matrix<unsigned, 2>>);
+static_assert(matrix_and_assignable<ysc::matrix<int, 2>>);
+
+TEST(arithmetic_bitwise_constraints, concept_constraints_checked_at_compile_time) {
+    // Runtime witness that the static_asserts above were checked.
+    SUCCEED();
+}


### PR DESCRIPTION
## Résumé

Ajoute les opérateurs bit-à-bit à `ysc::matrix<T, Dims...>` pour tous les types qui les supportent (types entiers, types avec opérateurs bit-à-bit définis).

Contrairement aux opérateurs arithmétiques existants (friend dans la classe, types identiques obligatoires), les opérateurs binaires `&`, `|`, `^` sont des **fonctions libres hors classe** acceptant des types d'éléments mixtes (`Ta`, `Tb`) et déduisant le type résultat avec `decltype(Ta{} OP Tb{})` — même modèle que `matmul` / `dot`.

## Critères d'acceptation

- [x] `matrix<unsigned,3>{1,2,3} & matrix<unsigned,3>{3,3,3}` compile et retourne `{1,2,3}`
- [x] `~matrix<unsigned,3>{0,0,0}` retourne matrice de `~0U`
- [x] `matrix<double,3>` avec `&` → erreur de compilation (`static_assert`)
- [x] Types mixtes : `matrix<uint8_t,3> & matrix<uint16_t,3>` compile avec type résultat déduit
- [x] 28 tests dans `test/src/arithmetic_bitwise.cpp` verts

## Décisions d'implémentation

- **Compound assignment** (`&=`, `|=`, `^=`) : membres templates sur `Other` — même pattern que les opérateurs scalaires. Utilise `other.cbegin()` (API publique) car `matrix<Other, D...>` est un type distinct dont les membres privés ne sont pas accessibles directement.
- **Opérateurs binaires** (`&`, `|`, `^`) : fonctions libres hors classe, templates sur `Ta, Tb`, type retour `matrix<decltype(Ta OP Tb), Dims...>`. Accès via API publique (`cbegin()`, `begin()`).
- **Décalages** (`<<=`, `>>=`) : membres templates sur `Scalar`, même pattern que `*=` scalaire. Pas de versions binaires `<<`/`>>` (hors spec).
- **NOT unaire** (`~`) : via `map()`, même pattern que `operator-` unaire.
- Contrainte : `requires requires(T a, const Other& b) { a OP= b; }` — exclut naturellement `double` et tout type sans opérateurs bit-à-bit.