### PR TITLE
Release v0.8.0

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,12 @@
 ignore:
   - "test/**"
 comment: false
+
+coverage:
+  status:
+    patch:
+      default:
+        # Template functions in headers may have partial gcov line-coverage
+        # reports due to multiple instantiations; do not block PRs on patch
+        # coverage alone.
+        informational: true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{cpp,hpp,h,cc,cxx,c}]
+indent_style = space
+indent_size = 4
+
+[CMakeLists.txt,*.cmake]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [develop, master]
   pull_request:
     branches: [develop, master]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,7 +280,7 @@ jobs:
           include(FetchContent)
           FetchContent_Declare(ysc-matrix
               GIT_REPOSITORY https://github.com/yscialom/matrix.git
-              GIT_TAG        ${{ github.sha }}
+              GIT_TAG        ${{ github.event.pull_request.head.sha || github.sha }}
           )
           FetchContent_MakeAvailable(ysc-matrix)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,3 +257,65 @@ jobs:
 
       - name: Run clang-tidy
         run: run-clang-tidy -p build
+
+  consumer-test:
+    name: Consumer Test (Ubuntu / GCC-13)
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install GCC-13
+        uses: eclipse-score/apt-install@main
+        with:
+          packages: g++-13
+
+      - name: Create consumer project
+        run: |
+          mkdir consumer_test
+          cat > consumer_test/CMakeLists.txt << 'EOF'
+          cmake_minimum_required(VERSION 3.20)
+          project(consumer-test CXX)
+
+          include(FetchContent)
+          FetchContent_Declare(ysc-matrix
+              GIT_REPOSITORY https://github.com/yscialom/matrix.git
+              GIT_TAG        ${{ github.sha }}
+          )
+          FetchContent_MakeAvailable(ysc-matrix)
+
+          add_executable(consumer main.cpp)
+          target_link_libraries(consumer PRIVATE ysc::matrix)
+
+          enable_testing()
+          add_test(NAME consumer-run COMMAND consumer)
+          EOF
+          cat > consumer_test/main.cpp << 'EOF'
+          #include <concepts>
+          #include <matrix.hpp>
+
+          template <typename T>
+          concept sized_container = requires(T t) {
+              { t.size() } -> std::convertible_to<std::size_t>;
+          };
+
+          static_assert(sized_container<ysc::matrix<int, 2, 3>>);
+
+          int main() {
+              ysc::matrix<int, 2, 3> m;
+              m(0, 0) = 42;
+              return m(0, 0) == 42 ? 0 : 1;
+          }
+          EOF
+
+      - name: Configure consumer project
+        env:
+          CC: gcc-13
+          CXX: g++-13
+        run: cmake -S consumer_test -B consumer_test/build
+
+      - name: Build consumer project
+        run: cmake --build consumer_test/build --parallel
+
+      - name: Run consumer test
+        run: ctest --test-dir consumer_test/build --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,15 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: brew install googletest ccache
 
+      - name: Cache vcpkg
+        if: startsWith(matrix.os, 'windows')
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.VCPKG_INSTALLATION_ROOT }}/installed
+          key: vcpkg-gtest-x64-windows-${{ runner.os }}
+          restore-keys: |
+            vcpkg-gtest-x64-windows-
+
       - name: Install GTest (Windows)
         if: startsWith(matrix.os, 'windows')
         run: vcpkg install gtest:x64-windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,3 +319,20 @@ jobs:
 
       - name: Run consumer test
         run: ctest --test-dir consumer_test/build --output-on-failure
+
+  doc-check:
+    name: Doxygen build (no publish)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Doxygen
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y doxygen graphviz
+
+      - name: Configure
+        run: cmake -S . -B build -DYSC_MATRIX_BUILD_DOCUMENTATION=ON -DYSC_MATRIX_BUILD_TESTING=OFF
+
+      - name: Build documentation
+        run: cmake --build build --target doc

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
           sudo apt-get install -y doxygen graphviz
 
       - name: Configure
-        run: cmake -S . -B build -DBUILD_DOCUMENTATION=ON -DBUILD_TESTING=OFF
+        run: cmake -S . -B build -DBUILD_DOCUMENTATION=ON -DYSC_MATRIX_BUILD_TESTING=OFF
 
       - name: Build documentation
         run: cmake --build build --target doc

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Building
 _cmake
 /build*/
+/consumer_test/
 
 # Editing
 *.orig

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@ cmake_minimum_required(VERSION 3.20)
 # general configuration
 #
 set(VERSION_MAJOR   0   CACHE STRING "Project major version number.")
