### PR TITLE
doc: marquer US-061, 062, 064, 065 Done — EPIC K 7/10

### DIFF
--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -14,9 +14,9 @@
 | **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
 | **I — Packaging & préparation v1.0.0** | 🔄 En cours | 8/10 | ✅ US-038, ✅ US-041, ✅ US-043, ✅ US-045, ✅ US-046, ✅ US-047, ✅ US-048, ✅ US-049, ⬜ US-040, US-042 |
 | **J — Ergonomie & finition** | ✅ Terminée | 11/11 | ✅ US-039, ✅ US-050 à US-059 |
-| **K — Extensions pre-v1** | 🔄 En cours | 3/10 | ✅ US-060, ✅ US-063, ✅ US-069, ⬜ US-061, US-062, US-064 à US-068 |
+| **K — Extensions pre-v1** | 🔄 En cours | 7/10 | ✅ US-060, ✅ US-061, ✅ US-062, ✅ US-063, ✅ US-064, ✅ US-065, ✅ US-069, ⬜ US-066, US-067, US-068 |
 
-**Total : 60 / 69 US**
+**Total : 64 / 69 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -66,11 +66,11 @@
 | US | Titre | Priorité | Statut |
 |----|-------|----------|--------|
 | US-060 | Réductions par axe (`sum<Axis>()`, etc.) | P2 | ✅ Done |
-| US-061 | `submatrix` : extraction d'un sous-bloc N-D | P2 | ⬜ À faire |
-| US-062 | `enumerate()` : itérateur de coordonnées | P2 | ⬜ À faire |
+| US-061 | `submatrix` : extraction d'un sous-bloc N-D | P2 | ✅ Done |
+| US-062 | `enumerate()` : itérateur de coordonnées | P2 | ✅ Done |
 | US-063 | Opérateurs bit-à-bit pour types entiers | P2 | ✅ Done |
-| US-064 | Test ASan : détection de vue dangling | P2 | ⬜ À faire |
-| US-065 | Tests de référence linalg (valeurs pré-calculées) | P2 | ⬜ À faire |
+| US-064 | Test ASan : détection de vue dangling | P2 | ✅ Done |
+| US-065 | Tests de référence linalg (valeurs pré-calculées) | P2 | ✅ Done |
 | US-066 | CI Windows : cache vcpkg | P2 | ⬜ À faire |
 | US-067 | Hygiène repo : `.editorconfig`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, Dependabot | P2 | ⬜ À faire |
 | US-068 | Migration guide : promesse de stabilité SemVer v1.0.0 | P2 | ⬜ À faire |


### PR DESCRIPTION
Mise à jour du tableau de bord `doc/user-stories.md` après merge des 4 PRs :

- PR #114 — US-061 : `submatrix` extraction N-D
- PR #115 — US-065 : Tests de référence linalg
- PR #116 — US-062 : `enumerate()` itérateur de coordonnées
- PR #117 — US-064 : Test ASan vue dangling

## Changements

- EPIC K : 3/10 → 7/10
- Total : 60/69 → 64/69
- US-061, US-062, US-064, US-065 marquées ✅ Done