### PR TITLE
fix(ci): éviter le double déclenchement push+PR sur les branches feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [develop, master]
   pull_request:
     branches: [develop, master]
 


### PR DESCRIPTION
## Problème

Chaque push sur une branche feature avec une PR ouverte déclenchait **deux exécutions** complètes de CI :
1. l'événement `push` (sans filtre de branche, donc sur toutes les branches)
2. l'événement `pull_request`

Cela doublait inutilement la consommation de minutes GitHub Actions.

## Correction

Ajout d'un filtre `branches: [develop, master]` sur le déclencheur `push`.

```yaml
# Avant
on:
  push:
  pull_request:
    branches: [develop, master]

# Après
on:
  push:
    branches: [develop, master]
  pull_request:
    branches: [develop, master]
```

## Comportement après correction

| Événement | Branche | CI déclenchée ? |
|-----------|---------|-----------------|
| `push` | `develop` / `master` | ✅ oui (merge, hotfix) |
| `pull_request` | feature → `develop` / `master` | ✅ oui (une seule fois) |
| `push` | feature branch | ❌ non (la PR couvre déjà) |

## Checklist
- [x] Plus de double exécution sur les branches feature
- [x] CI toujours déclenchée sur `develop` et `master` (merges)
- [x] CI toujours déclenchée sur les PRs