### PR TITLE
US-069 — generate avec callable multi-index

### DIFF
--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -14,9 +14,9 @@
 | **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
 | **I — Packaging & préparation v1.0.0** | 🔄 En cours | 8/10 | ✅ US-038, ✅ US-041, ✅ US-043, ✅ US-045, ✅ US-046, ✅ US-047, ✅ US-048, ✅ US-049, ⬜ US-040, US-042 |
 | **J — Ergonomie & finition** | ✅ Terminée | 11/11 | ✅ US-039, ✅ US-050 à US-059 |
-| **K — Extensions pre-v1** | 🔄 En cours | 2/10 | ✅ US-060, ✅ US-063, ⬜ US-061, US-062, US-064 à US-069 |
+| **K — Extensions pre-v1** | 🔄 En cours | 3/10 | ✅ US-060, ✅ US-063, ✅ US-069, ⬜ US-061, US-062, US-064 à US-068 |
 
-**Total : 59 / 69 US**
+**Total : 60 / 69 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -74,7 +74,7 @@
 | US-066 | CI Windows : cache vcpkg | P2 | ⬜ À faire |
 | US-067 | Hygiène repo : `.editorconfig`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, Dependabot | P2 | ⬜ À faire |
 | US-068 | Migration guide : promesse de stabilité SemVer v1.0.0 | P2 | ⬜ À faire |
