### PR TITLE
US-068 — Migration guide : promesse de stabilité SemVer v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,9 @@ cmake --build build --target check
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development guide.
+
+---
+
+## Upgrading from v0.x
+
+See the [Migration Guide](doc/migration.md) for breaking changes and upgrade instructions.

--- a/doc/mainpage.md
+++ b/doc/mainpage.md
@@ -104,6 +104,9 @@ The API is organized into the following groups — see the [Topics](topics.html)
 - @ref ysc_io — I/O (`operator<<`, `std::formatter`)
 - @ref ysc_hash — Hash support (`std::hash` specialization)
 
+For users upgrading from v0.x, see the [Migration Guide](migration.html) for breaking changes
+and the stability promise.
+
 You can also browse the full documentation for the main library classes:
 - Owning matrix — @ref ysc::matrix
 - Non-owning continuous view — @ref ysc::matrix_view< T, contiguous, Dimensions... >

--- a/doc/migration.md
+++ b/doc/migration.md
@@ -1,0 +1,47 @@
+# Migration Guide — v0.x → v1.0.0
+
+This document covers all breaking changes introduced in `ysc::matrix` v1.0.0 and explains
+how to update your code.
+
+## Stability Promise (since v1.0.0)
+
+Starting with v1.0.0, `ysc::matrix` follows [Semantic Versioning](https://semver.org/):
+
+- **Public API** = everything in namespace `ysc` *except* `ysc::detail::`.
+  Breaking changes to the public API require a **major version bump**.
+- **`ysc::detail::`** is internal implementation. It may change in any release, including
+  patch releases. Do **not** depend on it directly.
+
+## Breaking Changes
+
+### 1. CMake target renamed: `matrix` → `ysc::matrix`
+
+**Affected users:** anyone consuming the library via CMake `FetchContent` or `find_package`.
+
+**Before (v0.x):**
+```cmake
+target_link_libraries(myapp PRIVATE matrix)
+```
+
+**After (v1.0.0):**
+```cmake
+target_link_libraries(myapp PRIVATE ysc::matrix)
+```
+
+The old unnamespaced target `matrix` is no longer exported. The canonical name is now
+`ysc::matrix`, consistent with CMake namespacing conventions.
+
+### 2. Hash values changed
+
+**Affected users:** anyone using `ysc::matrix` as a key in `std::unordered_set`,
+`std::unordered_map`, or any hash-based container **and** persisting those hash values
+across program runs (e.g. written to disk or sent over the network).
+
+**What changed:** The `std::hash<ysc::matrix<T, Dims...>>` specialization was updated to
+use a 64-bit hash-combine algorithm for better distribution. Hash values computed by
+v1.0.0 differ from those computed by v0.x.
+
+**In-memory use is unaffected** — hash containers rehash automatically on construction.
+Only serialized hash values are invalidated.
+
+**Migration:** Recompute and replace any persisted hash values after upgrading.


### PR DESCRIPTION
## Résumé

Ajout du guide de migration v0.x → v1.0.0 documentant les changements breaking et la promesse de stabilité SemVer. Lien ajouté depuis `README.md` et `doc/mainpage.md`.

## Critères d'acceptation

- [x] `doc/migration.md` présent et lisible depuis le repo GitHub
- [x] Promesse SemVer documentée : API publique = tout hors `ysc::detail::` (peut changer en patch)
- [x] Changement breaking : renommage cible CMake `matrix` → `ysc::matrix` (avant/après)
- [x] Changement breaking : invalidation des hash sérialisés (US-059, hash-combine 64-bit)
- [x] Lien depuis `README.md` (section Building and Testing)
- [x] Lien depuis `doc/mainpage.md` (section API Reference)

## Notes d'implémentation

La dépendance US-042 (packaging CMake) n'est pas encore mergée, mais le renommage de cible est déjà spécifié — le guide le documente en anticipation. Les hash en mémoire ne sont pas affectés (rehashing automatique) ; seules les valeurs persistées sont invalidées.