### PR TITLE
doc: documenter les Named Requirements satisfaits par ysc::matrix

### DIFF
--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -106,7 +106,13 @@ constexpr struct matrix_zero_t {
  * the benefits of a standard container, such as knowing its own size,
  * supporting assignment, random access iterators, etc.
  *
- * @todo Requirements (Container, etc.)
+ * ### Named requirements
+ * `ysc::matrix` satisfies the C++ named requirements
+ * [Container](https://en.cppreference.com/w/cpp/named_req/Container),
+ * [ReversibleContainer](https://en.cppreference.com/w/cpp/named_req/ReversibleContainer),
+ * and
+ * [ContiguousContainer](https://en.cppreference.com/w/cpp/named_req/ContiguousContainer).
+ * It does **not** satisfy SequenceContainer (fixed size — no insert/erase).
  *
  * ### Iterator invalidation
  * As a rule, iterators to aa matrix are never invalidated throughout the


### PR DESCRIPTION
## Résumé

Ferme le `@todo Requirements (Container, etc.)` présent depuis l'origine dans le commentaire Doxygen de `ysc::matrix`.

Ajoute une section **Named requirements** précisant que `ysc::matrix` satisfait :
- [Container](https://en.cppreference.com/w/cpp/named_req/Container)
- [ReversibleContainer](https://en.cppreference.com/w/cpp/named_req/ReversibleContainer)
- [ContiguousContainer](https://en.cppreference.com/w/cpp/named_req/ContiguousContainer)

Et note explicitement que **SequenceContainer** n'est pas satisfait (taille fixe, pas d'`insert`/`erase`).

## Checklist

- [x] `@todo` supprimé
- [x] Les trois Named Requirements documentés avec liens cppreference
- [x] Exclusion de SequenceContainer justifiée
- [x] Build et tests verts