-| US-069 | `generate` avec callable multi-index | P2 | ⬜ À faire |
+| US-069 | `generate` avec callable multi-index | P2 | ✅ Done |
 
 ---
 

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -2260,6 +2260,48 @@ template <class T, std::size_t... Dims, std::invocable<std::size_t> F>
 }
 
 /**
+ * @brief Returns a matrix filled by calling @a f(i₀, i₁, …) for each N-D coordinate.
+ *
+ * This overload accepts a callable that takes @c sizeof...(Dims) arguments of type
+ * @c std::size_t — one per dimension, in row-major order.  It is selected when @a f is
+ * **not** callable with a single @c std::size_t (which would select the linear-index
+ * overload instead, preserving backward compatibility).
+ *
+ * @tparam T    Element type
+ * @tparam Dims Dimensions of the result matrix
+ * @tparam F    Callable type: @c f(i₀, …, iₙ) must be convertible to @c T
+ * @param  f    Generator callable receiving the N-D coordinates
+ * @return New @c matrix<T, Dims...> where element at @c (i₀,…,iₙ) equals @c f(i₀,…,iₙ)
+ *
+ * @code
+ * // 3×3 identity matrix
+ * auto I = ysc::generate<int, 3, 3>([](std::size_t i, std::size_t j) {
+ *     return i == j ? 1 : 0;
+ * });
+ * // Tensor: m(i,j,k) = i*100 + j*10 + k
+ * auto m = ysc::generate<int, 2, 3, 4>([](auto i, auto j, auto k) {
+ *     return int(i * 100 + j * 10 + k);
+ * });
+ * @endcode
+ *
+ * @ingroup ysc_construction
+ */
+template <class T, std::size_t... Dims, class F>
+    requires(!std::invocable<F, std::size_t> &&
+             requires(F f, std::array<std::size_t, sizeof...(Dims)> coords) {
+                 { std::apply(f, coords) } -> std::convertible_to<T>;
+             })
+[[nodiscard]] constexpr matrix<T, Dims...> generate(F f) {
+    matrix<T, Dims...> result;
+    for (std::size_t i = 0; i < matrix<T, Dims...>::size(); ++i) {
+        auto coords = detail::index_to_coordinates(matrix<T, Dims...>::dimensions, i);
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        result.begin()[i] = static_cast<T>(std::apply(f, coords));
+    }
+    return result;
+}
+
+/**
  * @defgroup ysc_linalg Linear algebra
  * @brief Linear algebra operations on @c ysc::matrix.
  */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(${TARGET_NAME}
     src/construct.cpp
     src/construct_from_buffer.cpp
     src/factories.cpp
+    src/generate_multi_index.cpp
     src/fill.cpp
     src/formatter.cpp
     src/hash.cpp

--- a/test/src/generate_multi_index.cpp
+++ b/test/src/generate_multi_index.cpp
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+// Tests for the multi-index overload of ysc::generate (US-069).
+
+#include <matrix.hpp>
+
+#include <gtest/gtest.h>
+
+// ---------------------------------------------------------------------------
+// Compile-time checks
+// ---------------------------------------------------------------------------
+
+// 2D: generate<int,2,2> with multi-index callable is constexpr
+static_assert(ysc::generate<int, 2, 2>([](std::size_t i, std::size_t j) {
+                  return int(i + j);
+              })(1, 1) == 2);
+
+// 2D: identity matrix
+static_assert(ysc::generate<int, 3, 3>([](std::size_t i, std::size_t j) {
+                  return i == j ? 1 : 0;
+              })(1, 1) == 1);
+static_assert(ysc::generate<int, 3, 3>([](std::size_t i, std::size_t j) {
+                  return i == j ? 1 : 0;
+              })(0, 1) == 0);
+
+// 3D: tensor constexpr
+static_assert(ysc::generate<int, 2, 3, 4>([](std::size_t i, std::size_t j, std::size_t k) {
+                  return int((i * 100) + (j * 10) + k);
+              })(1, 2, 3) == 123);
+
+// Backward-compat: linear-index overload still compiles and is constexpr
+static_assert(ysc::generate<int, 4>([](std::size_t k) { return int(k * k); })(2) == 4);
+
+// ---------------------------------------------------------------------------
+// Runtime tests
+// ---------------------------------------------------------------------------
+
+TEST(generate_multi_index, identity_2d) {
+    auto m = ysc::generate<int, 3, 3>([](std::size_t i, std::size_t j) { return i == j ? 1 : 0; });
+
+    for (std::size_t i = 0; i < 3; ++i) {
+        for (std::size_t j = 0; j < 3; ++j) {
+            EXPECT_EQ(m(i, j), i == j ? 1 : 0) << "at (" << i << ", " << j << ")";
+        }
+    }
+}
+
+TEST(generate_multi_index, sum_of_coords_2d) {
+    auto m = ysc::generate<int, 2, 3>([](std::size_t i, std::size_t j) { return int(i + j); });
+
+    EXPECT_EQ(m(0, 0), 0);
+    EXPECT_EQ(m(0, 2), 2);
+    EXPECT_EQ(m(1, 0), 1);
+    EXPECT_EQ(m(1, 2), 3);
+}
+
+TEST(generate_multi_index, tensor_3d) {
+    auto m = ysc::generate<int, 2, 3, 4>(
+        [](auto i, auto j, auto k) { return int((i * 100) + (j * 10) + k); });
+
+    EXPECT_EQ(m(0, 0, 0), 0);
+    EXPECT_EQ(m(1, 2, 3), 123);
+    EXPECT_EQ(m(0, 2, 3), 23);
+    EXPECT_EQ(m(1, 0, 0), 100);
+}
+
+TEST(generate_multi_index, retro_compat_linear) {
+    // The old single-size_t overload must remain usable.
+    auto v = ysc::generate<int, 4>([](std::size_t k) { return int(k * k); });
+
+    EXPECT_EQ(v(0), 0);
+    EXPECT_EQ(v(1), 1);
+    EXPECT_EQ(v(2), 4);
+    EXPECT_EQ(v(3), 9);
+}
+
+TEST(generate_multi_index, non_trivial_type) {
+    auto m = ysc::generate<double, 2, 2>(
+        [](std::size_t i, std::size_t j) { return double(i) + (0.1 * double(j)); });
+
+    EXPECT_DOUBLE_EQ(m(0, 0), 0.0);
+    EXPECT_DOUBLE_EQ(m(0, 1), 0.1);
+    EXPECT_DOUBLE_EQ(m(1, 0), 1.0);
+    EXPECT_DOUBLE_EQ(m(1, 1), 1.1);
+}
+
+TEST(generate_multi_index, row_major_order) {
+    // Verify that (i,j) coordinates follow row-major layout:
+    // element at linear index k has i = k / cols, j = k % cols.
+    constexpr std::size_t R = 3;
+    constexpr std::size_t C = 4;
+
+    auto m =
+        ysc::generate<int, R, C>([](std::size_t i, std::size_t j) { return int((i * 10) + j); });
+
+    for (std::size_t i = 0; i < R; ++i) {
+        for (std::size_t j = 0; j < C; ++j) {
+            EXPECT_EQ(m(i, j), int((i * 10) + j)) << "at (" << i << ", " << j << ")";
+        }
+    }
+}


### PR DESCRIPTION
## Résumé

Ajoute une deuxième surcharge de `ysc::generate` acceptant un callable
N-D — `f(i₀, i₁, …)` — en complément de la surcharge linéaire historique
`f(k)`. Les utilisateurs peuvent désormais construire des matrices
position-dépendantes (identité par fonction, Vandermonde, tenseur de
coordonnées…) sans dérouler l'index linéaire manuellement.

La rétrocompatibilité est totale : la contrainte `!std::invocable<F,
std::size_t>` sur la nouvelle surcharge garantit que les callables à un
seul `size_t` continuent d'utiliser l'ancienne surcharge, sans ambiguïté.

Implémentation : itération linéaire + `detail::index_to_coordinates()`
(US-044) + `std::apply`. Zero allocation, `constexpr` end-to-end.

## Critères d'acceptation

- [x] `generate<int,3,3>([](size_t i, size_t j){ return i==j?1:0; })` compile et produit l'identité 3×3
- [x] `static_assert(generate<int,2,2>([](auto i, auto j){ return int(i+j); })(1,1) == 2)` passe
- [x] Tenseur 3D : `m(1,2,3) == 123` ✅
- [x] Ancienne surcharge linéaire non cassée (test `retro_compat_linear`)
- [x] Doxygen `@brief/@tparam/@param/@return/@code/@ingroup` présent
- [x] Zéro warning clang-format et clang-tidy
- [x] Dashboard `doc/user-stories.md` mis à jour : US-069 ✅, EPIC K 2/10 → 3/10, Total 59 → 60/69