### PR TITLE
fix(doc): expose both generate() overloads in Doxygen group page

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1893,7 +1893,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = DOXYGEN=1
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -2446,6 +2446,17 @@ constexpr matrix<T, N, N> identity() {
     return m;
 }
 
+namespace detail {
+/// Satisfied when F can be invoked with sizeof...(Dims) std::size_t arguments
+/// and the result is convertible to T. Used to dispatch the multi-index
+/// overload of ysc::generate.
+template <class F, class T, std::size_t... Dims>
+concept coord_generator =
+    requires(F f, std::array<std::size_t, sizeof...(Dims)> coords) {
+        { std::apply(f, coords) } -> std::convertible_to<T>;
+    };
+} // namespace detail
+
 /**
  * @brief Returns a matrix filled by calling @a f(i) for each linear index @a i.
  * @tparam T    Element type
@@ -2498,11 +2509,15 @@ template <class T, std::size_t... Dims, std::invocable<std::size_t> F>
  *
  * @ingroup ysc_construction
  */
+// clang-format off
+#ifdef DOXYGEN
+// Doxygen-only prototype: distinct template parameter name avoids ID collision
+// with the linear-index overload (both would hash to generate(F f) otherwise).
+template <class T, std::size_t... Dims, detail::coord_generator<T, Dims...> MultiIndexF>
+[[nodiscard]] constexpr matrix<T, Dims...> generate(MultiIndexF f);
+#else
 template <class T, std::size_t... Dims, class F>
-    requires(!std::invocable<F, std::size_t> &&
-             requires(F f, std::array<std::size_t, sizeof...(Dims)> coords) {
-                 { std::apply(f, coords) } -> std::convertible_to<T>;
-             })
+    requires(!std::invocable<F, std::size_t> && detail::coord_generator<F, T, Dims...>)
 [[nodiscard]] constexpr matrix<T, Dims...> generate(F f) {
     matrix<T, Dims...> result;
     for (std::size_t i = 0; i < matrix<T, Dims...>::size(); ++i) {
@@ -2512,6 +2527,8 @@ template <class T, std::size_t... Dims, class F>
     }
     return result;
 }
+#endif
+// clang-format on
 
 /**
  * @defgroup ysc_linalg Linear algebra

--- a/src/include/matrix.hpp
+++ b/src/include/matrix.hpp
@@ -2451,10 +2451,9 @@ namespace detail {
 /// and the result is convertible to T. Used to dispatch the multi-index
 /// overload of ysc::generate.
 template <class F, class T, std::size_t... Dims>
-concept coord_generator =
-    requires(F f, std::array<std::size_t, sizeof...(Dims)> coords) {
-        { std::apply(f, coords) } -> std::convertible_to<T>;
-    };
+concept coord_generator = requires(F f, std::array<std::size_t, sizeof...(Dims)> coords) {
+    { std::apply(f, coords) } -> std::convertible_to<T>;
+};
 } // namespace detail
 
 /**


### PR DESCRIPTION
## Résumé

La page du groupe Doxygen `ysc_construction` n'affichait qu'une seule des deux surcharges de `ysc::generate(F)` — la surcharge multi-index (US-069) était silencieusement ignorée. Cause : Doxygen 1.15.0 calcule l'ID d'une fonction sur son nom + types de paramètres uniquement (sans les clauses `requires`), de sorte que les deux surcharges `generate(F f)` recevaient le même hash et entraient en collision.

Deux mesures complémentaires :

1. **`detail::coord_generator`** — le nested requirement est extrait dans un concept nommé dans `namespace ysc::detail`, rendant la clause `requires` de la 2ᵉ surcharge linéaire et parseable par Doxygen.
2. **Guard `#ifdef DOXYGEN`** — un prototype alternatif avec `MultiIndexF` (au lieu de `F`) est exposé à Doxygen, forçant un ID de hash distinct. `PREDEFINED = DOXYGEN=1` est ajouté dans `Doxyfile.in` pour activer ce guard.

## Critères de vérification

- [x] `cmake --build build --target check` — tests verts
- [x] `cmake --build build --target doc` — zéro warning Doxygen
- [x] `group__ysc__construction.html` liste bien `generate() [1/2]` (index linéaire) et `generate() [2/2]` (multi-index)
- [x] `@todo` supprimé de la 2ᵉ surcharge