### PR TITLE
US-064 — Test ASan : détection de vue dangling

### DIFF
--- a/src/include/matrix_view.hpp
+++ b/src/include/matrix_view.hpp
@@ -67,8 +67,11 @@ template <class T, class Storage, std::size_t... Dims> class matrix_view;
  * the lifetime of the underlying @c matrix (or raw array) must exceed that of
  * the view.
  *
- * @warning Destroying the underlying @c matrix while a view still refers to it
- *          is undefined behavior.
+ * @warning **Lifetime hazard:** a @c matrix_view does **not** extend the lifetime of
+ *          the underlying storage.  Destroying the @c matrix (or raw array) while any
+ *          view still refers to it is **undefined behavior** (heap-use-after-free).
+ *          AddressSanitizer detects this class of error at runtime; see
+ *          @c test/src/matrix_view_lifetime.cpp for a concrete example.
  *
  * Because dimensions are part of the type,
  * @c sizeof(matrix_view<T,contiguous,D...>) equals @c sizeof(T*) on every platform.
@@ -673,8 +676,11 @@ public:
  * @note Iterators and @c data() are not available (non-contiguous layout).
  *       Use @c operator() or @c at() for element access.
  *
- * @warning Destroying the underlying @c matrix while a view still refers to it
- *          is undefined behavior.
+ * @warning **Lifetime hazard:** a @c matrix_view does **not** extend the lifetime of
+ *          the underlying storage.  Destroying the @c matrix (or raw array) while any
+ *          view still refers to it is **undefined behavior** (heap-use-after-free).
+ *          AddressSanitizer detects this class of error at runtime; see
+ *          @c test/src/matrix_view_lifetime.cpp for a concrete example.
  *
  * @code
  * ysc::matrix<int, 3, 4> m{};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(${TARGET_NAME}
     src/matrix_from_view.cpp
     src/matrix_view.cpp
     src/matrix_view_io.cpp
+    src/matrix_view_lifetime.cpp
     src/reshape.cpp
     src/slice.cpp
     src/ostream.cpp

--- a/test/src/matrix_view_lifetime.cpp
+++ b/test/src/matrix_view_lifetime.cpp
@@ -1,0 +1,49 @@
+/**
+ * @file matrix_view_lifetime.cpp
+ * @brief ASan test: dangling matrix_view use-after-free detection.
+ *
+ * This test verifies that AddressSanitizer correctly detects a heap-use-after-free
+ * when a @c matrix_view outlives the @c matrix it refers to.
+ *
+ * The matrix is allocated on the heap (via @c new) so that ASan reliably poisons
+ * the freed memory and detects the subsequent read through the dangling view.
+ *
+ * @note The death-test style is set to @c "threadsafe" so that the child process
+ *       is spawned via @c exec() rather than @c fork().  This is required because
+ *       ASan's shadow memory is not correctly inherited across a plain @c fork(),
+ *       which would prevent the heap-use-after-free from being detected.
+ *
+ * Compiled in all configurations; the test body only runs under ASan
+ * (@c YSC_SANITIZERS_ENABLED defined).  Without sanitizers the test is
+ * skipped to avoid invoking undefined behavior in the normal build.
+ */
+#include <matrix.hpp>
+#include <matrix_view.hpp>
+
+#include <gtest/gtest.h>
+
+// Under ASan, accessing a dangling matrix_view must terminate the process.
+// EXPECT_DEATH forks a child process; ASan detects the heap-use-after-free in
+// the child and aborts it, which satisfies the "death" predicate.
+// The matrix is allocated on the heap so that ASan poisons the freed region.
+// The "threadsafe" style spawns via exec() so ASan initialises cleanly.
+TEST(MatrixViewLifetime, DanglingViewUseAfterFree) {
+#ifndef YSC_SANITIZERS_ENABLED
+    GTEST_SKIP() << "Test only meaningful under ASan (build with ENABLE_SANITIZERS=ON)";
+#else
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    auto trigger_uaf = [] {
+        // Allocate on the heap so that ASan reliably poisons the freed memory.
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        auto* m = new ysc::matrix<int, 3>{1, 2, 3};
+        ysc::matrix_view<int, ysc::contiguous, 3> view{*m};
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        delete m;
+        // The matrix has been freed; accessing the view is heap-use-after-free.
+        // NOLINTNEXTLINE(clang-analyzer-core.UndefinedBinaryOperatorResult)
+        volatile int val = view(0);
+        (void)val;
+    };
+    EXPECT_DEATH(trigger_uaf(), "");
+#endif
+}


### PR DESCRIPTION
## Résumé

Implémente US-064 : ajoute un test GoogleTest (`test/src/matrix_view_lifetime.cpp`) qui vérifie qu'AddressSanitizer détecte correctement un heap-use-after-free lorsqu'une `matrix_view` survit à la `matrix` sur laquelle elle pointe.

## Critères d'acceptation

- [x] Le fichier `test/src/matrix_view_lifetime.cpp` compile dans toutes les configurations
- [x] Le test est skippé sans `YSC_SANITIZERS_ENABLED` (build normal : `GTEST_SKIP()`)
- [x] Le comportement UB est documenté dans la docstring Doxygen de `matrix_view` (`@warning` enrichie sur les deux spécialisations contiguous et strided)

## Décisions d'implémentation

**Heap vs stack :** la matrice est allouée sur le heap (`new`/`delete`) plutôt que sur la stack. ASan détecte fiablement les heap-use-after-free (mémoire poisonnée après `delete`) ; la détection stack-use-after-scope requiert `-fsanitize-address-use-after-scope` qui n'est pas activé par défaut.

**Mode `threadsafe` pour `EXPECT_DEATH` :** en mode `fast` (défaut GTest), le death-test utilise `fork()`. Dans le processus enfant forké, la shadow memory d'ASan n'est pas correctement réinitialisée, ce qui empêche la détection du UAF. Le mode `threadsafe` respawn via `exec()`, ce qui donne à ASan un processus propre et permet la détection.

**Deux `NOLINTNEXTLINE` :** un pour `cppcoreguidelines-owning-memory` (usage intentionnel de `new`/`delete` bruts pour forcer l'allocation heap), un pour `clang-analyzer-core.UndefinedBinaryOperatorResult` (l'accès UB est précisément le comportement testé).