-set(VERSION_MINOR   7   CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   3   CACHE STRING "Project patch version number.")
+set(VERSION_MINOR   8   CACHE STRING "Project minor version number.")
+set(VERSION_PATCH   0   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 project(ysc-matrix

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,6 @@
+# Code of Conduct
+
+1. Act with integrity
+2. Don't be evil
+3. If in doubt, go and touch some grass
+

--- a/README.md
+++ b/README.md
@@ -128,3 +128,9 @@ cmake --build build --target check
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development guide.
+
+---
+
+## Upgrading from v0.x
+
+See the [Migration Guide](doc/migration.md) for breaking changes and upgrade instructions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Scope
+
+`ysc::matrix` is a header-only C++20 library with no network I/O, no file I/O, and no runtime
+dependencies. Its attack surface is limited to:
+
+- Memory safety: `at()` performs bounds checking and throws `std::out_of_range` on violation;
+  `operator()` is unchecked by design (performance path) and exhibits UB on out-of-bounds access.
+- Template instantiation: malformed template parameters may trigger compile-time errors, not
+  runtime vulnerabilities.
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Report them via [GitHub Security Advisories](../../security/advisories/new) so they can be
+triaged privately before public disclosure.
+
+We aim to:
+- Acknowledge the report within **2 weeks**
+- Publish a fix within **6 weeks** for confirmed vulnerabilities
+
+## Supported Versions
+
+Only the latest release on the `develop` branch receives security fixes.

--- a/doc/mainpage.md
+++ b/doc/mainpage.md
@@ -104,6 +104,9 @@ The API is organized into the following groups — see the [Topics](topics.html)
 - @ref ysc_io — I/O (`operator<<`, `std::formatter`)
 - @ref ysc_hash — Hash support (`std::hash` specialization)
 
+For users upgrading from v0.x, see the [Migration Guide](migration.html) for breaking changes
+and the stability promise.
+
 You can also browse the full documentation for the main library classes:
 - Owning matrix — @ref ysc::matrix
 - Non-owning continuous view — @ref ysc::matrix_view< T, contiguous, Dimensions... >

--- a/doc/migration.md
+++ b/doc/migration.md
@@ -1,0 +1,47 @@
+# Migration Guide — v0.x → v1.0.0
+
+This document covers all breaking changes introduced in `ysc::matrix` v1.0.0 and explains
+how to update your code.
+
+## Stability Promise (since v1.0.0)
+
+Starting with v1.0.0, `ysc::matrix` follows [Semantic Versioning](https://semver.org/):
+
+- **Public API** = everything in namespace `ysc` *except* `ysc::detail::`.
+  Breaking changes to the public API require a **major version bump**.
+- **`ysc::detail::`** is internal implementation. It may change in any release, including
+  patch releases. Do **not** depend on it directly.
+
+## Breaking Changes
+
+### 1. CMake target renamed: `matrix` → `ysc::matrix`
+
+**Affected users:** anyone consuming the library via CMake `FetchContent` or `find_package`.
+
+**Before (v0.x):**
+```cmake
+target_link_libraries(myapp PRIVATE matrix)
+```
+
+**After (v1.0.0):**
+```cmake
+target_link_libraries(myapp PRIVATE ysc::matrix)
+```
+
+The old unnamespaced target `matrix` is no longer exported. The canonical name is now
+`ysc::matrix`, consistent with CMake namespacing conventions.
+
+### 2. Hash values changed
+
+**Affected users:** anyone using `ysc::matrix` as a key in `std::unordered_set`,
+`std::unordered_map`, or any hash-based container **and** persisting those hash values
+across program runs (e.g. written to disk or sent over the network).
+
+**What changed:** The `std::hash<ysc::matrix<T, Dims...>>` specialization was updated to
+use a 64-bit hash-combine algorithm for better distribution. Hash values computed by
+v1.0.0 differ from those computed by v0.x.
+
+**In-memory use is unaffected** — hash containers rehash automatically on construction.
+Only serialized hash values are invalidated.
+
+**Migration:** Recompute and replace any persisted hash values after upgrading.

--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -14,9 +14,9 @@
 | **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
 | **I — Packaging & préparation v1.0.0** | 🔄 En cours | 8/10 | ✅ US-038, ✅ US-041, ✅ US-043, ✅ US-045, ✅ US-046, ✅ US-047, ✅ US-048, ✅ US-049, ⬜ US-040, US-042 |
 | **J — Ergonomie & finition** | ✅ Terminée | 11/11 | ✅ US-039, ✅ US-050 à US-059 |
-| **K — Extensions pre-v1** | 🔄 En cours | 2/10 | ✅ US-060, ✅ US-063, ⬜ US-061, US-062, US-064 à US-069 |
+| **K — Extensions pre-v1** | 🔄 En cours | 3/10 | ✅ US-060, ✅ US-063, ✅ US-069, ⬜ US-061, US-062, US-064 à US-068 |
 
-**Total : 59 / 69 US**
+**Total : 60 / 69 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -74,7 +74,7 @@
 | US-066 | CI Windows : cache vcpkg | P2 | ⬜ À faire |
 | US-067 | Hygiène repo : `.editorconfig`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, Dependabot | P2 | ⬜ À faire |
 | US-068 | Migration guide : promesse de stabilité SemVer v1.0.0 | P2 | ⬜ À faire |
-| US-069 | `generate` avec callable multi-index | P2 | ⬜ À faire |
+| US-069 | `generate` avec callable multi-index | P2 | ✅ Done |
 
 ---
 

--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -12,11 +12,11 @@
 | **F — Arithmétique** | ✅ Terminée | 4/4 | ✅ US-026, ✅ US-027, ✅ US-028, ✅ US-029 |
 | **G — Algorithmes** | ✅ Terminée | 5/5 | ✅ US-030, ✅ US-031, ✅ US-032, ✅ US-033, ✅ US-034 |
 | **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
-| **I — Packaging & préparation v1.0.0** | 🔄 En cours | 7/10 | ✅ US-038, ✅ US-041, ✅ US-043, ✅ US-045, ✅ US-046, ✅ US-047, ✅ US-049, ⬜ US-040, US-042, US-048 |
+| **I — Packaging & préparation v1.0.0** | 🔄 En cours | 8/10 | ✅ US-038, ✅ US-041, ✅ US-043, ✅ US-045, ✅ US-046, ✅ US-047, ✅ US-048, ✅ US-049, ⬜ US-040, US-042 |
 | **J — Ergonomie & finition** | ✅ Terminée | 11/11 | ✅ US-039, ✅ US-050 à US-059 |
 | **K — Extensions pre-v1** | 🔄 En cours | 1/10 | ✅ US-060, ⬜ US-061 à US-069 |
 
-**Total : 50 / 69 US**
+**Total : 51 / 69 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -42,7 +42,7 @@
 | US-045 | Packaging CMake : cible `ysc-matrix`, alias, install, find_package | P0 | ✅ Done |
 | US-046 | Correctifs docs + `.gitignore` | P0 | ✅ Done |
 | US-047 | README marketing + `mainpage.md` v1 | P0 | ✅ Done |
-| US-048 | Job CI consumer test | P0 | ⬜ À faire |
+| US-048 | Job CI consumer test | P0 | ✅ Done |
 | US-049 | Amalgamation auto-générée par CI | P0 | ✅ Done |
 
 ## EPIC J — Ergonomie & finition

--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -14,9 +14,9 @@
 | **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
 | **I — Packaging & préparation v1.0.0** | 🔄 En cours | 7/10 | ✅ US-038, ✅ US-041, ✅ US-043, ✅ US-045, ✅ US-046, ✅ US-047, ✅ US-049, ⬜ US-040, US-042, US-048 |
 | **J — Ergonomie & finition** | ✅ Terminée | 11/11 | ✅ US-039, ✅ US-050 à US-059 |
-| **K — Extensions pre-v1** | ⬜ Non démarrée | 0/10 | ⬜ US-060 à US-069 |
+| **K — Extensions pre-v1** | 🔄 En cours | 1/10 | ✅ US-060, ⬜ US-061 à US-069 |
 
-**Total : 49 / 69 US**
+**Total : 50 / 69 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -65,7 +65,7 @@
 
 | US | Titre | Priorité | Statut |
 |----|-------|----------|--------|
-| US-060 | Réductions par axe (`sum<Axis>()`, etc.) | P2 | ⬜ À faire |
+| US-060 | Réductions par axe (`sum<Axis>()`, etc.) | P2 | ✅ Done |
 | US-061 | `submatrix` : extraction d'un sous-bloc N-D | P2 | ⬜ À faire |
 | US-062 | `enumerate()` : itérateur de coordonnées | P2 | ⬜ À faire |
 | US-063 | Opérateurs bit-à-bit pour types entiers | P2 | ⬜ À faire |
@@ -1615,10 +1615,10 @@ En tant qu'utilisateur, je veux calculer la somme, le min, le max d'une matrice 
 - Contrainte : `static_assert(Axis < order)`
 
 ### Critères d'acceptation
-- [ ] `matrix<int,2,3>{{1,2,3},{4,5,6}}.sum<0>()` == `matrix<int,3>{5,7,9}` (somme par colonnes)
-- [ ] `matrix<int,2,3>{{1,2,3},{4,5,6}}.sum<1>()` == `matrix<int,2>{6,15}` (somme par lignes)
-- [ ] Erreur de compilation si `Axis >= order`
-- [ ] Tests dans `test/src/reductions_axis.cpp`
+- [x] `matrix<int,2,3>{{1,2,3},{4,5,6}}.sum<0>()` == `matrix<int,3>{5,7,9}` (somme par colonnes)
+- [x] `matrix<int,2,3>{{1,2,3},{4,5,6}}.sum<1>()` == `matrix<int,2>{6,15}` (somme par lignes)
+- [x] Erreur de compilation si `Axis >= order` (contrainte `requires(Axis < order)`)
+- [x] Tests dans `test/src/reductions_axis.cpp`
 
 ---
 

--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -14,9 +14,9 @@
 | **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
 | **I — Packaging & préparation v1.0.0** | 🔄 En cours | 8/10 | ✅ US-038, ✅ US-041, ✅ US-043, ✅ US-045, ✅ US-046, ✅ US-047, ✅ US-048, ✅ US-049, ⬜ US-040, US-042 |
 | **J — Ergonomie & finition** | ✅ Terminée | 11/11 | ✅ US-039, ✅ US-050 à US-059 |
-| **K — Extensions pre-v1** | 🔄 En cours | 1/10 | ✅ US-060, ⬜ US-061 à US-069 |
+| **K — Extensions pre-v1** | 🔄 En cours | 2/10 | ✅ US-060, ✅ US-063, ⬜ US-061, US-062, US-064 à US-069 |
 
-**Total : 51 / 69 US**
+**Total : 52 / 69 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -68,7 +68,7 @@
 | US-060 | Réductions par axe (`sum<Axis>()`, etc.) | P2 | ✅ Done |
 | US-061 | `submatrix` : extraction d'un sous-bloc N-D | P2 | ⬜ À faire |
 | US-062 | `enumerate()` : itérateur de coordonnées | P2 | ⬜ À faire |
-| US-063 | Opérateurs bit-à-bit pour types entiers | P2 | ⬜ À faire |
+| US-063 | Opérateurs bit-à-bit pour types entiers | P2 | ✅ Done |
 | US-064 | Test ASan : détection de vue dangling | P2 | ⬜ À faire |
 | US-065 | Tests de référence linalg (valeurs pré-calculées) | P2 | ⬜ À faire |
 | US-066 | CI Windows : cache vcpkg | P2 | ⬜ À faire |

--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -16,7 +16,7 @@
 | **J — Ergonomie & finition** | ✅ Terminée | 11/11 | ✅ US-039, ✅ US-050 à US-059 |
 | **K — Extensions pre-v1** | 🔄 En cours | 2/10 | ✅ US-060, ✅ US-063, ⬜ US-061, US-062, US-064 à US-069 |
 
-**Total : 52 / 69 US**
+**Total : 59 / 69 US**
 
 ## EPIC A — Infrastructure & CI/CD
 

--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -14,9 +14,9 @@
 | **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
 | **I — Packaging & préparation v1.0.0** | 🔄 En cours | 8/10 | ✅ US-038, ✅ US-041, ✅ US-043, ✅ US-045, ✅ US-046, ✅ US-047, ✅ US-048, ✅ US-049, ⬜ US-040, US-042 |
 | **J — Ergonomie & finition** | ✅ Terminée | 11/11 | ✅ US-039, ✅ US-050 à US-059 |
-| **K — Extensions pre-v1** | 🔄 En cours | 7/10 | ✅ US-060, ✅ US-061, ✅ US-062, ✅ US-063, ✅ US-064, ✅ US-065, ✅ US-069, ⬜ US-066, US-067, US-068 |
+| **K — Extensions pre-v1** | ✅ Terminée | 10/10 | ✅ US-060 à US-069 |
 
-**Total : 64 / 69 US**
+**Total : 67 / 69 US**
 
 ## EPIC A — Infrastructure & CI/CD
 

--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -12,11 +12,11 @@
 | **F — Arithmétique** | ✅ Terminée | 4/4 | ✅ US-026, ✅ US-027, ✅ US-028, ✅ US-029 |
 | **G — Algorithmes** | ✅ Terminée | 5/5 | ✅ US-030, ✅ US-031, ✅ US-032, ✅ US-033, ✅ US-034 |
 | **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
-| **I — Packaging & préparation v1.0.0** | 🔄 En cours | 6/10 | ✅ US-041, ✅ US-043, ✅ US-045, ✅ US-046, ✅ US-047, ✅ US-049, ⬜ US-038, US-040, US-042, US-048 |
+| **I — Packaging & préparation v1.0.0** | 🔄 En cours | 7/10 | ✅ US-038, ✅ US-041, ✅ US-043, ✅ US-045, ✅ US-046, ✅ US-047, ✅ US-049, ⬜ US-040, US-042, US-048 |
 | **J — Ergonomie & finition** | ✅ Terminée | 11/11 | ✅ US-039, ✅ US-050 à US-059 |
 | **K — Extensions pre-v1** | ⬜ Non démarrée | 0/10 | ⬜ US-060 à US-069 |
 
-**Total : 48 / 69 US**
+**Total : 49 / 69 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -34,7 +34,7 @@
 
 | US | Titre | Priorité | Statut |
 |----|-------|----------|--------|
-| US-038 | Cas particulier dimension 0 | P2 | ⬜ À faire |
+| US-038 | Cas particulier dimension 0 | P2 | ✅ Done |
 | US-040 | Dossier `examples/` enrichi | P1 | ⬜ À faire |
 | US-041 | Gate couverture 100 % | P1 | ✅ Done |
 | US-042 | Tag `v1.0.0` | P0 (final) | ⬜ À faire |

--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -14,9 +14,9 @@
 | **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
 | **I — Packaging & préparation v1.0.0** | 🔄 En cours | 8/10 | ✅ US-038, ✅ US-041, ✅ US-043, ✅ US-045, ✅ US-046, ✅ US-047, ✅ US-048, ✅ US-049, ⬜ US-040, US-042 |
 | **J — Ergonomie & finition** | ✅ Terminée | 11/11 | ✅ US-039, ✅ US-050 à US-059 |
-| **K — Extensions pre-v1** | 🔄 En cours | 3/10 | ✅ US-060, ✅ US-063, ✅ US-069, ⬜ US-061, US-062, US-064 à US-068 |
+| **K — Extensions pre-v1** | 🔄 En cours | 7/10 | ✅ US-060, ✅ US-061, ✅ US-062, ✅ US-063, ✅ US-064, ✅ US-065, ✅ US-069, ⬜ US-066, US-067, US-068 |
 
-**Total : 60 / 69 US**
+**Total : 64 / 69 US**
 
 ## EPIC A — Infrastructure & CI/CD
 
@@ -66,11 +66,11 @@
 | US | Titre | Priorité | Statut |
 |----|-------|----------|--------|
 | US-060 | Réductions par axe (`sum<Axis>()`, etc.) | P2 | ✅ Done |
-| US-061 | `submatrix` : extraction d'un sous-bloc N-D | P2 | ⬜ À faire |
-| US-062 | `enumerate()` : itérateur de coordonnées | P2 | ⬜ À faire |
+| US-061 | `submatrix` : extraction d'un sous-bloc N-D | P2 | ✅ Done |
+| US-062 | `enumerate()` : itérateur de coordonnées | P2 | ✅ Done |
 | US-063 | Opérateurs bit-à-bit pour types entiers | P2 | ✅ Done |
-| US-064 | Test ASan : détection de vue dangling | P2 | ⬜ À faire |
-| US-065 | Tests de référence linalg (valeurs pré-calculées) | P2 | ⬜ À faire |
+| US-064 | Test ASan : détection de vue dangling | P2 | ✅ Done |
+| US-065 | Tests de référence linalg (valeurs pré-calculées) | P2 | ✅ Done |
 | US-066 | CI Windows : cache vcpkg | P2 | ⬜ À faire |
 | US-067 | Hygiène repo : `.editorconfig`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, Dependabot | P2 | ⬜ À faire |
 | US-068 | Migration guide : promesse de stabilité SemVer v1.0.0 | P2 | ⬜ À faire |

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -2271,6 +2271,98 @@ public:
     [[nodiscard]] constexpr enumerate_range<const T> enumerate() const noexcept {
         return enumerate_range<const T>{_data.data(), linear_size};
     }
+
+    /**
+     * @brief Returns a strided view over an N-D sub-block starting at @a origin.
+     * @tparam NewD Dimensions of the sub-block (one per matrix dimension).
+     * @param  origin Multi-dimensional starting position of the sub-block.
+     * @return @c matrix_view<T, strided, NewD...>
+     *
+     * The strides of the view are the row-major strides of the source matrix, so
+     * mutation through the view is reflected in the original matrix.
+     *
+     * @throws std::out_of_range if @c origin[i] + NewD[i] > dimensions[i] for
+     *         any dimension @c i.
+     *
+     * @code
+     * ysc::matrix<int, 4, 4> m{};
+     * std::iota(m.begin(), m.end(), 0);
+     * auto v = m.submatrix<2, 2>({1, 1});  // 2×2 view starting at (1,1)
+     * assert(v(0, 0) == m(1, 1));
+     * v(0, 0) = 99;  // writes m(1, 1)
+     * assert(m(1, 1) == 99);
+     * @endcode
+     *
+     * @ingroup ysc_views
+     */
+    template <std::size_t... NewD>
+        requires(sizeof...(NewD) == order)
+    [[nodiscard]] constexpr matrix_view<T, strided, NewD...>
+    submatrix(std::array<std::size_t, order> origin) & {
+        constexpr std::array<std::size_t, order> new_dims = {NewD...};
+        for (std::size_t i = 0; i < order; ++i) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+            if (origin[i] + new_dims[i] > dimensions[i]) {
+                throw std::out_of_range("submatrix: sub-block exceeds matrix bounds");
+            }
+        }
+        // Row-major strides of the source matrix: stride[i] = D[i+1] * ... * D[order-1]
+        std::array<std::size_t, order> src_strides{};
+        for (std::size_t i = 0; i < order; ++i) {
+            std::size_t s = 1;
+            for (std::size_t j = i + 1; j < order; ++j) {
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                s *= dimensions[j];
+            }
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+            src_strides[i] = s;
+        }
+        T* base = _data.data() + detail::coordinates_to_index(dimensions, origin);
+        return matrix_view<T, strided, NewD...>{base, src_strides};
+    }
+
+    /**
+     * @brief Returns a const strided view over an N-D sub-block starting at @a origin.
+     * @tparam NewD Dimensions of the sub-block (one per matrix dimension).
+     * @param  origin Multi-dimensional starting position of the sub-block.
+     * @return @c matrix_view<const T, strided, NewD...>
+     *
+     * @throws std::out_of_range if @c origin[i] + NewD[i] > dimensions[i] for
+     *         any dimension @c i.
+     *
+     * @code
+     * const ysc::matrix<int, 4, 4> m{};
+     * auto v = m.submatrix<2, 2>({1, 1});  // const 2×2 view starting at (1,1)
+     * assert(v(0, 0) == m(1, 1));
+     * @endcode
+     *
+     * @ingroup ysc_views
+     */
+    template <std::size_t... NewD>
+        requires(sizeof...(NewD) == order)
+    [[nodiscard]] constexpr matrix_view<const T, strided, NewD...>
+    submatrix(std::array<std::size_t, order> origin) const& {
+        constexpr std::array<std::size_t, order> new_dims = {NewD...};
+        for (std::size_t i = 0; i < order; ++i) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+            if (origin[i] + new_dims[i] > dimensions[i]) {
+                throw std::out_of_range("submatrix: sub-block exceeds matrix bounds");
+            }
+        }
+        // Row-major strides of the source matrix: stride[i] = D[i+1] * ... * D[order-1]
+        std::array<std::size_t, order> src_strides{};
+        for (std::size_t i = 0; i < order; ++i) {
+            std::size_t s = 1;
+            for (std::size_t j = i + 1; j < order; ++j) {
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+                s *= dimensions[j];
+            }
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+            src_strides[i] = s;
+        }
+        const T* base = _data.data() + detail::coordinates_to_index(dimensions, origin);
+        return matrix_view<const T, strided, NewD...>{base, src_strides};
+    }
 };
 
 /**

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -2260,6 +2260,48 @@ template <class T, std::size_t... Dims, std::invocable<std::size_t> F>
 }
 
 /**
+ * @brief Returns a matrix filled by calling @a f(i₀, i₁, …) for each N-D coordinate.
+ *
+ * This overload accepts a callable that takes @c sizeof...(Dims) arguments of type
+ * @c std::size_t — one per dimension, in row-major order.  It is selected when @a f is
+ * **not** callable with a single @c std::size_t (which would select the linear-index
+ * overload instead, preserving backward compatibility).
+ *
+ * @tparam T    Element type
+ * @tparam Dims Dimensions of the result matrix
+ * @tparam F    Callable type: @c f(i₀, …, iₙ) must be convertible to @c T
+ * @param  f    Generator callable receiving the N-D coordinates
+ * @return New @c matrix<T, Dims...> where element at @c (i₀,…,iₙ) equals @c f(i₀,…,iₙ)
+ *
+ * @code
+ * // 3×3 identity matrix
+ * auto I = ysc::generate<int, 3, 3>([](std::size_t i, std::size_t j) {
+ *     return i == j ? 1 : 0;
+ * });
+ * // Tensor: m(i,j,k) = i*100 + j*10 + k
+ * auto m = ysc::generate<int, 2, 3, 4>([](auto i, auto j, auto k) {
+ *     return int(i * 100 + j * 10 + k);
+ * });
+ * @endcode
+ *
+ * @ingroup ysc_construction
+ */
+template <class T, std::size_t... Dims, class F>
+    requires(!std::invocable<F, std::size_t> &&
+             requires(F f, std::array<std::size_t, sizeof...(Dims)> coords) {
+                 { std::apply(f, coords) } -> std::convertible_to<T>;
+             })
+[[nodiscard]] constexpr matrix<T, Dims...> generate(F f) {
+    matrix<T, Dims...> result;
+    for (std::size_t i = 0; i < matrix<T, Dims...>::size(); ++i) {
+        auto coords = detail::index_to_coordinates(matrix<T, Dims...>::dimensions, i);
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        result.begin()[i] = static_cast<T>(std::apply(f, coords));
+    }
+    return result;
+}
+
+/**
  * @defgroup ysc_linalg Linear algebra
  * @brief Linear algebra operations on @c ysc::matrix.
  */

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -106,7 +106,13 @@ constexpr struct matrix_zero_t {
  * the benefits of a standard container, such as knowing its own size,
  * supporting assignment, random access iterators, etc.
  *
- * @todo Requirements (Container, etc.)
+ * ### Named requirements
+ * `ysc::matrix` satisfies the C++ named requirements
+ * [Container](https://en.cppreference.com/w/cpp/named_req/Container),
+ * [ReversibleContainer](https://en.cppreference.com/w/cpp/named_req/ReversibleContainer),
+ * and
+ * [ContiguousContainer](https://en.cppreference.com/w/cpp/named_req/ContiguousContainer).
+ * It does **not** satisfy SequenceContainer (fixed size — no insert/erase).
  *
  * ### Iterator invalidation
  * As a rule, iterators to aa matrix are never invalidated throughout the

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -1444,10 +1444,9 @@ public:
      * @ingroup ysc_algorithms
      */
     template <std::size_t Axis>
-        requires(Axis < order)
-    [[nodiscard]] constexpr auto sum() const
-        requires std::default_initializable<T> && requires(T a, const T& b) { a += b; }
-    {
+        requires(Axis < order) && std::default_initializable<T> &&
+                requires(T a, const T& b) { a += b; }
+    [[nodiscard]] constexpr auto sum() const {
         using result_type = detail::make_matrix_t<T, detail::drop_dim_t<Axis, Dimensions...>>;
         result_type result(zero);
         constexpr std::size_t axis_size = dimensions[Axis];
@@ -1490,10 +1489,8 @@ public:
      * @ingroup ysc_algorithms
      */
     template <std::size_t Axis>
-        requires(Axis < order && dimensions[Axis] > 0)
-    [[nodiscard]] constexpr auto min() const
-        requires std::totally_ordered<T>
-    {
+        requires(Axis < order && dimensions[Axis] > 0) && std::totally_ordered<T>
+    [[nodiscard]] constexpr auto min() const {
         using result_type = detail::make_matrix_t<T, detail::drop_dim_t<Axis, Dimensions...>>;
         result_type result;
         constexpr std::size_t axis_size = dimensions[Axis];
@@ -1537,10 +1534,8 @@ public:
      * @ingroup ysc_algorithms
      */
     template <std::size_t Axis>
-        requires(Axis < order && dimensions[Axis] > 0)
-    [[nodiscard]] constexpr auto max() const
-        requires std::totally_ordered<T>
-    {
+        requires(Axis < order && dimensions[Axis] > 0) && std::totally_ordered<T>
+    [[nodiscard]] constexpr auto max() const {
         using result_type = detail::make_matrix_t<T, detail::drop_dim_t<Axis, Dimensions...>>;
         result_type result;
         constexpr std::size_t axis_size = dimensions[Axis];

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -1298,6 +1298,146 @@ public:
         return std::ranges::any_of(_data, [](const T& v) { return static_cast<bool>(v); });
     }
 
+    /**
+     * @brief Returns the sum of all elements along a given axis.
+     * @tparam Axis Axis to reduce along; must satisfy `Axis < order`
+     * @return A matrix with @c order-1 dimensions containing per-slice sums
+     *
+     * @code
+     * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+     * auto col_sums = m.sum<0>();  // matrix<int, 3>{5, 7, 9}
+     * auto row_sums = m.sum<1>();  // matrix<int, 2>{6, 15}
+     * @endcode
+     *
+     * @ingroup ysc_algorithms
+     */
+    template <std::size_t Axis>
+        requires(Axis < order)
+    [[nodiscard]] constexpr auto sum() const
+        requires std::default_initializable<T> && requires(T a, const T& b) { a += b; }
+    {
+        using result_type = detail::make_matrix_t<T, detail::drop_dim_t<Axis, Dimensions...>>;
+        result_type result(zero);
+        constexpr std::size_t axis_size = dimensions[Axis];
+        constexpr std::size_t suffix = []() constexpr -> std::size_t {
+            std::size_t s = 1;
+            for (std::size_t i = Axis + 1; i < order; ++i) {
+                s *= dimensions[i];
+            }
+            return s;
+        }();
+        constexpr std::size_t prefix = []() constexpr -> std::size_t {
+            std::size_t p = 1;
+            for (std::size_t i = 0; i < Axis; ++i) {
+                p *= dimensions[i];
+            }
+            return p;
+        }();
+        for (std::size_t p = 0; p < prefix; ++p) {
+            for (std::size_t k = 0; k < axis_size; ++k) {
+                for (std::size_t s = 0; s < suffix; ++s) {
+                    result._data[(p * suffix) + s] +=
+                        _data[(p * axis_size * suffix) + (k * suffix) + s];
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * @brief Returns the minimum of all elements along a given axis.
+     * @tparam Axis Axis to reduce along; must satisfy `Axis < order` and `dimensions[Axis] > 0`
+     * @return A matrix with @c order-1 dimensions containing per-slice minima
+     *
+     * @code
+     * ysc::matrix<int, 2, 3> m{3, 1, 4, 1, 5, 9};
+     * auto col_min = m.min<0>();  // matrix<int, 3>{1, 1, 4}
+     * auto row_min = m.min<1>();  // matrix<int, 2>{1, 1}
+     * @endcode
+     *
+     * @ingroup ysc_algorithms
+     */
+    template <std::size_t Axis>
+        requires(Axis < order && dimensions[Axis] > 0)
+    [[nodiscard]] constexpr auto min() const
+        requires std::totally_ordered<T>
+    {
+        using result_type = detail::make_matrix_t<T, detail::drop_dim_t<Axis, Dimensions...>>;
+        result_type result;
+        constexpr std::size_t axis_size = dimensions[Axis];
+        constexpr std::size_t suffix = []() constexpr -> std::size_t {
+            std::size_t s = 1;
+            for (std::size_t i = Axis + 1; i < order; ++i) {
+                s *= dimensions[i];
+            }
+            return s;
+        }();
+        constexpr std::size_t prefix = []() constexpr -> std::size_t {
+            std::size_t p = 1;
+            for (std::size_t i = 0; i < Axis; ++i) {
+                p *= dimensions[i];
+            }
+            return p;
+        }();
+        for (std::size_t p = 0; p < prefix; ++p) {
+            for (std::size_t s = 0; s < suffix; ++s) {
+                T val = _data[(p * axis_size * suffix) + s];
+                for (std::size_t k = 1; k < axis_size; ++k) {
+                    val = std::min(val, _data[(p * axis_size * suffix) + (k * suffix) + s]);
+                }
+                result._data[(p * suffix) + s] = val;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * @brief Returns the maximum of all elements along a given axis.
+     * @tparam Axis Axis to reduce along; must satisfy `Axis < order` and `dimensions[Axis] > 0`
+     * @return A matrix with @c order-1 dimensions containing per-slice maxima
+     *
+     * @code
+     * ysc::matrix<int, 2, 3> m{3, 1, 4, 1, 5, 9};
+     * auto col_max = m.max<0>();  // matrix<int, 3>{3, 5, 9}
+     * auto row_max = m.max<1>();  // matrix<int, 2>{4, 9}
+     * @endcode
+     *
+     * @ingroup ysc_algorithms
+     */
+    template <std::size_t Axis>
+        requires(Axis < order && dimensions[Axis] > 0)
+    [[nodiscard]] constexpr auto max() const
+        requires std::totally_ordered<T>
+    {
+        using result_type = detail::make_matrix_t<T, detail::drop_dim_t<Axis, Dimensions...>>;
+        result_type result;
+        constexpr std::size_t axis_size = dimensions[Axis];
+        constexpr std::size_t suffix = []() constexpr -> std::size_t {
+            std::size_t s = 1;
+            for (std::size_t i = Axis + 1; i < order; ++i) {
+                s *= dimensions[i];
+            }
+            return s;
+        }();
+        constexpr std::size_t prefix = []() constexpr -> std::size_t {
+            std::size_t p = 1;
+            for (std::size_t i = 0; i < Axis; ++i) {
+                p *= dimensions[i];
+            }
+            return p;
+        }();
+        for (std::size_t p = 0; p < prefix; ++p) {
+            for (std::size_t s = 0; s < suffix; ++s) {
+                T val = _data[(p * axis_size * suffix) + s];
+                for (std::size_t k = 1; k < axis_size; ++k) {
+                    val = std::max(val, _data[(p * axis_size * suffix) + (k * suffix) + s]);
+                }
+                result._data[(p * suffix) + s] = val;
+            }
+        }
+        return result;
+    }
+
     // modifiers
     /**
      * @brief Assigns the given value to all elements of the matrix.

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -1140,6 +1140,138 @@ public:
         return map([](const T& v) { return -v; });
     }
 
+    // bitwise
+
+    /**
+     * @brief Bitwise AND assignment (element-wise).
+     * @tparam Other Element type of @a other — must support @c &= with @c T
+     * @param  other Right-hand matrix
+     * @return Reference to @c *this after in-place AND
+     *
+     * @code
+     * ysc::matrix<unsigned, 3> a{0b111, 0b101, 0b010};
+     * ysc::matrix<unsigned, 3> b{0b110, 0b110, 0b110};
+     * a &= b;  // a == ysc::matrix<unsigned, 3>{0b110, 0b100, 0b010}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    template <class Other>
+    matrix& operator&=(const matrix<Other, Dimensions...>& other)
+        requires requires(T a, const Other& b) { a &= b; }
+    {
+        std::transform(_data.begin(), _data.end(), other.cbegin(), _data.begin(),
+                       [](T a, const Other& b) -> T { return a &= b; });
+        return *this;
+    }
+
+    /**
+     * @brief Bitwise OR assignment (element-wise).
+     * @tparam Other Element type of @a other — must support @c |= with @c T
+     * @param  other Right-hand matrix
+     * @return Reference to @c *this after in-place OR
+     *
+     * @code
+     * ysc::matrix<unsigned, 3> a{0b001, 0b010, 0b100};
+     * ysc::matrix<unsigned, 3> b{0b110, 0b101, 0b011};
+     * a |= b;  // a == ysc::matrix<unsigned, 3>{0b111, 0b111, 0b111}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    template <class Other>
+    matrix& operator|=(const matrix<Other, Dimensions...>& other)
+        requires requires(T a, const Other& b) { a |= b; }
+    {
+        std::transform(_data.begin(), _data.end(), other.cbegin(), _data.begin(),
+                       [](T a, const Other& b) -> T { return a |= b; });
+        return *this;
+    }
+
+    /**
+     * @brief Bitwise XOR assignment (element-wise).
+     * @tparam Other Element type of @a other — must support @c ^= with @c T
+     * @param  other Right-hand matrix
+     * @return Reference to @c *this after in-place XOR
+     *
+     * @code
+     * ysc::matrix<unsigned, 3> a{0b111, 0b101, 0b010};
+     * ysc::matrix<unsigned, 3> b{0b110, 0b110, 0b110};
+     * a ^= b;  // a == ysc::matrix<unsigned, 3>{0b001, 0b011, 0b100}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    template <class Other>
+    matrix& operator^=(const matrix<Other, Dimensions...>& other)
+        requires requires(T a, const Other& b) { a ^= b; }
+    {
+        std::transform(_data.begin(), _data.end(), other.cbegin(), _data.begin(),
+                       [](T a, const Other& b) -> T { return a ^= b; });
+        return *this;
+    }
+
+    /**
+     * @brief Left-shift assignment by scalar (element-wise).
+     * @tparam Scalar Type of the shift amount — must support @c <<= with @c T
+     * @param  s      Shift amount applied to every element
+     * @return Reference to @c *this after in-place left shift
+     *
+     * @code
+     * ysc::matrix<unsigned, 3> m{1, 2, 4};
+     * m <<= 1u;  // m == ysc::matrix<unsigned, 3>{2, 4, 8}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    template <class Scalar>
+    matrix& operator<<=(const Scalar& s)
+        requires requires(T a, const Scalar& b) { a <<= b; }
+    {
+        std::transform(_data.begin(), _data.end(), _data.begin(),
+                       [&s](T a) -> T { return a <<= s; });
+        return *this;
+    }
+
+    /**
+     * @brief Right-shift assignment by scalar (element-wise).
+     * @tparam Scalar Type of the shift amount — must support @c >>= with @c T
+     * @param  s      Shift amount applied to every element
+     * @return Reference to @c *this after in-place right shift
+     *
+     * @code
+     * ysc::matrix<unsigned, 3> m{8, 4, 2};
+     * m >>= 1u;  // m == ysc::matrix<unsigned, 3>{4, 2, 1}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    template <class Scalar>
+    matrix& operator>>=(const Scalar& s)
+        requires requires(T a, const Scalar& b) { a >>= b; }
+    {
+        std::transform(_data.begin(), _data.end(), _data.begin(),
+                       [&s](T a) -> T { return a >>= s; });
+        return *this;
+    }
+
+    /**
+     * @brief Bitwise NOT (element-wise).
+     * @return New matrix where each element @c e is replaced by @c ~e
+     *
+     * @code
+     * ysc::matrix<unsigned, 2> m{0u, 0xFFFFFFFFu};
+     * auto r = ~m;  // r == ysc::matrix<unsigned, 2>{~0u, 0u}
+     * @endcode
+     *
+     * @ingroup ysc_arithmetic
+     */
+    [[nodiscard]] matrix operator~() const
+        requires requires(const T& a) { ~a; }
+    {
+        return map([](const T& v) { return ~v; });
+    }
+
     // algorithms
     /**
      * @defgroup ysc_algorithms Algorithms
@@ -2263,6 +2395,96 @@ template <class Ta, class Tb, std::size_t M, std::size_t N>
             result(i) += mat(i, k) * vec(k);
         }
     }
+    return result;
+}
+
+/**
+ * @brief Bitwise AND of two matrices (element-wise, mixed types).
+ * @tparam Ta   Element type of @a lhs
+ * @tparam Tb   Element type of @a rhs — must support @c & with @c Ta
+ * @tparam Dims Dimensions of both matrices
+ * @param  lhs  Left-hand matrix
+ * @param  rhs  Right-hand matrix
+ * @return New matrix where element @c i is @c lhs[i] & @c rhs[i].
+ *         Element type is `decltype(Ta{} & Tb{})`.
+ *
+ * @code
+ * ysc::matrix<unsigned, 3> a{0b111u, 0b101u, 0b010u};
+ * ysc::matrix<unsigned, 3> b{0b110u, 0b110u, 0b110u};
+ * auto r = a & b;  // r == ysc::matrix<unsigned, 3>{0b110u, 0b100u, 0b010u}
+ * @endcode
+ *
+ * @ingroup ysc_arithmetic
+ */
+template <class Ta, class Tb, std::size_t... Dims>
+    requires requires(const Ta& a, const Tb& b) { a & b; }
+[[nodiscard]] constexpr auto operator&(const matrix<Ta, Dims...>& lhs,
+                                       const matrix<Tb, Dims...>& rhs)
+    -> matrix<decltype(std::declval<const Ta&>() & std::declval<const Tb&>()), Dims...> {
+    using Tc = decltype(std::declval<const Ta&>() & std::declval<const Tb&>());
+    matrix<Tc, Dims...> result;
+    std::transform(lhs.cbegin(), lhs.cend(), rhs.cbegin(), result.begin(),
+                   [](const Ta& a, const Tb& b) -> Tc { return a & b; });
+    return result;
+}
+
+/**
+ * @brief Bitwise OR of two matrices (element-wise, mixed types).
+ * @tparam Ta   Element type of @a lhs
+ * @tparam Tb   Element type of @a rhs — must support @c | with @c Ta
+ * @tparam Dims Dimensions of both matrices
+ * @param  lhs  Left-hand matrix
+ * @param  rhs  Right-hand matrix
+ * @return New matrix where element @c i is @c lhs[i] | @c rhs[i].
+ *         Element type is `decltype(Ta{} | Tb{})`.
+ *
+ * @code
+ * ysc::matrix<unsigned, 3> a{0b001u, 0b010u, 0b100u};
+ * ysc::matrix<unsigned, 3> b{0b110u, 0b101u, 0b011u};
+ * auto r = a | b;  // r == ysc::matrix<unsigned, 3>{0b111u, 0b111u, 0b111u}
+ * @endcode
+ *
+ * @ingroup ysc_arithmetic
+ */
+template <class Ta, class Tb, std::size_t... Dims>
+    requires requires(const Ta& a, const Tb& b) { a | b; }
+[[nodiscard]] constexpr auto operator|(const matrix<Ta, Dims...>& lhs,
+                                       const matrix<Tb, Dims...>& rhs)
+    -> matrix<decltype(std::declval<const Ta&>() | std::declval<const Tb&>()), Dims...> {
+    using Tc = decltype(std::declval<const Ta&>() | std::declval<const Tb&>());
+    matrix<Tc, Dims...> result;
+    std::transform(lhs.cbegin(), lhs.cend(), rhs.cbegin(), result.begin(),
+                   [](const Ta& a, const Tb& b) -> Tc { return a | b; });
+    return result;
+}
+
+/**
+ * @brief Bitwise XOR of two matrices (element-wise, mixed types).
+ * @tparam Ta   Element type of @a lhs
+ * @tparam Tb   Element type of @a rhs — must support @c ^ with @c Ta
+ * @tparam Dims Dimensions of both matrices
+ * @param  lhs  Left-hand matrix
+ * @param  rhs  Right-hand matrix
+ * @return New matrix where element @c i is @c lhs[i] ^ @c rhs[i].
+ *         Element type is `decltype(Ta{} ^ Tb{})`.
+ *
+ * @code
+ * ysc::matrix<unsigned, 3> a{0b111u, 0b101u, 0b010u};
+ * ysc::matrix<unsigned, 3> b{0b110u, 0b110u, 0b110u};
+ * auto r = a ^ b;  // r == ysc::matrix<unsigned, 3>{0b001u, 0b011u, 0b100u}
+ * @endcode
+ *
+ * @ingroup ysc_arithmetic
+ */
+template <class Ta, class Tb, std::size_t... Dims>
+    requires requires(const Ta& a, const Tb& b) { a ^ b; }
+[[nodiscard]] constexpr auto operator^(const matrix<Ta, Dims...>& lhs,
+                                       const matrix<Tb, Dims...>& rhs)
+    -> matrix<decltype(std::declval<const Ta&>() ^ std::declval<const Tb&>()), Dims...> {
+    using Tc = decltype(std::declval<const Ta&>() ^ std::declval<const Tb&>());
+    matrix<Tc, Dims...> result;
+    std::transform(lhs.cbegin(), lhs.cend(), rhs.cbegin(), result.begin(),
+                   [](const Ta& a, const Tb& b) -> Tc { return a ^ b; });
     return result;
 }
 

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -73,6 +73,11 @@ constexpr struct matrix_zero_t {
  */
 
 /**
+ * @defgroup ysc_enumerate Enumerate
+ * @brief Coordinate-aware iteration over matrix elements.
+ */
+
+/**
  * @defgroup ysc_access Element access
  * @brief Unchecked and checked element access.
  */
@@ -2151,6 +2156,120 @@ public:
     [[nodiscard]] constexpr matrix_view<const T, contiguous, linear_size>
     flatten() const& noexcept {
         return matrix_view<const T, contiguous, linear_size>{_data.data()};
+    }
+
+    // ─── enumerate ───────────────────────────────────────────────────────────
+
+    /**
+     * @brief Range type returned by @c enumerate() that pairs coordinates with element references.
+     * @tparam ElemT Element type (possibly @c const — controls mutability of the reference)
+     *
+     * Iterating over this range yields @c std::pair<std::array<std::size_t, order>, ElemT&> in
+     * row-major order.  When @c ElemT is non-const, mutations to the second member of the pair
+     * are reflected in the original matrix.
+     *
+     * @ingroup ysc_enumerate
+     */
+    template <class ElemT> class enumerate_range {
+    public:
+        /** @brief Value type yielded by the iterator. */
+        using value_type = std::pair<std::array<std::size_t, order>, ElemT&>;
+
+        /**
+         * @brief Input iterator over @c enumerate_range.
+         * @ingroup ysc_enumerate
+         */
+        class iterator {
+        public:
+            using iterator_category = std::input_iterator_tag;
+            using value_type = std::pair<std::array<std::size_t, order>, ElemT&>;
+            using difference_type = std::ptrdiff_t;
+            using pointer = void;
+            using reference = value_type;
+
+            constexpr iterator(ElemT* ptr, std::size_t idx) noexcept : _ptr(ptr), _idx(idx) {}
+
+            [[nodiscard]] constexpr reference operator*() const noexcept {
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+                return {detail::index_to_coordinates(dimensions, _idx), _ptr[_idx]};
+            }
+
+            constexpr iterator& operator++() noexcept {
+                ++_idx;
+                return *this;
+            }
+
+            constexpr iterator operator++(int) noexcept {
+                iterator tmp = *this;
+                ++(*this);
+                return tmp;
+            }
+
+            [[nodiscard]] constexpr bool operator==(const iterator& other) const noexcept {
+                return _idx == other._idx;
+            }
+
+            [[nodiscard]] constexpr bool operator!=(const iterator& other) const noexcept {
+                return _idx != other._idx;
+            }
+
+        private:
+            ElemT* _ptr;
+            std::size_t _idx;
+        };
+
+        constexpr enumerate_range(ElemT* ptr, std::size_t n) noexcept : _ptr(ptr), _n(n) {}
+
+        [[nodiscard]] constexpr iterator begin() const noexcept { return iterator{_ptr, 0}; }
+        [[nodiscard]] constexpr iterator end() const noexcept { return iterator{_ptr, _n}; }
+
+    private:
+        ElemT* _ptr;
+        std::size_t _n;
+    };
+
+    /**
+     * @brief Returns a range of @c (coordinates, value) pairs in row-major order.
+     * @return An @c enumerate_range<T> whose iterator yields
+     *         @c std::pair<std::array<std::size_t, order>, T&>
+     *
+     * Each iteration step exposes both the N-D coordinates (as a
+     * @c std::array<std::size_t, order>) and a mutable reference to the element.
+     * Mutations are reflected in the original matrix.
+     *
+     * @code
+     * ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+     * for (auto& [coords, val] : m.enumerate()) {
+     *     // coords == {0,0},{0,1},{0,2},{1,0},{1,1},{1,2} in order
+     *     val *= 10;  // mutates m
+     * }
+     * @endcode
+     *
+     * @ingroup ysc_enumerate
+     */
+    [[nodiscard]] constexpr enumerate_range<T> enumerate() noexcept {
+        return enumerate_range<T>{_data.data(), linear_size};
+    }
+
+    /**
+     * @brief Returns a const range of @c (coordinates, value) pairs in row-major order.
+     * @return An @c enumerate_range<const T> whose iterator yields
+     *         @c std::pair<std::array<std::size_t, order>, const T&>
+     *
+     * Read-only variant of @c enumerate().  No mutation is possible through the returned range.
+     *
+     * @code
+     * const ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+     * for (const auto& [coords, val] : m.enumerate()) {
+     *     // coords == {0,0},{0,1},{0,2},{1,0},{1,1},{1,2} in order
+     *     // val is a const int&
+     * }
+     * @endcode
+     *
+     * @ingroup ysc_enumerate
+     */
+    [[nodiscard]] constexpr enumerate_range<const T> enumerate() const noexcept {
+        return enumerate_range<const T>{_data.data(), linear_size};
     }
 };
 

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -103,8 +103,6 @@ constexpr struct matrix_zero_t {
  *
  * @todo Requirements (Container, etc.)
  *
- * @todo Special case when one dimension is 0.
- *
  * ### Iterator invalidation
  * As a rule, iterators to aa matrix are never invalidated throughout the
  * lifetime of the matrix. One should take note, however, that during swap, the

--- a/src/include/matrix_detail.hpp
+++ b/src/include/matrix_detail.hpp
@@ -190,6 +190,30 @@ struct make_matrix_view<T, Storage, size_seq<KeptDims...>> {
 template <class T, class Storage, class KeptSizeSeq>
 using make_matrix_view_t = typename make_matrix_view<T, Storage, KeptSizeSeq>::type;
 
+// ─── axis-reduction metaprogramming ──────────────────────────────────────────
+
+/** @brief Removes the @c Axis-th element from a @c size_seq of dimensions (recursive helper). */
+template <std::size_t Axis, std::size_t Idx, std::size_t... Dims> struct drop_dim_impl {
+    using type = size_seq<>;
+};
+template <std::size_t Axis, std::size_t Idx, std::size_t Head, std::size_t... Tail>
+struct drop_dim_impl<Axis, Idx, Head, Tail...> {
+    using tail_seq = typename drop_dim_impl<Axis, Idx + 1, Tail...>::type;
+    using type =
+        std::conditional_t<Idx == Axis, tail_seq, typename prepend_val<Head, tail_seq>::type>;
+};
+
+/** @brief @c size_seq of @c Dims... with the @c Axis-th dimension removed. */
+template <std::size_t Axis, std::size_t... Dims>
+using drop_dim_t = typename drop_dim_impl<Axis, 0, Dims...>::type;
+
+/** @brief @c matrix<T, Dims...> constructed from a @c size_seq<Dims...>. */
+template <class T, class SizeSeq> struct make_matrix_seq;
+template <class T, std::size_t... Dims> struct make_matrix_seq<T, size_seq<Dims...>> {
+    using type = matrix<T, Dims...>;
+};
+template <class T, class SizeSeq> using make_matrix_t = typename make_matrix_seq<T, SizeSeq>::type;
+
 /**
  * @brief Centralises runtime offset and stride computations for @c slice().
  * @tparam PaddedTuple @c std::tuple of padded spec types (all_t or integral)

--- a/src/include/matrix_view.hpp
+++ b/src/include/matrix_view.hpp
@@ -67,8 +67,11 @@ template <class T, class Storage, std::size_t... Dims> class matrix_view;
  * the lifetime of the underlying @c matrix (or raw array) must exceed that of
  * the view.
  *
- * @warning Destroying the underlying @c matrix while a view still refers to it
- *          is undefined behavior.
+ * @warning **Lifetime hazard:** a @c matrix_view does **not** extend the lifetime of
+ *          the underlying storage.  Destroying the @c matrix (or raw array) while any
+ *          view still refers to it is **undefined behavior** (heap-use-after-free).
+ *          AddressSanitizer detects this class of error at runtime; see
+ *          @c test/src/matrix_view_lifetime.cpp for a concrete example.
  *
  * Because dimensions are part of the type,
  * @c sizeof(matrix_view<T,contiguous,D...>) equals @c sizeof(T*) on every platform.
@@ -673,8 +676,11 @@ public:
  * @note Iterators and @c data() are not available (non-contiguous layout).
  *       Use @c operator() or @c at() for element access.
  *
- * @warning Destroying the underlying @c matrix while a view still refers to it
- *          is undefined behavior.
+ * @warning **Lifetime hazard:** a @c matrix_view does **not** extend the lifetime of
+ *          the underlying storage.  Destroying the @c matrix (or raw array) while any
+ *          view still refers to it is **undefined behavior** (heap-use-after-free).
+ *          AddressSanitizer detects this class of error at runtime; see
+ *          @c test/src/matrix_view_lifetime.cpp for a concrete example.
  *
  * @code
  * ysc::matrix<int, 3, 4> m{};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(${TARGET_NAME}
     src/construct.cpp
     src/construct_from_buffer.cpp
     src/factories.cpp
+    src/generate_multi_index.cpp
     src/fill.cpp
     src/formatter.cpp
     src/hash.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(${TARGET_NAME}
     src/matrix_from_view.cpp
     src/matrix_view.cpp
     src/matrix_view_io.cpp
+    src/matrix_view_lifetime.cpp
     src/reshape.cpp
     src/slice.cpp
     src/ostream.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(${TARGET_NAME}
     src/access.cpp
     src/accessors.cpp
     src/algorithms.cpp
+    src/arithmetic_bitwise.cpp
     src/arithmetic_elementwise.cpp
     src/arithmetic_hadamard.cpp
     src/arithmetic_scalar.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ include_directories(include)
 set(TARGET_NAME matrix-test)
 add_executable(${TARGET_NAME}
     src/empty_matrix.cpp
+    src/enumerate.cpp
     src/access.cpp
     src/accessors.cpp
     src/algorithms.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,7 @@ include_directories(include)
 #
 set(TARGET_NAME matrix-test)
 add_executable(${TARGET_NAME}
+    src/empty_matrix.cpp
     src/access.cpp
     src/accessors.cpp
     src/algorithms.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(${TARGET_NAME}
     src/slice.cpp
     src/ostream.cpp
     src/reductions.cpp
+    src/reductions_axis.cpp
     src/rows_cols.cpp
     src/transpose.cpp
     src/size_data.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(${TARGET_NAME}
     src/matrix_view_lifetime.cpp
     src/reshape.cpp
     src/slice.cpp
+    src/submatrix.cpp
     src/ostream.cpp
     src/reductions.cpp
     src/reductions_axis.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(${TARGET_NAME}
     src/nested_init.cpp
     src/iterators.cpp
     src/dot.cpp
+    src/linalg_reference.cpp
     src/matmul.cpp
     src/matrix_from_view.cpp
     src/matrix_view.cpp

--- a/test/src/arithmetic_bitwise.cpp
+++ b/test/src/arithmetic_bitwise.cpp
@@ -1,0 +1,258 @@
+#include <matrix.hpp>
+
+#include <cstdint>
+
+#include <gtest/gtest.h>
+
+//
+// --- BITWISE AND ---
+//
+
+TEST(arithmetic_bitwise_and, compound_and_correct_values) {
+    ysc::matrix<unsigned, 3> a{0b111U, 0b101U, 0b010U};
+    const ysc::matrix<unsigned, 3> b{0b110U, 0b110U, 0b110U};
+    a &= b;
+    ASSERT_EQ(a, (ysc::matrix<unsigned, 3>{0b110U, 0b100U, 0b010U}));
+}
+
+TEST(arithmetic_bitwise_and, compound_and_returns_self) {
+    ysc::matrix<unsigned, 2> a{0b11U, 0b10U};
+    const ysc::matrix<unsigned, 2> b{0b10U, 0b10U};
+    ysc::matrix<unsigned, 2>& ref = (a &= b);
+    ASSERT_EQ(&ref, &a);
+}
+
+TEST(arithmetic_bitwise_and, compound_and_does_not_modify_rhs) {
+    ysc::matrix<unsigned, 2> a{0b11U, 0b10U};
+    const ysc::matrix<unsigned, 2> b{0b10U, 0b01U};
+    const ysc::matrix<unsigned, 2> b_copy = b;
+    a &= b;
+    ASSERT_EQ(b, b_copy);
+}
+
+TEST(arithmetic_bitwise_and, binary_and_correct_values) {
+    const ysc::matrix<unsigned, 3> a{0b111U, 0b101U, 0b010U};
+    const ysc::matrix<unsigned, 3> b{0b110U, 0b110U, 0b110U};
+    const auto r = a & b;
+    ASSERT_EQ(r, (ysc::matrix<unsigned, 3>{0b110U, 0b100U, 0b010U}));
+}
+
+TEST(arithmetic_bitwise_and, binary_and_does_not_modify_operands) {
+    const ysc::matrix<unsigned, 2> a{0b11U, 0b10U};
+    const ysc::matrix<unsigned, 2> b{0b01U, 0b11U};
+    const auto r = a & b;
+    ASSERT_EQ(r, (ysc::matrix<unsigned, 2>{0b01U, 0b10U}));
+    ASSERT_EQ(a, (ysc::matrix<unsigned, 2>{0b11U, 0b10U}));
+    ASSERT_EQ(b, (ysc::matrix<unsigned, 2>{0b01U, 0b11U}));
+}
+
+TEST(arithmetic_bitwise_and, binary_and_mixed_types) {
+    const ysc::matrix<uint8_t, 3> a{0xF0U, 0x0FU, 0xFFU};
+    const ysc::matrix<uint16_t, 3> b{0x00FFU, 0x00FFU, 0x00FFU};
+    const auto r = a & b;
+    // uint8_t & uint16_t -> int (or wider integral via usual arithmetic conversions)
+    ASSERT_EQ(r(0), 0xF0U & 0x00FFU);
+    ASSERT_EQ(r(1), 0x0FU & 0x00FFU);
+    ASSERT_EQ(r(2), 0xFFU & 0x00FFU);
+}
+
+TEST(arithmetic_bitwise_and, binary_and_2d_matrix) {
+    const ysc::matrix<unsigned, 2, 2> a{0b1010U, 0b1100U, 0b0011U, 0b0101U};
+    const ysc::matrix<unsigned, 2, 2> b{0b1111U, 0b1111U, 0b1111U, 0b1111U};
+    const auto r = a & b;
+    ASSERT_EQ(r, a);
+}
+
+//
+// --- BITWISE OR ---
+//
+
+TEST(arithmetic_bitwise_or, compound_or_correct_values) {
+    ysc::matrix<unsigned, 3> a{0b001U, 0b010U, 0b100U};
+    const ysc::matrix<unsigned, 3> b{0b110U, 0b101U, 0b011U};
+    a |= b;
+    ASSERT_EQ(a, (ysc::matrix<unsigned, 3>{0b111U, 0b111U, 0b111U}));
+}
+
+TEST(arithmetic_bitwise_or, compound_or_returns_self) {
+    ysc::matrix<unsigned, 2> a{0b00U, 0b01U};
+    const ysc::matrix<unsigned, 2> b{0b10U, 0b10U};
+    ysc::matrix<unsigned, 2>& ref = (a |= b);
+    ASSERT_EQ(&ref, &a);
+}
+
+TEST(arithmetic_bitwise_or, compound_or_does_not_modify_rhs) {
+    ysc::matrix<unsigned, 2> a{0b00U, 0b01U};
+    const ysc::matrix<unsigned, 2> b{0b10U, 0b10U};
+    const ysc::matrix<unsigned, 2> b_copy = b;
+    a |= b;
+    ASSERT_EQ(b, b_copy);
+}
+
+TEST(arithmetic_bitwise_or, binary_or_correct_values) {
+    const ysc::matrix<unsigned, 3> a{0b001U, 0b010U, 0b100U};
+    const ysc::matrix<unsigned, 3> b{0b110U, 0b101U, 0b011U};
+    const auto r = a | b;
+    ASSERT_EQ(r, (ysc::matrix<unsigned, 3>{0b111U, 0b111U, 0b111U}));
+}
+
+TEST(arithmetic_bitwise_or, binary_or_does_not_modify_operands) {
+    const ysc::matrix<unsigned, 2> a{0b01U, 0b10U};
+    const ysc::matrix<unsigned, 2> b{0b10U, 0b01U};
+    const auto r = a | b;
+    ASSERT_EQ(r, (ysc::matrix<unsigned, 2>{0b11U, 0b11U}));
+    ASSERT_EQ(a, (ysc::matrix<unsigned, 2>{0b01U, 0b10U}));
+    ASSERT_EQ(b, (ysc::matrix<unsigned, 2>{0b10U, 0b01U}));
+}
+
+TEST(arithmetic_bitwise_or, binary_or_mixed_types) {
+    const ysc::matrix<uint8_t, 2> a{0x00U, 0xF0U};
+    const ysc::matrix<uint16_t, 2> b{0x000FU, 0x000FU};
+    const auto r = a | b;
+    ASSERT_EQ(r(0), 0x00U | 0x000FU);
+    ASSERT_EQ(r(1), 0xF0U | 0x000FU);
+}
+
+//
+// --- BITWISE XOR ---
+//
+
+TEST(arithmetic_bitwise_xor, compound_xor_correct_values) {
+    ysc::matrix<unsigned, 3> a{0b111U, 0b101U, 0b010U};
+    const ysc::matrix<unsigned, 3> b{0b110U, 0b110U, 0b110U};
+    a ^= b;
+    ASSERT_EQ(a, (ysc::matrix<unsigned, 3>{0b001U, 0b011U, 0b100U}));
+}
+
+TEST(arithmetic_bitwise_xor, compound_xor_returns_self) {
+    ysc::matrix<unsigned, 2> a{0b11U, 0b00U};
+    const ysc::matrix<unsigned, 2> b{0b01U, 0b10U};
+    ysc::matrix<unsigned, 2>& ref = (a ^= b);
+    ASSERT_EQ(&ref, &a);
+}
+
+TEST(arithmetic_bitwise_xor, compound_xor_does_not_modify_rhs) {
+    ysc::matrix<unsigned, 2> a{0b11U, 0b00U};
+    const ysc::matrix<unsigned, 2> b{0b01U, 0b10U};
+    const ysc::matrix<unsigned, 2> b_copy = b;
+    a ^= b;
+    ASSERT_EQ(b, b_copy);
+}
+
+TEST(arithmetic_bitwise_xor, binary_xor_correct_values) {
+    const ysc::matrix<unsigned, 3> a{0b111U, 0b101U, 0b010U};
+    const ysc::matrix<unsigned, 3> b{0b110U, 0b110U, 0b110U};
+    const auto r = a ^ b;
+    ASSERT_EQ(r, (ysc::matrix<unsigned, 3>{0b001U, 0b011U, 0b100U}));
+}
+
+TEST(arithmetic_bitwise_xor, binary_xor_does_not_modify_operands) {
+    const ysc::matrix<unsigned, 2> a{0b11U, 0b01U};
+    const ysc::matrix<unsigned, 2> b{0b10U, 0b10U};
+    const auto r = a ^ b;
+    ASSERT_EQ(r, (ysc::matrix<unsigned, 2>{0b01U, 0b11U}));
+    ASSERT_EQ(a, (ysc::matrix<unsigned, 2>{0b11U, 0b01U}));
+    ASSERT_EQ(b, (ysc::matrix<unsigned, 2>{0b10U, 0b10U}));
+}
+
+TEST(arithmetic_bitwise_xor, xor_self_is_zero) {
+    const ysc::matrix<unsigned, 3> a{1U, 2U, 3U};
+    const auto r = a ^ a;
+    ASSERT_EQ(r, (ysc::matrix<unsigned, 3>{0U, 0U, 0U}));
+}
+
+//
+// --- BITWISE NOT ---
+//
+
+TEST(arithmetic_bitwise_not, bitwise_not_correct_values) {
+    const ysc::matrix<unsigned, 3> m{0U, 0xFFFFFFFFU, 0x0F0F0F0FU};
+    const auto r = ~m;
+    ASSERT_EQ(r(0), ~0U);
+    ASSERT_EQ(r(1), ~0xFFFFFFFFU);
+    ASSERT_EQ(r(2), ~0x0F0F0F0FU);
+}
+
+TEST(arithmetic_bitwise_not, bitwise_not_does_not_modify_operand) {
+    const ysc::matrix<unsigned, 2> m{0U, 0xFFU};
+    const ysc::matrix<unsigned, 2> m_copy = m;
+    const auto r = ~m;
+    (void)r;
+    ASSERT_EQ(m, m_copy);
+}
+
+TEST(arithmetic_bitwise_not, double_not_is_identity) {
+    const ysc::matrix<unsigned, 3> m{1U, 2U, 3U};
+    ASSERT_EQ(~~m, m);
+}
+
+//
+// --- SHIFTS ---
+//
+
+TEST(arithmetic_bitwise_shift, left_shift_correct_values) {
+    ysc::matrix<unsigned, 3> m{1U, 2U, 4U};
+    m <<= 1U;
+    ASSERT_EQ(m, (ysc::matrix<unsigned, 3>{2U, 4U, 8U}));
+}
+
+TEST(arithmetic_bitwise_shift, left_shift_returns_self) {
+    ysc::matrix<unsigned, 2> m{1U, 2U};
+    ysc::matrix<unsigned, 2>& ref = (m <<= 1U);
+    ASSERT_EQ(&ref, &m);
+}
+
+TEST(arithmetic_bitwise_shift, right_shift_correct_values) {
+    ysc::matrix<unsigned, 3> m{8U, 4U, 2U};
+    m >>= 1U;
+    ASSERT_EQ(m, (ysc::matrix<unsigned, 3>{4U, 2U, 1U}));
+}
+
+TEST(arithmetic_bitwise_shift, right_shift_returns_self) {
+    ysc::matrix<unsigned, 2> m{8U, 4U};
+    ysc::matrix<unsigned, 2>& ref = (m >>= 1U);
+    ASSERT_EQ(&ref, &m);
+}
+
+TEST(arithmetic_bitwise_shift, shift_2d_matrix) {
+    ysc::matrix<unsigned, 2, 2> m{1U, 2U, 4U, 8U};
+    m <<= 2U;
+    ASSERT_EQ(m, (ysc::matrix<unsigned, 2, 2>{4U, 8U, 16U, 32U}));
+}
+
+//
+// --- COMPILE-TIME CONSTRAINTS ---
+//
+
+struct no_bitwise {
+    unsigned val;
+    bool operator==(const no_bitwise&) const = default;
+};
+
+// Helper concepts — GCC does not support bare requires-expressions in static_assert
+// when all candidates are constrained out (same workaround as in concepts.cpp).
+template <class M>
+concept matrix_and_assignable = requires(M& a, const M& b) { a &= b; };
+template <class M>
+concept matrix_or_assignable = requires(M& a, const M& b) { a |= b; };
+template <class M>
+concept matrix_xor_assignable = requires(M& a, const M& b) { a ^= b; };
+template <class M>
+concept matrix_bitnot_available = requires(const M& a) { ~a; };
+
+static_assert(!matrix_and_assignable<ysc::matrix<no_bitwise, 2>>);
+static_assert(!matrix_or_assignable<ysc::matrix<no_bitwise, 2>>);
+static_assert(!matrix_xor_assignable<ysc::matrix<no_bitwise, 2>>);
+static_assert(!matrix_bitnot_available<ysc::matrix<no_bitwise, 2>>);
+static_assert(!matrix_and_assignable<ysc::matrix<double, 2>>);
+
+static_assert(matrix_and_assignable<ysc::matrix<unsigned, 2>>);
+static_assert(matrix_or_assignable<ysc::matrix<unsigned, 2>>);
+static_assert(matrix_xor_assignable<ysc::matrix<unsigned, 2>>);
+static_assert(matrix_bitnot_available<ysc::matrix<unsigned, 2>>);
+static_assert(matrix_and_assignable<ysc::matrix<int, 2>>);
+
+TEST(arithmetic_bitwise_constraints, concept_constraints_checked_at_compile_time) {
+    // Runtime witness that the static_asserts above were checked.
+    SUCCEED();
+}

--- a/test/src/empty_matrix.cpp
+++ b/test/src/empty_matrix.cpp
@@ -1,0 +1,100 @@
+#include "matrix.hpp"
+#include <gtest/gtest.h>
+#include <stdexcept>
+
+// --- static checks ---
+
+static_assert(ysc::matrix<int, 0>::size() == 0);
+static_assert(ysc::matrix<int, 0>::empty());
+
+static_assert(ysc::matrix<int, 2, 0, 3>::size() == 0);
+static_assert(ysc::matrix<int, 2, 0, 3>::empty());
+
+// --- order-1 empty matrix ---
+
+TEST(EmptyMatrix, DefaultConstruct) {
+    ysc::matrix<int, 0> m;
+    EXPECT_TRUE(m.empty());
+    EXPECT_EQ(m.size(), 0U);
+}
+
+TEST(EmptyMatrix, ZeroConstruct) {
+    ysc::matrix<int, 0> m{ysc::zero};
+    EXPECT_TRUE(m.empty());
+}
+
+TEST(EmptyMatrix, CopyConstruct) {
+    ysc::matrix<int, 0> a;
+    ysc::matrix<int, 0> b = a; // NOLINT(performance-unnecessary-copy-initialization)
+    EXPECT_EQ(a, b);
+}
+
+TEST(EmptyMatrix, FillIsNoop) {
+    ysc::matrix<int, 0> m;
+    m.fill(42);
+    EXPECT_TRUE(m.empty());
+}
+
+TEST(EmptyMatrix, BeginEqualsEnd) {
+    ysc::matrix<int, 0> m;
+    EXPECT_EQ(m.begin(), m.end());
+    EXPECT_EQ(m.cbegin(), m.cend());
+}
+
+TEST(EmptyMatrix, AtThrows) {
+    ysc::matrix<int, 0> m;
+    EXPECT_THROW(m.at(0), std::out_of_range);
+}
+
+TEST(EmptyMatrix, SumIsZero) {
+    ysc::matrix<int, 0> m;
+    EXPECT_EQ(m.sum(), 0);
+}
+
+TEST(EmptyMatrix, AllVacuouslyTrue) {
+    ysc::matrix<int, 0> m;
+    EXPECT_TRUE(m.all());
+}
+
+TEST(EmptyMatrix, AnyVacuouslyFalse) {
+    ysc::matrix<int, 0> m;
+    EXPECT_FALSE(m.any());
+}
+
+TEST(EmptyMatrix, ApplyIsNoop) {
+    ysc::matrix<int, 0> m;
+    m.apply([](int& v) { v = 99; });
+    EXPECT_TRUE(m.empty());
+}
+
+TEST(EmptyMatrix, MapReturnsEmpty) {
+    ysc::matrix<int, 0> m;
+    auto result = m.map([](int v) { return v * 2; });
+    EXPECT_TRUE(result.empty());
+}
+
+TEST(EmptyMatrix, EqualityHolds) {
+    ysc::matrix<int, 0> a;
+    ysc::matrix<int, 0> b;
+    EXPECT_EQ(a, b);
+}
+
+// --- order-3 empty matrix (one zero dimension) ---
+
+TEST(EmptyMatrix, MultiDimDefaultConstruct) {
+    ysc::matrix<int, 2, 0, 3> m;
+    EXPECT_TRUE(m.empty());
+    EXPECT_EQ(m.size(), 0U);
+}
+
+TEST(EmptyMatrix, MultiDimBeginEqualsEnd) {
+    ysc::matrix<int, 2, 0, 3> m;
+    EXPECT_EQ(m.begin(), m.end());
+    EXPECT_EQ(m.cbegin(), m.cend());
+}
+
+TEST(EmptyMatrix, MultiDimAtThrows) {
+    ysc::matrix<int, 2, 0, 3> m;
+    EXPECT_THROW(m.at(0, 0, 0), std::out_of_range);
+    EXPECT_THROW(m.at(1, 0, 2), std::out_of_range);
+}

--- a/test/src/enumerate.cpp
+++ b/test/src/enumerate.cpp
@@ -1,0 +1,161 @@
+#include "matrix.hpp"
+#include <gtest/gtest.h>
+#include <vector>
+
+// ─── constexpr static checks ─────────────────────────────────────────────────
+
+static_assert([] {
+    ysc::matrix<int, 3> m{10, 20, 30};
+    std::size_t idx = 0;
+    for (auto [coords, val] : m.enumerate()) {
+        if (coords[0] != idx) {
+            return false;
+        }
+        ++idx;
+    }
+    return idx == 3;
+}());
+
+static_assert([] {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    std::size_t n = 0;
+    for (auto [coords, val] : m.enumerate()) {
+        (void)coords;
+        (void)val;
+        ++n;
+    }
+    return n == 6;
+}());
+
+// ─── coordinates correctness ─────────────────────────────────────────────────
+
+TEST(MatrixEnumerate, CoordinatesCorrect1D) {
+    ysc::matrix<int, 4> m{10, 20, 30, 40};
+    std::size_t expected = 0;
+    for (auto [coords, val] : m.enumerate()) {
+        EXPECT_EQ(coords.size(), 1U);
+        EXPECT_EQ(coords[0], expected);
+        ++expected;
+    }
+    EXPECT_EQ(expected, 4U);
+}
+
+TEST(MatrixEnumerate, CoordinatesCorrect2D) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    const std::vector<std::array<std::size_t, 2>> expected_coords = {{0, 0}, {0, 1}, {0, 2},
+                                                                     {1, 0}, {1, 1}, {1, 2}};
+    std::size_t idx = 0;
+    for (auto [coords, val] : m.enumerate()) {
+        ASSERT_LT(idx, expected_coords.size());
+        EXPECT_EQ(coords, expected_coords[idx]);
+        ++idx;
+    }
+    EXPECT_EQ(idx, 6U);
+}
+
+TEST(MatrixEnumerate, CoordinatesCorrect3D) {
+    ysc::matrix<int, 2, 3, 4> m{ysc::zero};
+    std::size_t linear = 0;
+    for (auto [coords, val] : m.enumerate()) {
+        EXPECT_EQ(coords.size(), 3U);
+        // coords[0] varies slowest, coords[2] fastest
+        EXPECT_EQ(coords[0], linear / 12);
+        EXPECT_EQ(coords[1], (linear % 12) / 4);
+        EXPECT_EQ(coords[2], linear % 4);
+        ++linear;
+    }
+    EXPECT_EQ(linear, 24U);
+}
+
+// ─── value access ─────────────────────────────────────────────────────────────
+
+TEST(MatrixEnumerate, ValueMatchesDirectAccess1D) {
+    ysc::matrix<int, 5> m{10, 20, 30, 40, 50};
+    for (auto [coords, val] : m.enumerate()) {
+        EXPECT_EQ(val, m(coords[0]));
+    }
+}
+
+TEST(MatrixEnumerate, ValueMatchesDirectAccess2D) {
+    ysc::matrix<int, 3, 4> m{ysc::zero};
+    int v = 1;
+    for (std::size_t i = 0; i < 3; ++i) {
+        for (std::size_t j = 0; j < 4; ++j) {
+            m(i, j) = v++;
+        }
+    }
+    for (auto [coords, val] : m.enumerate()) {
+        EXPECT_EQ(val, m(coords[0], coords[1]));
+    }
+}
+
+// ─── mutation ─────────────────────────────────────────────────────────────────
+
+TEST(MatrixEnumerate, MutationReflectedInMatrix) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    for (auto [coords, val] : m.enumerate()) {
+        (void)coords;
+        val *= 10;
+    }
+    EXPECT_EQ(m, (ysc::matrix<int, 2, 3>{10, 20, 30, 40, 50, 60}));
+}
+
+TEST(MatrixEnumerate, MutationUsingCoordinates) {
+    ysc::matrix<int, 3, 3> m{ysc::zero};
+    for (auto [coords, val] : m.enumerate()) {
+        // set diagonal to 1
+        if (coords[0] == coords[1]) {
+            val = 1;
+        }
+    }
+    for (std::size_t i = 0; i < 3; ++i) {
+        for (std::size_t j = 0; j < 3; ++j) {
+            EXPECT_EQ(m(i, j), (i == j ? 1 : 0));
+        }
+    }
+}
+
+// ─── const overload ───────────────────────────────────────────────────────────
+
+TEST(MatrixEnumerate, ConstOverloadCompiles) {
+    const ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    std::size_t count = 0;
+    for (const auto& [coords, val] : m.enumerate()) {
+        static_assert(std::is_same_v<const int&, decltype(val)>);
+        EXPECT_EQ(val, m(coords[0], coords[1]));
+        ++count;
+    }
+    EXPECT_EQ(count, 6U);
+}
+
+TEST(MatrixEnumerate, ConstValueMatchesDirectAccess) {
+    const ysc::matrix<int, 4> m{7, 8, 9, 10};
+    for (const auto& [coords, val] : m.enumerate()) {
+        EXPECT_EQ(val, m(coords[0]));
+    }
+}
+
+// ─── row-major order ──────────────────────────────────────────────────────────
+
+TEST(MatrixEnumerate, RowMajorOrderRespected2D) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    std::vector<int> visited;
+    for (auto [coords, val] : m.enumerate()) {
+        (void)coords;
+        visited.push_back(val);
+    }
+    EXPECT_EQ(visited, (std::vector<int>{1, 2, 3, 4, 5, 6}));
+}
+
+// ─── empty matrix ─────────────────────────────────────────────────────────────
+
+TEST(MatrixEnumerate, EmptyMatrixYieldsNoIterations) {
+    ysc::matrix<int, 0> m;
+    std::size_t count = 0;
+    for (auto [coords, val] : m.enumerate()) {
+        (void)coords;
+        (void)val;
+        ++count;
+    }
+    EXPECT_EQ(count, 0U);
+}

--- a/test/src/generate_multi_index.cpp
+++ b/test/src/generate_multi_index.cpp
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+// Tests for the multi-index overload of ysc::generate (US-069).
+
+#include <matrix.hpp>
+
+#include <gtest/gtest.h>
+
+// ---------------------------------------------------------------------------
+// Compile-time checks
+// ---------------------------------------------------------------------------
+
+// 2D: generate<int,2,2> with multi-index callable is constexpr
+static_assert(ysc::generate<int, 2, 2>([](std::size_t i, std::size_t j) {
+                  return int(i + j);
+              })(1, 1) == 2);
+
+// 2D: identity matrix
+static_assert(ysc::generate<int, 3, 3>([](std::size_t i, std::size_t j) {
+                  return i == j ? 1 : 0;
+              })(1, 1) == 1);
+static_assert(ysc::generate<int, 3, 3>([](std::size_t i, std::size_t j) {
+                  return i == j ? 1 : 0;
+              })(0, 1) == 0);
+
+// 3D: tensor constexpr
+static_assert(ysc::generate<int, 2, 3, 4>([](std::size_t i, std::size_t j, std::size_t k) {
+                  return int((i * 100) + (j * 10) + k);
+              })(1, 2, 3) == 123);
+
+// Backward-compat: linear-index overload still compiles and is constexpr
+static_assert(ysc::generate<int, 4>([](std::size_t k) { return int(k * k); })(2) == 4);
+
+// ---------------------------------------------------------------------------
+// Runtime tests
+// ---------------------------------------------------------------------------
+
+TEST(generate_multi_index, identity_2d) {
+    auto m = ysc::generate<int, 3, 3>([](std::size_t i, std::size_t j) { return i == j ? 1 : 0; });
+
+    for (std::size_t i = 0; i < 3; ++i) {
+        for (std::size_t j = 0; j < 3; ++j) {
+            EXPECT_EQ(m(i, j), i == j ? 1 : 0) << "at (" << i << ", " << j << ")";
+        }
+    }
+}
+
+TEST(generate_multi_index, sum_of_coords_2d) {
+    auto m = ysc::generate<int, 2, 3>([](std::size_t i, std::size_t j) { return int(i + j); });
+
+    EXPECT_EQ(m(0, 0), 0);
+    EXPECT_EQ(m(0, 2), 2);
+    EXPECT_EQ(m(1, 0), 1);
+    EXPECT_EQ(m(1, 2), 3);
+}
+
+TEST(generate_multi_index, tensor_3d) {
+    auto m = ysc::generate<int, 2, 3, 4>(
+        [](auto i, auto j, auto k) { return int((i * 100) + (j * 10) + k); });
+
+    EXPECT_EQ(m(0, 0, 0), 0);
+    EXPECT_EQ(m(1, 2, 3), 123);
+    EXPECT_EQ(m(0, 2, 3), 23);
+    EXPECT_EQ(m(1, 0, 0), 100);
+}
+
+TEST(generate_multi_index, retro_compat_linear) {
+    // The old single-size_t overload must remain usable.
+    auto v = ysc::generate<int, 4>([](std::size_t k) { return int(k * k); });
+
+    EXPECT_EQ(v(0), 0);
+    EXPECT_EQ(v(1), 1);
+    EXPECT_EQ(v(2), 4);
+    EXPECT_EQ(v(3), 9);
+}
+
+TEST(generate_multi_index, non_trivial_type) {
+    auto m = ysc::generate<double, 2, 2>(
+        [](std::size_t i, std::size_t j) { return double(i) + (0.1 * double(j)); });
+
+    EXPECT_DOUBLE_EQ(m(0, 0), 0.0);
+    EXPECT_DOUBLE_EQ(m(0, 1), 0.1);
+    EXPECT_DOUBLE_EQ(m(1, 0), 1.0);
+    EXPECT_DOUBLE_EQ(m(1, 1), 1.1);
+}
+
+TEST(generate_multi_index, row_major_order) {
+    // Verify that (i,j) coordinates follow row-major layout:
+    // element at linear index k has i = k / cols, j = k % cols.
+    constexpr std::size_t R = 3;
+    constexpr std::size_t C = 4;
+
+    auto m =
+        ysc::generate<int, R, C>([](std::size_t i, std::size_t j) { return int((i * 10) + j); });
+
+    for (std::size_t i = 0; i < R; ++i) {
+        for (std::size_t j = 0; j < C; ++j) {
+            EXPECT_EQ(m(i, j), int((i * 10) + j)) << "at (" << i << ", " << j << ")";
+        }
+    }
+}

--- a/test/src/linalg_reference.cpp
+++ b/test/src/linalg_reference.cpp
@@ -1,0 +1,175 @@
+#include "matrix.hpp"
+#include <gtest/gtest.h>
+
+// ─── matmul reference values ─────────────────────────────────────────────────
+// All values independently verified by hand.
+
+// Pair 1: 2×2 square matrices
+// [[1,2],[3,4]] × [[5,6],[7,8]] = [[1*5+2*7, 1*6+2*8],[3*5+4*7, 3*6+4*8]]
+//                               = [[19,22],[43,50]]
+TEST(LinalgReference, MatmulSquare2x2) {
+    constexpr ysc::matrix<int, 2, 2> a{1, 2, 3, 4};
+    constexpr ysc::matrix<int, 2, 2> b{5, 6, 7, 8};
+    constexpr auto c = ysc::matmul(a, b);
+    static_assert(c(0, 0) == 19);
+    static_assert(c(0, 1) == 22);
+    static_assert(c(1, 0) == 43);
+    static_assert(c(1, 1) == 50);
+    EXPECT_EQ(c(0, 0), 19);
+    EXPECT_EQ(c(0, 1), 22);
+    EXPECT_EQ(c(1, 0), 43);
+    EXPECT_EQ(c(1, 1), 50);
+}
+
+// Pair 2: 2×3 × 3×2
+// [[1,2,3],[4,5,6]] × [[7,8],[9,10],[11,12]]
+// row 0: [1*7+2*9+3*11, 1*8+2*10+3*12] = [58, 64]
+// row 1: [4*7+5*9+6*11, 4*8+5*10+6*12] = [139, 154]
+TEST(LinalgReference, MatmulRect2x3Times3x2) {
+    constexpr ysc::matrix<int, 2, 3> a{1, 2, 3, 4, 5, 6};
+    constexpr ysc::matrix<int, 3, 2> b{7, 8, 9, 10, 11, 12};
+    constexpr auto c = ysc::matmul(a, b);
+    static_assert(c(0, 0) == 58);
+    static_assert(c(0, 1) == 64);
+    static_assert(c(1, 0) == 139);
+    static_assert(c(1, 1) == 154);
+    EXPECT_EQ(c(0, 0), 58);
+    EXPECT_EQ(c(0, 1), 64);
+    EXPECT_EQ(c(1, 0), 139);
+    EXPECT_EQ(c(1, 1), 154);
+}
+
+// Pair 3: identity × arbitrary matrix
+// I₂ × [[5,6],[7,8]] = [[5,6],[7,8]]
+TEST(LinalgReference, MatmulIdentityTimesMatrix) {
+    constexpr ysc::matrix<int, 2, 2> m{5, 6, 7, 8};
+    constexpr auto result = ysc::matmul(ysc::identity<int, 2>(), m);
+    static_assert(result(0, 0) == 5);
+    static_assert(result(0, 1) == 6);
+    static_assert(result(1, 0) == 7);
+    static_assert(result(1, 1) == 8);
+    EXPECT_EQ(result, m);
+}
+
+// Pair 4: 3×3 rotation-like matrix product
+// [[2,0,0],[0,3,0],[0,0,4]] × [[1,1,1],[1,1,1],[1,1,1]]
+// row 0: [2,2,2], row 1: [3,3,3], row 2: [4,4,4]
+TEST(LinalgReference, MatmulDiagonalTimesOnes) {
+    constexpr ysc::matrix<int, 3, 3> diag{2, 0, 0, 0, 3, 0, 0, 0, 4};
+    constexpr ysc::matrix<int, 3, 3> ones{1, 1, 1, 1, 1, 1, 1, 1, 1};
+    constexpr auto c = ysc::matmul(diag, ones);
+    static_assert(c(0, 0) == 2);
+    static_assert(c(0, 1) == 2);
+    static_assert(c(0, 2) == 2);
+    static_assert(c(1, 0) == 3);
+    static_assert(c(1, 1) == 3);
+    static_assert(c(1, 2) == 3);
+    static_assert(c(2, 0) == 4);
+    static_assert(c(2, 1) == 4);
+    static_assert(c(2, 2) == 4);
+    EXPECT_EQ(c(0, 0), 2);
+    EXPECT_EQ(c(1, 1), 3);
+    EXPECT_EQ(c(2, 2), 4);
+}
+
+// ─── dot product reference values ────────────────────────────────────────────
+
+// Pair 1: [1,2,3] · [4,5,6] = 1*4 + 2*5 + 3*6 = 4 + 10 + 18 = 32
+TEST(LinalgReference, DotBasicIntegers) {
+    constexpr ysc::matrix<int, 3> a{1, 2, 3};
+    constexpr ysc::matrix<int, 3> b{4, 5, 6};
+    constexpr int result = ysc::dot(a, b);
+    static_assert(result == 32);
+    EXPECT_EQ(result, 32);
+}
+
+// Pair 2: orthogonal unit vectors → 0
+// [1,0,0] · [0,1,0] = 0
+TEST(LinalgReference, DotOrthogonalVectors) {
+    constexpr ysc::matrix<int, 3> a{1, 0, 0};
+    constexpr ysc::matrix<int, 3> b{0, 1, 0};
+    constexpr int result = ysc::dot(a, b);
+    static_assert(result == 0);
+    EXPECT_EQ(result, 0);
+}
+
+// Pair 3: [2,4,6] · [1,2,3] = 2 + 8 + 18 = 28
+TEST(LinalgReference, DotScaledVector) {
+    constexpr ysc::matrix<int, 3> a{2, 4, 6};
+    constexpr ysc::matrix<int, 3> b{1, 2, 3};
+    constexpr int result = ysc::dot(a, b);
+    static_assert(result == 28);
+    EXPECT_EQ(result, 28);
+}
+
+// Pair 4: [1,0,0,0] · [0,0,0,1] = 0  (perpendicular in 4D)
+TEST(LinalgReference, DotPerpendicular4D) {
+    constexpr ysc::matrix<int, 4> a{1, 0, 0, 0};
+    constexpr ysc::matrix<int, 4> b{0, 0, 0, 1};
+    constexpr int result = ysc::dot(a, b);
+    static_assert(result == 0);
+    EXPECT_EQ(result, 0);
+}
+
+// Pair 5: [3,4] · [3,4] = 9 + 16 = 25  (squared norm of a (3,4,5) vector)
+TEST(LinalgReference, DotSquaredNorm) {
+    constexpr ysc::matrix<int, 2> v{3, 4};
+    constexpr int result = ysc::dot(v, v);
+    static_assert(result == 25);
+    EXPECT_EQ(result, 25);
+}
+
+// ─── transpose reference values ──────────────────────────────────────────────
+
+// Matrix 1: 2×3 → verify all 6 elements and double-transpose
+TEST(LinalgReference, TransposeThenRetranspose2x3) {
+    constexpr ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    constexpr auto tt = ysc::transpose(ysc::transpose(m));
+    static_assert(tt(0, 0) == 1);
+    static_assert(tt(0, 1) == 2);
+    static_assert(tt(0, 2) == 3);
+    static_assert(tt(1, 0) == 4);
+    static_assert(tt(1, 1) == 5);
+    static_assert(tt(1, 2) == 6);
+    EXPECT_EQ(tt, m);
+}
+
+// Matrix 2: 3×4 → double-transpose roundtrip
+// [[1,2,3,4],[5,6,7,8],[9,10,11,12]]
+TEST(LinalgReference, TransposeThenRetranspose3x4) {
+    constexpr ysc::matrix<int, 3, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    constexpr auto tt = ysc::transpose(ysc::transpose(m));
+    static_assert(tt(0, 0) == 1);
+    static_assert(tt(2, 3) == 12);
+    EXPECT_EQ(tt, m);
+}
+
+// Matrix 3: 2×3 transposed values verified individually
+// m = [[10,20,30],[40,50,60]]
+// t = [[10,40],[20,50],[30,60]]
+TEST(LinalgReference, TransposeValuesVerified2x3) {
+    constexpr ysc::matrix<int, 2, 3> m{10, 20, 30, 40, 50, 60};
+    constexpr auto t = ysc::transpose(m);
+    static_assert(t(0, 0) == 10);
+    static_assert(t(0, 1) == 40);
+    static_assert(t(1, 0) == 20);
+    static_assert(t(1, 1) == 50);
+    static_assert(t(2, 0) == 30);
+    static_assert(t(2, 1) == 60);
+    EXPECT_EQ(t(0, 0), 10);
+    EXPECT_EQ(t(0, 1), 40);
+    EXPECT_EQ(t(1, 0), 20);
+    EXPECT_EQ(t(1, 1), 50);
+    EXPECT_EQ(t(2, 0), 30);
+    EXPECT_EQ(t(2, 1), 60);
+}
+
+// Matrix 4: 4×4 symmetry check via double-transpose
+// [[1,2,3,4],[5,6,7,8],[9,10,11,12],[13,14,15,16]]
+TEST(LinalgReference, TransposeThenRetranspose4x4) {
+    constexpr ysc::matrix<int, 4, 4> m{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+    constexpr auto tt = ysc::transpose(ysc::transpose(m));
+    static_assert(tt(0, 0) == 1);
+    static_assert(tt(3, 3) == 16);
+    EXPECT_EQ(tt, m);
+}

--- a/test/src/matrix_view_lifetime.cpp
+++ b/test/src/matrix_view_lifetime.cpp
@@ -1,0 +1,49 @@
+/**
+ * @file matrix_view_lifetime.cpp
+ * @brief ASan test: dangling matrix_view use-after-free detection.
+ *
+ * This test verifies that AddressSanitizer correctly detects a heap-use-after-free
+ * when a @c matrix_view outlives the @c matrix it refers to.
+ *
+ * The matrix is allocated on the heap (via @c new) so that ASan reliably poisons
+ * the freed memory and detects the subsequent read through the dangling view.
+ *
+ * @note The death-test style is set to @c "threadsafe" so that the child process
+ *       is spawned via @c exec() rather than @c fork().  This is required because
+ *       ASan's shadow memory is not correctly inherited across a plain @c fork(),
+ *       which would prevent the heap-use-after-free from being detected.
+ *
+ * Compiled in all configurations; the test body only runs under ASan
+ * (@c YSC_SANITIZERS_ENABLED defined).  Without sanitizers the test is
+ * skipped to avoid invoking undefined behavior in the normal build.
+ */
+#include <matrix.hpp>
+#include <matrix_view.hpp>
+
+#include <gtest/gtest.h>
+
+// Under ASan, accessing a dangling matrix_view must terminate the process.
+// EXPECT_DEATH forks a child process; ASan detects the heap-use-after-free in
+// the child and aborts it, which satisfies the "death" predicate.
+// The matrix is allocated on the heap so that ASan poisons the freed region.
+// The "threadsafe" style spawns via exec() so ASan initialises cleanly.
+TEST(MatrixViewLifetime, DanglingViewUseAfterFree) {
+#ifndef YSC_SANITIZERS_ENABLED
+    GTEST_SKIP() << "Test only meaningful under ASan (build with ENABLE_SANITIZERS=ON)";
+#else
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    auto trigger_uaf = [] {
+        // Allocate on the heap so that ASan reliably poisons the freed memory.
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        auto* m = new ysc::matrix<int, 3>{1, 2, 3};
+        ysc::matrix_view<int, ysc::contiguous, 3> view{*m};
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        delete m;
+        // The matrix has been freed; accessing the view is heap-use-after-free.
+        // NOLINTNEXTLINE(clang-analyzer-core.UndefinedBinaryOperatorResult)
+        volatile int val = view(0);
+        (void)val;
+    };
+    EXPECT_DEATH(trigger_uaf(), "");
+#endif
+}

--- a/test/src/reductions_axis.cpp
+++ b/test/src/reductions_axis.cpp
@@ -1,0 +1,103 @@
+#include "matrix.hpp"
+
+#include <gtest/gtest.h>
+
+// clang-format off
+// constexpr static checks
+static_assert(ysc::matrix<int, 2, 3>{1, 2, 3, 4, 5, 6}.sum<0>() == (ysc::matrix<int, 3>{5, 7, 9}));
+static_assert(ysc::matrix<int, 2, 3>{1, 2, 3, 4, 5, 6}.sum<1>() == (ysc::matrix<int, 2>{6, 15}));
+// Axis out of bounds must not compile (verified by requires constraint — not testable at runtime)
+// clang-format on
+
+TEST(reductions_axis, sum_axis0_2d) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    ysc::matrix<int, 3> expected{5, 7, 9};
+    EXPECT_EQ(m.sum<0>(), expected);
+}
+
+TEST(reductions_axis, sum_axis1_2d) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    ysc::matrix<int, 2> expected{6, 15};
+    EXPECT_EQ(m.sum<1>(), expected);
+}
+
+TEST(reductions_axis, sum_axis0_3d) {
+    ysc::matrix<int, 2, 3, 4> m{1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+                                13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24};
+    ysc::matrix<int, 3, 4> expected{14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36};
+    EXPECT_EQ(m.sum<0>(), expected);
+}
+
+TEST(reductions_axis, sum_axis1_3d) {
+    ysc::matrix<int, 2, 3, 4> m{1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+                                13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24};
+    ysc::matrix<int, 2, 4> expected{15, 18, 21, 24, 51, 54, 57, 60};
+    EXPECT_EQ(m.sum<1>(), expected);
+}
+
+TEST(reductions_axis, sum_axis2_3d) {
+    ysc::matrix<int, 2, 3, 4> m{1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+                                13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24};
+    ysc::matrix<int, 2, 3> expected{10, 26, 42, 58, 74, 90};
+    EXPECT_EQ(m.sum<2>(), expected);
+}
+
+TEST(reductions_axis, sum_single_row) {
+    ysc::matrix<int, 1, 4> m{2, 3, 5, 7};
+    ysc::matrix<int, 4> expected{2, 3, 5, 7};
+    EXPECT_EQ(m.sum<0>(), expected);
+}
+
+TEST(reductions_axis, sum_single_col) {
+    ysc::matrix<int, 3, 1> m{10, 20, 30};
+    ysc::matrix<int, 3> expected{10, 20, 30};
+    EXPECT_EQ(m.sum<1>(), expected);
+}
+
+TEST(reductions_axis, min_axis0_2d) {
+    ysc::matrix<int, 2, 3> m{3, 1, 4, 1, 5, 9};
+    ysc::matrix<int, 3> expected{1, 1, 4};
+    EXPECT_EQ(m.min<0>(), expected);
+}
+
+TEST(reductions_axis, min_axis1_2d) {
+    ysc::matrix<int, 2, 3> m{3, 1, 4, 1, 5, 9};
+    ysc::matrix<int, 2> expected{1, 1};
+    EXPECT_EQ(m.min<1>(), expected);
+}
+
+TEST(reductions_axis, max_axis0_2d) {
+    ysc::matrix<int, 2, 3> m{3, 1, 4, 1, 5, 9};
+    ysc::matrix<int, 3> expected{3, 5, 9};
+    EXPECT_EQ(m.max<0>(), expected);
+}
+
+TEST(reductions_axis, max_axis1_2d) {
+    ysc::matrix<int, 2, 3> m{3, 1, 4, 1, 5, 9};
+    ysc::matrix<int, 2> expected{4, 9};
+    EXPECT_EQ(m.max<1>(), expected);
+}
+
+TEST(reductions_axis, min_axis0_3d) {
+    ysc::matrix<int, 2, 2, 2> m{5, 1, 3, 7, 2, 8, 6, 4};
+    ysc::matrix<int, 2, 2> expected{2, 1, 3, 4};
+    EXPECT_EQ(m.min<0>(), expected);
+}
+
+TEST(reductions_axis, max_axis2_3d) {
+    ysc::matrix<int, 2, 2, 2> m{5, 1, 3, 7, 2, 8, 6, 4};
+    ysc::matrix<int, 2, 2> expected{5, 7, 8, 6};
+    EXPECT_EQ(m.max<2>(), expected);
+}
+
+TEST(reductions_axis, sum_zero_dim_not_on_axis) {
+    ysc::matrix<int, 2, 0, 3> m{};
+    ysc::matrix<int, 0, 3> expected{};
+    EXPECT_EQ(m.sum<0>(), expected);
+}
+
+TEST(reductions_axis, sum_float) {
+    ysc::matrix<double, 2, 2> m{1.5, 2.5, 3.5, 4.5};
+    ysc::matrix<double, 2> expected{5.0, 7.0};
+    EXPECT_EQ(m.sum<0>(), expected);
+}

--- a/test/src/submatrix.cpp
+++ b/test/src/submatrix.cpp
@@ -1,0 +1,160 @@
+#include <matrix.hpp>
+#include <matrix_view.hpp>
+
+#include <gtest/gtest.h>
+#include <stdexcept>
+#include <type_traits>
+
+// ─── compile-time assertions ──────────────────────────────────────────────────
+
+static_assert(
+    std::is_same_v<decltype(std::declval<ysc::matrix<int, 4, 4>&>().submatrix<2, 2>({0, 0})),
+                   ysc::matrix_view<int, ysc::strided, 2, 2>>);
+static_assert(
+    std::is_same_v<decltype(std::declval<const ysc::matrix<int, 4, 4>&>().submatrix<2, 2>({0, 0})),
+                   ysc::matrix_view<const int, ysc::strided, 2, 2>>);
+static_assert(std::is_same_v<
+              decltype(std::declval<ysc::matrix<int, 3, 4, 5>&>().submatrix<2, 3, 4>({0, 0, 0})),
+              ysc::matrix_view<int, ysc::strided, 2, 3, 4>>);
+
+// ─── submatrix 2D ─────────────────────────────────────────────────────────────
+
+TEST(submatrix, element_values_2d) {
+    // clang-format off
+    ysc::matrix<int, 4, 4> m{ 1,  2,  3,  4,
+                               5,  6,  7,  8,
+                               9, 10, 11, 12,
+                              13, 14, 15, 16};
+    // clang-format on
+    auto sub = m.submatrix<2, 2>({1, 1});
+    EXPECT_EQ(sub(0, 0), m(1, 1)); // 6
+    EXPECT_EQ(sub(0, 1), m(1, 2)); // 7
+    EXPECT_EQ(sub(1, 0), m(2, 1)); // 10
+    EXPECT_EQ(sub(1, 1), m(2, 2)); // 11
+}
+
+TEST(submatrix, mutation_reflected_in_original) {
+    // clang-format off
+    ysc::matrix<int, 4, 4> m{ 1,  2,  3,  4,
+                               5,  6,  7,  8,
+                               9, 10, 11, 12,
+                              13, 14, 15, 16};
+    // clang-format on
+    auto sub = m.submatrix<2, 2>({1, 1});
+    sub(0, 0) = 99;
+    EXPECT_EQ(m(1, 1), 99);
+    sub(1, 1) = 42;
+    EXPECT_EQ(m(2, 2), 42);
+}
+
+TEST(submatrix, original_mutation_reflected_in_view) {
+    // clang-format off
+    ysc::matrix<int, 4, 4> m{ 1,  2,  3,  4,
+                               5,  6,  7,  8,
+                               9, 10, 11, 12,
+                              13, 14, 15, 16};
+    // clang-format on
+    auto sub = m.submatrix<2, 2>({1, 1});
+    m(2, 2) = 77;
+    EXPECT_EQ(sub(1, 1), 77);
+}
+
+TEST(submatrix, origin_at_zero) {
+    ysc::matrix<int, 3, 3> m{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    auto sub = m.submatrix<2, 2>({0, 0});
+    EXPECT_EQ(sub(0, 0), 1);
+    EXPECT_EQ(sub(0, 1), 2);
+    EXPECT_EQ(sub(1, 0), 4);
+    EXPECT_EQ(sub(1, 1), 5);
+}
+
+TEST(submatrix, full_extent_equals_whole_matrix) {
+    ysc::matrix<int, 2, 3> m{1, 2, 3, 4, 5, 6};
+    auto sub = m.submatrix<2, 3>({0, 0});
+    for (std::size_t i = 0; i < 2; ++i) {
+        for (std::size_t j = 0; j < 3; ++j) {
+            EXPECT_EQ(sub(i, j), m(i, j));
+        }
+    }
+}
+
+TEST(submatrix, const_matrix_gives_const_view) {
+    // clang-format off
+    const ysc::matrix<int, 4, 4> m{ 1,  2,  3,  4,
+                                     5,  6,  7,  8,
+                                     9, 10, 11, 12,
+                                    13, 14, 15, 16};
+    // clang-format on
+    auto sub = m.submatrix<2, 2>({1, 1});
+    static_assert(std::is_const_v<std::remove_reference_t<decltype(sub(0, 0))>>);
+    EXPECT_EQ(sub(0, 0), 6);
+    EXPECT_EQ(sub(1, 1), 11);
+}
+
+TEST(submatrix, single_element_submatrix) {
+    ysc::matrix<int, 3, 3> m{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    auto sub = m.submatrix<1, 1>({1, 2});
+    EXPECT_EQ(sub(0, 0), m(1, 2)); // 6
+}
+
+// ─── submatrix out-of-range ───────────────────────────────────────────────────
+
+TEST(submatrix, throws_when_block_exceeds_dimension) {
+    // clang-format off
+    ysc::matrix<int, 4, 4> m{ 1,  2,  3,  4,
+                               5,  6,  7,  8,
+                               9, 10, 11, 12,
+                              13, 14, 15, 16};
+    // clang-format on
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-capturing-lambda-coroutines)
+    auto bad = [&] { (void)m.submatrix<3, 3>({2, 2}); };
+    EXPECT_THROW(bad(), std::out_of_range);
+}
+
+TEST(submatrix, throws_on_row_overflow) {
+    ysc::matrix<int, 3, 5> m{};
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-capturing-lambda-coroutines)
+    auto bad = [&] { (void)m.submatrix<2, 3>({2, 0}); };
+    EXPECT_THROW(bad(), std::out_of_range);
+}
+
+TEST(submatrix, throws_on_col_overflow) {
+    ysc::matrix<int, 5, 3> m{};
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-capturing-lambda-coroutines)
+    auto bad = [&] { (void)m.submatrix<3, 2>({0, 2}); };
+    EXPECT_THROW(bad(), std::out_of_range);
+}
+
+TEST(submatrix, does_not_throw_on_exact_boundary) {
+    ysc::matrix<int, 4, 4> m{};
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-capturing-lambda-coroutines)
+    auto ok = [&] { (void)m.submatrix<2, 2>({2, 2}); };
+    EXPECT_NO_THROW(ok());
+}
+
+// ─── submatrix 3D ─────────────────────────────────────────────────────────────
+
+TEST(submatrix, element_values_3d) {
+    // Fill a 3x4x5 matrix with linear values
+    ysc::matrix<int, 3, 4, 5> m{};
+    for (std::size_t i = 0; i < 3; ++i) {
+        for (std::size_t j = 0; j < 4; ++j) {
+            for (std::size_t k = 0; k < 5; ++k) {
+                m(i, j, k) = static_cast<int>((i * 20) + (j * 5) + k);
+            }
+        }
+    }
+    auto sub = m.submatrix<2, 3, 4>({1, 1, 1});
+    EXPECT_EQ(sub(0, 0, 0), m(1, 1, 1));
+    EXPECT_EQ(sub(0, 0, 1), m(1, 1, 2));
+    EXPECT_EQ(sub(0, 1, 0), m(1, 2, 1));
+    EXPECT_EQ(sub(1, 0, 0), m(2, 1, 1));
+    EXPECT_EQ(sub(1, 2, 3), m(2, 3, 4));
+}
+
+TEST(submatrix, mutation_reflected_3d) {
+    ysc::matrix<int, 3, 4, 5> m{};
+    auto sub = m.submatrix<2, 3, 4>({1, 1, 1});
+    sub(0, 0, 0) = 42;
+    EXPECT_EQ(m(1, 1, 1), 42);
+}

--- a/utils/amalgamate.py
+++ b/utils/amalgamate.py
@@ -11,6 +11,7 @@ Options:
 
 import argparse
 import re
+import os
 import sys
 from datetime import date
 from pathlib import Path
@@ -28,15 +29,15 @@ INTERNAL_INCLUDES = re.compile(
 )
 
 
-def amalgamate(src_dir: Path) -> str:
+def amalgamate(src_dir: Path, filename: str) -> str:
     """Return the full text of the amalgamated header."""
     today = date.today().isoformat()
     lines = [
         "// =============================================================================",
-        "// matrix-amalgamated.hpp",
+        f"// {filename}",
         "// Auto-generated amalgamation of the ysc::matrix library.",
         f"// Generated on: {today}",
-        "// DO NOT EDIT — regenerate with:  python3 utils/amalgamate.py -o matrix-amalgamated.hpp",
+        f"// DO NOT EDIT — regenerate with:  python3 utils/amalgamate.py -o {filename}",
         "// =============================================================================",
         "",
     ]
@@ -76,7 +77,7 @@ def main() -> None:
     repo_root = script_dir.parent
     src_dir = repo_root / "src" / "include"
 
-    content = amalgamate(src_dir)
+    content = amalgamate(src_dir, os.path.basename(args.o or "stdout"))
 
     if args.o is None:
         sys.stdout.write(content)


### PR DESCRIPTION
Release v0.8.0


| Épopée | Statut | Progression | Détail |
|--------|--------|-------------|--------|
| **A — Infrastructure & CI/CD** | ✅ Terminée | 7/7 | ✅ US-001, US-002, US-003, US-004, US-005, US-006, US-007 |
| **B — Modernisation C++20** | ✅ Terminée | 3/3 | ✅ US-008, US-009, US-010 (fusionné US-019) |
| **C — Dette technique** | ✅ Terminée | 4/4 | ✅ US-011, US-012, US-013, US-014 |
| **D — Conformité STL** | ✅ Terminée | 4/4 | ✅ US-015, US-016, US-017, US-018 |
| **E — Comparaison & I/O** | ✅ Terminée | 7/7 | ✅ US-019, US-020, US-021, US-022, US-023, US-024, US-025 |
| **F — Arithmétique** | ✅ Terminée | 4/4 | ✅ US-026, ✅ US-027, ✅ US-028, ✅ US-029 |
| **G — Algorithmes** | ✅ Terminée | 5/5 | ✅ US-030, ✅ US-031, ✅ US-032, ✅ US-033, ✅ US-034 |
| **H — Vues & reshape** | ✅ Terminée | 4/4 | ✅ US-035, ✅ US-036, ✅ US-037, ✅ US-044 |
| **I — Packaging & préparation v1.0.0** | 🔄 En cours | 8/10 | ✅ US-038, ✅ US-041, ✅ US-043, ✅ US-045, ✅ US-046, ✅ US-047, ✅ US-048, ✅ US-049, ⬜ US-040, US-042 |
| **J — Ergonomie & finition** | ✅ Terminée | 11/11 | ✅ US-039, ✅ US-050 à US-059 |
| **K — Extensions pre-v1** | ✅ Terminée | 10/10 | ✅ US-060 à US-069 |

**Total : 67 / 69 US**