### PR TITLE
chore(v1-check): README adoption overhaul (axe 11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,78 +8,8 @@
 [![codecov](https://codecov.io/gh/yscialom/matrix/graph/badge.svg)](https://codecov.io/gh/yscialom/matrix)
 [![docs](https://github.com/yscialom/matrix/actions/workflows/docs.yml/badge.svg)](https://yscialom.github.io/matrix/)
 
-A **header-only C++20** template library providing a general-purpose multi-dimensional
-container with static dimensions. Inspired by `std::array`, it extends it to N dimensions
-while keeping the same zero-overhead, `constexpr`-friendly design.
-
-Full API reference: [yscialom.github.io/matrix](https://yscialom.github.io/matrix/) —
-[Cookbook](https://yscialom.github.io/matrix/cookbook.html)
-
----
-
-## Installation
-
-### CMake FetchContent (recommended)
-
-Add to your `CMakeLists.txt`:
-
-```cmake
-include(FetchContent)
-FetchContent_Declare(
-    ysc-matrix
-    GIT_REPOSITORY https://github.com/yscialom/matrix.git
-    GIT_TAG        v1.0.0
-)
-FetchContent_MakeAvailable(ysc-matrix)
-
-target_link_libraries(my_target PRIVATE ysc::matrix)
-```
-
-Tests and documentation are automatically disabled when the library is consumed this way.
-
-### CMake find_package (system install)
-
-Install the library first:
-
-```bash
-cmake -S path/to/ysc-matrix -B build
-cmake --install build --prefix /usr/local
-```
-
-Then in your project's `CMakeLists.txt`:
-
-```cmake
-find_package(ysc-matrix CONFIG REQUIRED)
-
-target_link_libraries(my_target PRIVATE ysc::matrix)
-```
-
-Version constraints are supported:
-
-```cmake
-find_package(ysc-matrix 1.0 CONFIG REQUIRED)
-```
-
-The headers are installed to `<prefix>/include/ysc/` and the CMake package config to
-`<prefix>/lib/cmake/ysc-matrix/`.
-
-### Manual
-
-Download `matrix.hpp` from a [GitHub Release](https://github.com/yscialom/matrix/releases) and
-copy it into your project.
-
----
-
-## Stability & Semantic Versioning
-
-Starting with v1.0.0, `ysc::matrix` follows [Semantic Versioning](https://semver.org/):
-
-- **Public API** = everything in namespace `ysc` *except* `ysc::detail::`.
-  Breaking changes to the public API require a **major version bump**.
-- **`ysc::detail::`** is internal implementation. It may change in any release, including
-  patch releases. Do **not** depend on it directly.
-
----
+> A **header-only C++20** multi-dimensional container with **static dimensions** —
+> the performance of a raw C array, the ergonomics of `std::array`, extended to N dimensions.
 
 ## Quick Start
 
@@ -89,53 +19,90 @@ Starting with v1.0.0, `ysc::matrix` follows [Semantic Versioning](https://semver
 
 int main()
 {
-    // A 3×3 matrix of integers, aggregate-initialized
-    ysc::matrix<int, 3, 3> m = {
-        1, 2, 3,
-        4, 5, 6,
-        7, 8, 9
-    };
+    // A 3×3 matrix of ints, aggregate-initialized
+    ysc::matrix<int, 3, 3> m = {1, 2, 3,
+                                4, 5, 6,
+                                7, 8, 9};
 
-    // Unchecked element access (performance path)
-    std::cout << m(1, 1) << '\n';  // 5
+    m(1, 1) = 42;                 // unchecked write (fast path)
+    int v = m.at(2, 2);           // bounds-checked read
 
-    // Bounds-checked access (throws std::out_of_range if out of bounds)
-    std::cout << m.at(2, 2) << '\n';  // 9
+    for (int& x : m) x *= 2;      // range-based for, row-major
 
-    // Compile-time metadata
-    static_assert(m.order == 2);
-    static_assert(m.dimensions[0] == 3);
-    static_assert(m.size() == 9);
-
-    // Range-based for loop (row-major order)
-    for (int& x : m)
-        x *= 2;
-
-    // Works with any type, any number of dimensions
-    ysc::matrix<double, 2, 3, 4> tensor;  // 3D, 24 elements
+    auto t = ysc::transpose(m);   // constexpr-friendly linear algebra
+    std::cout << t << '\n';
 }
 ```
 
----
+## Why `ysc::matrix`?
 
-## Features
+- **Zero overhead.** Storage is `std::array<T, N>` — no heap, no virtual, no indirection.
+  Benchmarked against raw `std::array` on every hot path.
+- **`constexpr` end to end.** `dot`, `matmul`, `transpose`, reductions — evaluable inside
+  `static_assert`. Move invariants from your test suite into the build itself.
+- **Dimensions in the type.** `matrix<T, M, N>` × `matrix<T, N, P>` → compile-time inner-dim
+  check; mismatched shapes never reach runtime.
+- **STL-compatible.** Iterators, `size()`, `data()`, `front`/`back`, `fill`, `swap`, `==`,
+  `<=>`, `std::hash`, `std::formatter`.
+- **Zero-copy views.** `row()`, `col()`, `slice()`, `reshape()`, `flatten()` return
+  `matrix_view` — pointer + static shape, const-correct by type.
+- **Header-only.** Drop `matrix.hpp` into your project, or consume via CMake.
 
-| Feature | Description |
-|---------|-------------|
-| N-dimensional | Any number of dimensions; all sizes fixed at compile time |
-| STL-compatible | `begin`/`end`, `size()`, `data()`, `front()`, `back()`, `fill()`, `swap()` |
-| Unchecked access | `operator()` — no bounds check, UB out-of-bounds (performance path) |
-| Bounds-checked access | `at()` — throws `std::out_of_range` |
-| Aggregate init | `matrix<int,2,3> m = {1,2,3,4,5,6};` |
-| Type conversion | Converting constructors and assignment from `matrix<U, Dims...>` |
-| Comparison | `==` and `<=>` (lexicographic on row-major storage) |
-| Compile-time metadata | `order`, `dimensions`, `size()`, `empty()` — all `static constexpr` |
-| Zero-init tag | `matrix<T, Dims...> m{ysc::zero};` — explicit zero-initialization |
-| Zero overhead | Storage is `std::array<T, N>`, no heap, no virtual, no indirection |
+## Documentation
 
----
+- [**API reference**](https://yscialom.github.io/matrix/) — full Doxygen, hosted on GitHub Pages
+- [**Cookbook**](https://yscialom.github.io/matrix/cookbook.html) — six task-oriented recipes
+- [**Migration guide**](doc/migration.md) — v0.x → v1.0.0 breaking changes
 
-## Building and Testing
+## Installation
+
+### CMake `FetchContent` (recommended)
+
+```cmake
+include(FetchContent)
+FetchContent_Declare(ysc-matrix
+    GIT_REPOSITORY https://github.com/yscialom/matrix.git
+    GIT_TAG        v1.0.0)
+FetchContent_MakeAvailable(ysc-matrix)
+
+target_link_libraries(my_target PRIVATE ysc::matrix)
+```
+
+Tests and documentation auto-disable when the library is consumed as a subproject.
+
+### CMake `find_package` (system install)
+
+```bash
+cmake -S path/to/ysc-matrix -B build
+cmake --install build --prefix /usr/local
+```
+
+```cmake
+find_package(ysc-matrix 1.0 CONFIG REQUIRED)
+target_link_libraries(my_target PRIVATE ysc::matrix)
+```
+
+### Single header (manual)
+
+Download `matrix.hpp` from a [GitHub Release](https://github.com/yscialom/matrix/releases) and
+`#include` it.
+
+## Requirements
+
+- **C++20** compiler — GCC ≥ 12, Clang ≥ 15, MSVC ≥ 19.30 (VS 2022), Apple Clang ≥ 14
+- **CMake** ≥ 3.20 (only if consumed via CMake)
+- **No runtime dependencies.** Header-only, no link step.
+
+## Stability & Semantic Versioning
+
+Starting with v1.0.0, `ysc::matrix` follows [Semantic Versioning](https://semver.org/):
+
+- **Public API** = everything in namespace `ysc` *except* `ysc::detail::`.
+  Breaking changes to the public API require a **major version bump**.
+- **`ysc::detail::`** is internal. It may change in any release, including patch releases.
+  Do **not** depend on it directly.
+
+## Building from source
 
 ```bash
 cmake -S . -B build
@@ -143,8 +110,6 @@ cmake --build build --target check
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development guide.
-
----
 
 ## Upgrading from v0.x
 

--- a/doc/v1-checks/11-readme-overhaul.md
+++ b/doc/v1-checks/11-readme-overhaul.md
@@ -1,0 +1,96 @@
+# Axe 11 — README adoption overhaul
+
+**Date.** 2026-06-07
+**Branche.** `chore/v1-check-11-readme-overhaul`
+**Référence.** `doc/before-v1-checks.md` §11
+**Résultat global : Refonte appliquée.**
+
+## Objectif
+
+Réécrire le `README.md` (contenu et ordre) pour faciliter l'adoption de la
+bibliothèque : faire passer le `Quick Start` et la proposition de valeur
+au-dessus de la ligne de flottaison, et compresser la section d'installation
+qui occupait l'essentiel du fichier.
+
+## Périmètre
+
+- **IN** : `README.md`.
+- **OUT** : `doc/mainpage.md`, `doc/cookbook.md` (intacts).
+
+## Analyse du `README.md` précédent
+
+| Section | Lignes | Position |
+|---|---|---|
+| Banner + titre + badges | 1–13 | tête |
+| Pitch (description) | 11–13 | tête |
+| Liens API/Cookbook | 15–16 | tête |
+| **Installation** (3 sous-sections) | 20–69 | **avant Quick Start** |
+| Stability & SemVer | 73–80 | milieu |
+| Quick Start | 84–117 | bas de page |
+| Features (tableau) | 121–134 | bas |
+| Building/Testing, Upgrading | 138–151 | pied |
+
+**Problèmes constatés.**
+1. **Quick Start invisible** sans scroll important — le nouveau lecteur voit
+   trois sous-sections CMake avant un seul exemple de code.
+2. **Section Installation surdimensionnée** : ~50 lignes sur 151 (≈ 33 %),
+   au-dessus du seuil 30 % fixé par l'axe.
+3. **Proposition de valeur diluée** dans un paragraphe générique ; les USPs
+   (zero-overhead, constexpr end-to-end, dimensions statiques, vues zero-copy)
+   ne sont mises en avant nulle part.
+4. **Dépendances techniques** (C++20, header-only) noyées dans le pitch ; pas
+   de section dédiée listant compilateurs et CMake supportés.
+
+## Refonte appliquée
+
+Nouvelle structure :
+
+1. Banner + titre + badges (inchangé).
+2. Pitch d'une phrase (resserré, met C++20 et header-only en gras).
+3. **Quick Start** (immédiat, ligne 14).
+4. **Why `ysc::matrix`?** — 6 bullets USPs (zero-overhead, constexpr, dimensions
+   dans le type, STL-compat, vues zero-copy, header-only).
+5. **Documentation** — 3 liens (API ref, Cookbook, Migration).
+6. **Installation** — 3 sous-sections condensées (FetchContent, find_package,
+   single-header).
+7. **Requirements** — nouvelle section listant compilateurs et CMake supportés.
+8. **Stability & SemVer** (conservée, identique à l'axe 4).
+9. **Building from source** (compressée).
+10. **Upgrading from v0.x** (lien Migration).
+
+## Critères de succès
+
+| Critère | Cible | Mesuré | État |
+|---|---|---|---|
+| Quick Start visible au premier écran | Avant le 1er fold | Démarre ligne 14 / 116 | ✅ |
+| Dépendances techniques claires | C++20 + header-only explicites | Pitch + section *Requirements* dédiée | ✅ |
+| Installation ≤ 30 % de la hauteur | ≤ 35 lignes / 116 | 33 lignes (57–89) = **28 %** | ✅ |
+| Quick Start compile | g++ -std=c++20 -Wall -Wextra -Wpedantic | ✅ Compile et exécute (`/tmp/readme_quickstart.cpp`) | ✅ |
+| Liens internes valides | tous résolvent | `CONTRIBUTING.md`, `doc/migration.md`, `doc/logo/ysc-matrix-banner.png` présents | ✅ |
+
+## Cohérence avec les axes déjà clos
+
+- **Axe 4 (docs cross-check, 2026-06-07).** Préserve les deux corrections
+  posées par l'axe 4 sur le `README.md` :
+  - `find_package(ysc-matrix 1.0 CONFIG REQUIRED)` conservé (la version 0.7
+    incorrecte avait été corrigée par l'axe 4).
+  - Section *Stability & Semantic Versioning* conservée intégralement.
+- **Axe 6 (CI matrix, 2026-06-07).** La section *Requirements* reprend
+  exactement la matrice annoncée et validée par l'axe 6 : GCC ≥ 12, Clang ≥ 15,
+  MSVC ≥ 19.30 (VS 2022), Apple Clang ≥ 14, CMake ≥ 3.20.
+- **Axe 9 (packaging E2E, 2026-06-07).** Les trois scénarios d'installation
+  cités sont exactement ceux validés par l'axe 9 : FetchContent (tests/examples
+  désactivés automatiquement par la détection top-level), find_package + alias
+  `ysc::matrix`, single-header (publié dans `release.yml`).
+- **Axe 10 (benchmarks, 2026-06-07).** Le claim *zero overhead vs std::array*
+  cité dans le bullet « Zero overhead » est précisément celui que l'axe 10 a
+  confirmé mesurément (assembly identique pour `operator()`, ratios mesurés
+  ≤ 1.05 sur tous les chemins chauds).
+
+## Conclusion
+
+Refonte appliquée. Quick Start above-the-fold, USPs synthétisées dans une
+section dédiée, Installation ramenée à 28 % de la hauteur, dépendances
+techniques explicitées. Aucun élément de la documentation n'a été désynchronisé
+des axes précédemment validés (4, 6, 9, 10) ; le snippet Quick Start a été
+re-validé par compilation locale.


### PR DESCRIPTION
## Résumé

Refonte du `README.md` pour faciliter l'adoption de la bibliothèque (axe 11 de `doc/before-v1-checks.md`). Le `Quick Start` passe en première position (above-the-fold), une section *Why `ysc::matrix`?* synthétise les USPs (zero-overhead, `constexpr` end-to-end, dimensions dans le type, vues zero-copy, header-only), la section *Installation* est ramenée de ~33 % à 28 % de la hauteur du fichier, et une section *Requirements* dédiée liste compilateurs et CMake supportés.

Rapport détaillé : `doc/v1-checks/11-readme-overhaul.md`.

## Critères de succès (axe 11)

- [x] Le `Quick Start` est visible dès le premier écran (démarre ligne 14 / 116).
- [x] Les dépendances techniques (C++20, header-only) sont claires (pitch + section *Requirements*).
- [x] L'installation n'occupe pas plus de 30 % de la hauteur du fichier (mesuré : 33 lignes / 116 = **28 %**).

## Vérifications transverses

- **Snippet Quick Start** : compile et exécute avec `g++-14 -std=c++20 -Wall -Wextra -Wpedantic`.
- **Liens internes** : tous résolvent (`CONTRIBUTING.md`, `doc/migration.md`, `doc/logo/ysc-matrix-banner.png`).
- **Axe 4 (docs cross-check)** : préserve les deux corrections déjà posées sur le `README.md` (version `find_package(... 1.0 ...)`, section *Stability & Semantic Versioning*).
- **Axe 6 (CI matrix)** : la section *Requirements* reprend exactement la matrice annoncée et validée (GCC ≥ 12, Clang ≥ 15, MSVC ≥ 19.30, Apple Clang ≥ 14, CMake ≥ 3.20).
- **Axe 9 (packaging E2E)** : les trois scénarios d'installation cités sont précisément ceux validés (FetchContent, find_package + alias, single-header).
- **Axe 10 (benchmarks)** : le claim *zero overhead vs std::array* mis en avant correspond à ce qui a été mesuré (assembly identique, ratios ≤ 1.05).

## Notes d'implémentation

- Aucune modification d'API, de code ou de configuration build/CI : seul le `README.md` et le rapport `doc/v1-checks/11-readme-overhaul.md` sont touchés.
- Le fichier `doc/before-v1-checks.md` n'est volontairement pas inclus dans cette PR (il est suivi par une autre session/branche).