### PR TITLE
fix(doc): doc-check CI + corriger Doxygen WARN_AS_ERROR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,3 +319,20 @@ jobs:
 
       - name: Run consumer test
         run: ctest --test-dir consumer_test/build --output-on-failure
+
+  doc-check:
+    name: Doxygen build (no publish)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Doxygen
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y doxygen graphviz
+
+      - name: Configure
+        run: cmake -S . -B build -DYSC_MATRIX_BUILD_DOCUMENTATION=ON -DYSC_MATRIX_BUILD_TESTING=OFF
+
+      - name: Build documentation
+        run: cmake --build build --target doc

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -1444,10 +1444,9 @@ public:
      * @ingroup ysc_algorithms
      */
     template <std::size_t Axis>
-        requires(Axis < order)
-    [[nodiscard]] constexpr auto sum() const
-        requires std::default_initializable<T> && requires(T a, const T& b) { a += b; }
-    {
+        requires(Axis < order) && std::default_initializable<T> &&
+                requires(T a, const T& b) { a += b; }
+    [[nodiscard]] constexpr auto sum() const {
         using result_type = detail::make_matrix_t<T, detail::drop_dim_t<Axis, Dimensions...>>;
         result_type result(zero);
         constexpr std::size_t axis_size = dimensions[Axis];
@@ -1490,10 +1489,8 @@ public:
      * @ingroup ysc_algorithms
      */
     template <std::size_t Axis>
-        requires(Axis < order && dimensions[Axis] > 0)
-    [[nodiscard]] constexpr auto min() const
-        requires std::totally_ordered<T>
-    {
+        requires(Axis < order && dimensions[Axis] > 0) && std::totally_ordered<T>
+    [[nodiscard]] constexpr auto min() const {
         using result_type = detail::make_matrix_t<T, detail::drop_dim_t<Axis, Dimensions...>>;
         result_type result;
         constexpr std::size_t axis_size = dimensions[Axis];
@@ -1537,10 +1534,8 @@ public:
      * @ingroup ysc_algorithms
      */
     template <std::size_t Axis>
-        requires(Axis < order && dimensions[Axis] > 0)
-    [[nodiscard]] constexpr auto max() const
-        requires std::totally_ordered<T>
-    {
+        requires(Axis < order && dimensions[Axis] > 0) && std::totally_ordered<T>
+    [[nodiscard]] constexpr auto max() const {
         using result_type = detail::make_matrix_t<T, detail::drop_dim_t<Axis, Dimensions...>>;
         result_type result;
         constexpr std::size_t axis_size = dimensions[Axis];


### PR DESCRIPTION
## Contexte

La génération Doxygen échoue sur `develop` depuis le merge de **US-060** (réductions par axe `sum/min/max<Axis>()`). Le workflow `docs.yml` ne tournant qu'au push sur `develop` (post-merge), la régression n'a pas été détectée à temps.

## Erreur reproduite localement

```
src/include/matrix.hpp:1494: warning: Member min found in multiple @ingroup groups!
    The member will be put in group ysc_modifiers, and not in group ysc_algorithms
src/include/matrix.hpp:1575: warning: ysc::matrix::min has @param documentation
    sections but no arguments
```

Diagnostic : Doxygen 1.15.0 attribuait par erreur le bloc Doxygen de `fill()` (lignes 1574-1585) au symbole `min` à cause de la coexistence de quatre surcharges `min()`/`max()` membres avec des `requires` éclatés en deux endroits (avant signature + trailing après `const`). Le `@param value` et `@ingroup ysc_modifiers` de `fill()` se retrouvaient appliqués à `min`.

## Changements

### Fix : fusion des clauses `requires` (`src/include/matrix.hpp`)

Pour les trois surcharges per-axis `sum<Axis>()`, `min<Axis>()`, `max<Axis>()`, fusion des deux clauses `requires` en une seule placée avant la signature. Sémantiquement identique (conjonction), lève l'ambiguïté de parsing Doxygen.

Tentative initiale d'envelopper les fonctions dans un bloc `@addtogroup ysc_algorithms / @{ ... @}` rejetée : Doxygen 1.15.0 produit alors `Illegal member name found` à l'intérieur de la classe.

### Nouveau job CI `doc-check` (`.github/workflows/ci.yml`)

Job ubuntu-24.04 qui installe Doxygen, configure avec `-DYSC_MATRIX_BUILD_DOCUMENTATION=ON -DYSC_MATRIX_BUILD_TESTING=OFF` et build la cible `doc`. Pas de publication GitHub Pages — l'objectif est de bloquer toute régression doc avant merge. `WARN_AS_ERROR=YES` (déjà actif dans `Doxyfile.in:709`) garantit que le moindre warning casse le job.

## Vérifications locales

- [x] `cmake --build build --target doc` : passe sans warning
- [x] `cmake --build build --target check` : tests verts (1/1)
- [x] `cmake --build build --target format` : pas de diff
- [x] `clang-format --dry-run --Werror src/ test/` : exit 0

## Hors scope

- `docs.yml` passe `-DBUILD_DOCUMENTATION=ON` (au lieu de `-DYSC_MATRIX_BUILD_DOCUMENTATION=ON`) : flag inopérant, mais fonctionne par défaut via `DOXYGEN_FOUND`. Latent bug, à corriger dans une PR séparée.
- Le dossier `html/` à la racine (généré par un `doxygen` lancé hors `build/`) reste untracked.