### PR TITLE
US-062 — enumerate() : itérateur de coordonnées

### DIFF
--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -73,6 +73,11 @@ constexpr struct matrix_zero_t {
  */
 
 /**
+ * @defgroup ysc_enumerate Enumerate
+ * @brief Coordinate-aware iteration over matrix elements.
+ */
+
+/**
  * @defgroup ysc_access Element access
  * @brief Unchecked and checked element access.
  */
@@ -2151,6 +2156,120 @@ public:
     [[nodiscard]] constexpr matrix_view<const T, contiguous, linear_size>
     flatten() const& noexcept {
         return matrix_view<const T, contiguous, linear_size>{_data.data()};
+    }
+
+    // ─── enumerate ───────────────────────────────────────────────────────────
+
+    /**
+     * @brief Range type returned by @c enumerate() that pairs coordinates with element references.
+     * @tparam ElemT Element type (possibly @c const — controls mutability of the reference)
+     *
+     * Iterating over this range yields @c std::pair<std::array<std::size_t, order>, ElemT&> in
+     * row-major order.  When @c ElemT is non-const, mutations to the second member of the pair
+     * are reflected in the original matrix.
+     *
+     * @ingroup ysc_enumerate
+     */
+    template <class ElemT> class enumerate_range {
+    public:
+        /** @brief Value type yielded by the iterator. */
+        using value_type = std::pair<std::array<std::size_t, order>, ElemT&>;
+
+        /**
+         * @brief Input iterator over @c enumerate_range.
+         * @ingroup ysc_enumerate
+         */
+        class iterator {
+        public:
+            using iterator_category = std::input_iterator_tag;
+            using value_type = std::pair<std::array<std::size_t, order>, ElemT&>;
+            using difference_type = std::ptrdiff_t;
+            using pointer = void;
+            using reference = value_type;
+
+            constexpr iterator(ElemT* ptr, std::size_t idx) noexcept : _ptr(ptr), _idx(idx) {}
+
+            [[nodiscard]] constexpr reference operator*() const noexcept {
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+                return {detail::index_to_coordinates(dimensions, _idx), _ptr[_idx]};
+            }
+
+            constexpr iterator& operator++() noexcept {
+                ++_idx;
+                return *this;
+            }
+
+            constexpr iterator operator++(int) noexcept {
+                iterator tmp = *this;
+                ++(*this);
+                return tmp;
+            }
+
+            [[nodiscard]] constexpr bool operator==(const iterator& other) const noexcept {
+                return _idx == other._idx;
+            }
+
+            [[nodiscard]] constexpr bool operator!=(const iterator& other) const noexcept {
+                return _idx != other._idx;
+            }
+
+        private:
+            ElemT* _ptr;
+            std::size_t _idx;
+        };
+
+        constexpr enumerate_range(ElemT* ptr, std::size_t n) noexcept : _ptr(ptr), _n(n) {}
+
+        [[nodiscard]] constexpr iterator begin() const noexcept { return iterator{_ptr, 0}; }
+        [[nodiscard]] constexpr iterator end() const noexcept { return iterator{_ptr, _n}; }
+
+    private:
+        ElemT* _ptr;
+        std::size_t _n;
+    };
+
+    /**
+     * @brief Returns a range of @c (coordinates, value) pairs in row-major order.
+     * @return An @c enumerate_range<T> whose iterator yields
+     *         @c std::pair<std::array<std::size_t, order>, T&>
+     *
+     * Each iteration step exposes both the N-D coordinates (as a
+     * @c std::array<std::size_t, order>) and a mutable reference to the element.
+     * Mutations are reflected in the original matrix.
+     *
+     * @code
+     * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+     * for (auto& [coords, val] : m.enumerate()) {
+     *     // coords == {0,0},{0,1},{0,2},{1,0},{1,1},{1,2} in order
+     *     val *= 10;  // mutates m
+     * }
+     * @endcode
+     *
+     * @ingroup ysc_enumerate
+     */
+    [[nodiscard]] constexpr enumerate_range<T> enumerate() noexcept {
+        return enumerate_range<T>{_data.data(), linear_size};
+    }
+
+    /**
+     * @brief Returns a const range of @c (coordinates, value) pairs in row-major order.
+     * @return An @c enumerate_range<const T> whose iterator yields
+     *         @c std::pair<std::array<std::size_t, order>, const T&>
+     *
+     * Read-only variant of @c enumerate().  No mutation is possible through the returned range.
+     *
+     * @code
+     * const ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+     * for (const auto& [coords, val] : m.enumerate()) {
+     *     // coords == {0,0},{0,1},{0,2},{1,0},{1,1},{1,2} in order
+     *     // val is a const int&
+     * }
+     * @endcode
+     *
+     * @ingroup ysc_enumerate
+     */
+    [[nodiscard]] constexpr enumerate_range<const T> enumerate() const noexcept {
+        return enumerate_range<const T>{_data.data(), linear_size};
     }
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(${TARGET_NAME}
     src/matrix_from_view.cpp
     src/matrix_view.cpp
     src/matrix_view_io.cpp
+    src/matrix_view_lifetime.cpp
     src/reshape.cpp
     src/slice.cpp
     src/ostream.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ include_directories(include)
 set(TARGET_NAME matrix-test)
 add_executable(${TARGET_NAME}
     src/empty_matrix.cpp
+    src/enumerate.cpp
     src/access.cpp
     src/accessors.cpp
     src/algorithms.cpp
@@ -37,7 +38,6 @@ add_executable(${TARGET_NAME}
     src/matrix_from_view.cpp
     src/matrix_view.cpp
     src/matrix_view_io.cpp
-    src/matrix_view_lifetime.cpp
     src/reshape.cpp
     src/slice.cpp
     src/ostream.cpp

--- a/test/src/enumerate.cpp
+++ b/test/src/enumerate.cpp
@@ -1,0 +1,161 @@
+#include "matrix.hpp"
+#include <gtest/gtest.h>
+#include <vector>
+
+// ─── constexpr static checks ─────────────────────────────────────────────────
+
+static_assert([] {
+    ysc::matrix<int, 3> m{10, 20, 30};
+    std::size_t idx = 0;
+    for (auto [coords, val] : m.enumerate()) {
+        if (coords[0] != idx) {
+            return false;
+        }
+        ++idx;
+    }
+    return idx == 3;
+}());
+
+static_assert([] {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    std::size_t n = 0;
+    for (auto [coords, val] : m.enumerate()) {
+        (void)coords;
+        (void)val;
+        ++n;
+    }
+    return n == 6;
+}());
+
+// ─── coordinates correctness ─────────────────────────────────────────────────
+
+TEST(MatrixEnumerate, CoordinatesCorrect1D) {
+    ysc::matrix<int, 4> m{10, 20, 30, 40};
+    std::size_t expected = 0;
+    for (auto [coords, val] : m.enumerate()) {
+        EXPECT_EQ(coords.size(), 1U);
+        EXPECT_EQ(coords[0], expected);
+        ++expected;
+    }
+    EXPECT_EQ(expected, 4U);
+}
+
+TEST(MatrixEnumerate, CoordinatesCorrect2D) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    const std::vector<std::array<std::size_t, 2>> expected_coords = {{0, 0}, {0, 1}, {0, 2},
+                                                                     {1, 0}, {1, 1}, {1, 2}};
+    std::size_t idx = 0;
+    for (auto [coords, val] : m.enumerate()) {
+        ASSERT_LT(idx, expected_coords.size());
+        EXPECT_EQ(coords, expected_coords[idx]);
+        ++idx;
+    }
+    EXPECT_EQ(idx, 6U);
+}
+
+TEST(MatrixEnumerate, CoordinatesCorrect3D) {
+    ysc::matrix<int, 2, 3, 4> m{ysc::zero};
+    std::size_t linear = 0;
+    for (auto [coords, val] : m.enumerate()) {
+        EXPECT_EQ(coords.size(), 3U);
+        // coords[0] varies slowest, coords[2] fastest
+        EXPECT_EQ(coords[0], linear / 12);
+        EXPECT_EQ(coords[1], (linear % 12) / 4);
+        EXPECT_EQ(coords[2], linear % 4);
+        ++linear;
+    }
+    EXPECT_EQ(linear, 24U);
+}
+
+// ─── value access ─────────────────────────────────────────────────────────────
+
+TEST(MatrixEnumerate, ValueMatchesDirectAccess1D) {
+    ysc::matrix<int, 5> m{10, 20, 30, 40, 50};
+    for (auto [coords, val] : m.enumerate()) {
+        EXPECT_EQ(val, m(coords[0]));
+    }
+}
+
+TEST(MatrixEnumerate, ValueMatchesDirectAccess2D) {
+    ysc::matrix<int, 3, 4> m{ysc::zero};
+    int v = 1;
+    for (std::size_t i = 0; i < 3; ++i) {
+        for (std::size_t j = 0; j < 4; ++j) {
+            m(i, j) = v++;
+        }
+    }
+    for (auto [coords, val] : m.enumerate()) {
+        EXPECT_EQ(val, m(coords[0], coords[1]));
+    }
+}
+
+// ─── mutation ─────────────────────────────────────────────────────────────────
+
+TEST(MatrixEnumerate, MutationReflectedInMatrix) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    for (auto [coords, val] : m.enumerate()) {
+        (void)coords;
+        val *= 10;
+    }
+    EXPECT_EQ(m, (ysc::matrix<int, 2, 3>{10, 20, 30, 40, 50, 60}));
+}
+
+TEST(MatrixEnumerate, MutationUsingCoordinates) {
+    ysc::matrix<int, 3, 3> m{ysc::zero};
+    for (auto [coords, val] : m.enumerate()) {
+        // set diagonal to 1
+        if (coords[0] == coords[1]) {
+            val = 1;
+        }
+    }
+    for (std::size_t i = 0; i < 3; ++i) {
+        for (std::size_t j = 0; j < 3; ++j) {
+            EXPECT_EQ(m(i, j), (i == j ? 1 : 0));
+        }
+    }
+}
+
+// ─── const overload ───────────────────────────────────────────────────────────
+
+TEST(MatrixEnumerate, ConstOverloadCompiles) {
+    const ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    std::size_t count = 0;
+    for (const auto& [coords, val] : m.enumerate()) {
+        static_assert(std::is_same_v<const int&, decltype(val)>);
+        EXPECT_EQ(val, m(coords[0], coords[1]));
+        ++count;
+    }
+    EXPECT_EQ(count, 6U);
+}
+
+TEST(MatrixEnumerate, ConstValueMatchesDirectAccess) {
+    const ysc::matrix<int, 4> m{7, 8, 9, 10};
+    for (const auto& [coords, val] : m.enumerate()) {
+        EXPECT_EQ(val, m(coords[0]));
+    }
+}
+
+// ─── row-major order ──────────────────────────────────────────────────────────
+
+TEST(MatrixEnumerate, RowMajorOrderRespected2D) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    std::vector<int> visited;
+    for (auto [coords, val] : m.enumerate()) {
+        (void)coords;
+        visited.push_back(val);
+    }
+    EXPECT_EQ(visited, (std::vector<int>{1, 2, 3, 4, 5, 6}));
+}
+
+// ─── empty matrix ─────────────────────────────────────────────────────────────
+
+TEST(MatrixEnumerate, EmptyMatrixYieldsNoIterations) {
+    ysc::matrix<int, 0> m;
+    std::size_t count = 0;
+    for (auto [coords, val] : m.enumerate()) {
+        (void)coords;
+        (void)val;
+        ++count;
+    }
+    EXPECT_EQ(count, 0U);
+}


### PR DESCRIPTION
## Résumé

Implémentation de `matrix::enumerate()` : une méthode membre (mutable et const) qui retourne un range de `std::pair<std::array<std::size_t, order>, T&>`, permettant d'itérer sur les éléments d'une matrice avec leurs coordonnées N-D en ordre row-major.

L'implémentation repose sur la classe interne `enumerate_range<ElemT>` avec son propre type itérateur, et utilise `detail::index_to_coordinates` déjà présent dans `matrix_detail.hpp` pour la conversion indice linéaire → coordonnées. Un groupe Doxygen `ysc_enumerate` a été créé pour documenter la fonctionnalité.

## Critères d'acceptation

- [x] `for (auto& [coords, val] : m.enumerate())` compile
- [x] `coords` est un `std::array<std::size_t, order>` correct pour chaque élément
- [x] Mutation via `val` se reflète dans `m`
- [x] Surcharge `const` retournant `std::pair<std::array<std::size_t, order>, const T&>`
- [x] Tests dans `test/src/enumerate.cpp`

## Tests

12 tests GTest + 2 `static_assert` constexpr couvrant :
- Coordonnées correctes pour 1D, 2D et 3D
- Accès valeur cohérent avec `operator()`
- Mutation (directe et via coordonnées)
- Surcharge const (type de référence vérifié par `static_assert`)
- Ordre row-major respecté
- Matrice de dimension 0 (aucune itération)

## Décisions d'implémentation

- `enumerate_range<ElemT>` est une classe interne template de `matrix` : `ElemT = T` pour la surcharge mutable, `ElemT = const T` pour la surcharge const — évite la duplication de code.
- L'itérateur est un **input iterator** (pas forward/random-access) car `operator*` reconstruit la paire à chaque appel (références, pas valeurs) ; `std::pair<..., T&>` n'est pas copiable.
- `operator*` retourne une valeur (pas une référence à une valeur stockée), ce qui est conforme aux input iterators.
- Le NOLINTNEXTLINE sur l'arithmétique de pointeur dans `operator*` est nécessaire pour clang-tidy.